### PR TITLE
Add usage tests.

### DIFF
--- a/src/test/java/com/google/javascript/cl2dts/DeclarationGeneratorTests.java
+++ b/src/test/java/com/google/javascript/cl2dts/DeclarationGeneratorTests.java
@@ -24,10 +24,23 @@ import java.util.List;
 @RunWith(AllTests.class)
 public class DeclarationGeneratorTests {
 
+  public static final FilenameFilter JS = new FilenameFilter() {
+    @Override
+    public boolean accept(File dir, String name) {
+      return name.endsWith(".js");
+    }
+  };
+  public static final FilenameFilter TS_SOURCES = new FilenameFilter() {
+    @Override
+    public boolean accept(File dir, String name) {
+      return name.endsWith(".ts") && !name.endsWith(".d.ts");
+    }
+  };
+
   public static TestSuite suite() throws IOException {
     TestSuite suite = new TestSuite(DeclarationGeneratorTests.class.getName());
 
-    List<File> testFiles = getTestInputFiles();
+    List<File> testFiles = getTestInputFiles(JS);
     for (final File input : testFiles) {
       File golden = getGoldenFile(input);
       final String inputText = getTestFileText(input);
@@ -41,17 +54,12 @@ public class DeclarationGeneratorTests {
     return new File(input.getPath().replaceAll("\\.js$", ".d.ts"));
   }
 
-  static List<File> getTestInputFiles() {
+  static List<File> getTestInputFiles(FilenameFilter filter) {
     Path testDir = FileSystems.getDefault().getPath("src", "test", "java");
     String packageName = DeclarationGeneratorTests.class.getPackage().getName();
     Path testPackage = testDir.resolve(packageName.replace('.', File.separatorChar));
 
-    File[] testFiles = testPackage.toFile().listFiles(new FilenameFilter() {
-      @Override
-      public boolean accept(File dir, String name) {
-        return name.endsWith(".js");
-      }
-    });
+    File[] testFiles = testPackage.toFile().listFiles(filter);
     return Arrays.asList(testFiles);
   }
 

--- a/src/test/java/com/google/javascript/cl2dts/DeclarationSyntaxTest.java
+++ b/src/test/java/com/google/javascript/cl2dts/DeclarationSyntaxTest.java
@@ -1,5 +1,7 @@
 package com.google.javascript.cl2dts;
 
+import static com.google.javascript.cl2dts.DeclarationGeneratorTests.JS;
+import static com.google.javascript.cl2dts.DeclarationGeneratorTests.TS_SOURCES;
 import static org.junit.Assert.fail;
 
 import com.google.common.base.Charsets;
@@ -38,7 +40,7 @@ public class DeclarationSyntaxTest {
     // This currently runs *all* test files as one test case. This gives less insight into errors,
     // but improves runtime as TypeScript only has to read its lib.d.ts once, amortizing the cost
     // across test cases.
-    List<File> inputs = DeclarationGeneratorTests.getTestInputFiles();
+    List<File> inputs = DeclarationGeneratorTests.getTestInputFiles(JS);
     List<String> goldenFilePaths = new ArrayList<>();
     for (File input : inputs) {
       goldenFilePaths.add(DeclarationGeneratorTests.getGoldenFile(input).getPath());
@@ -47,6 +49,17 @@ public class DeclarationSyntaxTest {
     final List<String> tscCommand =
         Lists.newArrayList(TSC.toString(), "--noEmit", "--skipDefaultLibCheck");
     tscCommand.addAll(goldenFilePaths);
+    runChecked(tscCommand);
+  }
+
+  @Test
+  public void testDeclarationUsage() throws Exception {
+    List<File> inputs = DeclarationGeneratorTests.getTestInputFiles(TS_SOURCES);
+    final List<String> tscCommand =
+        Lists.newArrayList(TSC.toString(), "--noEmit", "--skipDefaultLibCheck", "-m", "commonjs");
+    for (File input : inputs) {
+      tscCommand.add(input.getPath());
+    }
     runChecked(tscCommand);
   }
 

--- a/src/test/java/com/google/javascript/cl2dts/default_fn_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/default_fn_usage.ts
@@ -1,0 +1,3 @@
+/// <reference path="./default_fn" />
+import fn from 'goog:default_fn';
+var n: number = fn();

--- a/src/test/java/com/google/javascript/cl2dts/default_var_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/default_var_usage.ts
@@ -1,0 +1,3 @@
+/// <reference path="./default_var" />
+import v from 'goog:default_var.Var';
+let n: number = v + 2;

--- a/src/test/java/com/google/javascript/cl2dts/enum_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/enum_usage.ts
@@ -1,0 +1,3 @@
+/// <reference path="./enum" />
+import {SomeEnum} from 'goog:SomeEnum';
+var v: SomeEnum = SomeEnum.A;

--- a/src/test/java/com/google/javascript/cl2dts/fn_params_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/fn_params_usage.ts
@@ -1,0 +1,5 @@
+/// <reference path="./fn_params" />
+import {optional, optionalNullable, varargs} from 'goog:fn_params';
+let n1: number = optional("this");
+let n2: number = optionalNullable("that");
+varargs("other", 1, 2, 3);

--- a/src/test/java/com/google/javascript/cl2dts/interface_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/interface_usage.ts
@@ -1,0 +1,5 @@
+/// <reference path="./interface" />
+import I from 'goog:interface_exp';
+class C implements I {
+    method(): number { return 0; }
+}

--- a/src/test/java/com/google/javascript/cl2dts/multi_class_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/multi_class_usage.ts
@@ -1,0 +1,4 @@
+/// <reference path="./multi_class" />
+import {A, B, I} from 'goog:multi_class';
+class C extends A {}
+class C2 extends B implements I {}

--- a/src/test/java/com/google/javascript/cl2dts/nullable_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/nullable_usage.ts
@@ -1,0 +1,4 @@
+///<reference path="./nullable" />
+import {w,x,y,z} from 'goog:nullable';
+let b: boolean = w;
+let o: Object = x;

--- a/src/test/java/com/google/javascript/cl2dts/provide_single_class_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/provide_single_class_usage.ts
@@ -1,0 +1,6 @@
+/// <reference path="./provide_single_class"/>
+import C from 'goog:foo.bar.Baz';
+var n: number = C.staticMethod("some");
+let x = new C();
+let s: string = x.field;
+n = x.method("some");


### PR DESCRIPTION
I was doing some refactoring that produced unusable .d.ts files but existing tests passed and couldn't repro the problem.

I don't think we need this kind of test to go along with _every_ .js->.d.ts pair, just in places where the resulting .d.ts has some degree of freedom, and some ways work and some don't.
