### PR TITLE
Use official typescript

### DIFF
--- a/src/test/java/com/google/javascript/cl2dts/DeclarationSyntaxTest.java
+++ b/src/test/java/com/google/javascript/cl2dts/DeclarationSyntaxTest.java
@@ -22,13 +22,14 @@ import java.util.List;
  */
 public class DeclarationSyntaxTest {
 
-  static final Path TSC = FileSystems.getDefault().getPath("node_modules", "tsc", "bin", "tsc");
+  static final Path TSC = FileSystems.getDefault()
+      .getPath("node_modules", "typescript", "bin", "tsc");
 
   @BeforeClass
   public static void setUpTsc() throws Exception {
     if (!TSC.toFile().exists()) {
-      System.err.println("Installing tsc...");
-      runChecked("npm", "install", "tsc");
+      System.err.println("Installing typescript...");
+      runChecked("npm", "install", "typescript@next");
     }
   }
 


### PR DESCRIPTION
The 'tsc' npm package is deprecated, and not published by the typescript team.
If the intent here is to use the latest typescript, we can use the `@next` label which the team has started pushing with nightly releases. I've preserved that intent here.

If we instead mean to use released TS 1.5.3, we'll need to remove the `--skipDefaultLibCheck` flag since it's not available.
