### PR TITLE
fix: do not emit empty templatized args.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -687,6 +687,12 @@ public class DeclarationGenerator {
               templateTypeName = "PromiseLike";
             }
           }
+          if (type.getTemplateTypes().isEmpty()) {
+            // In Closure, subtypes of `TemplatizedType`s that do not take type arguments are still
+            // represented by templatized types.
+            emit(templateTypeName);
+            return null;
+          }
           Iterator<JSType> it = type.getTemplateTypes().iterator();
           if (typeRegistry.getNativeType(OBJECT_TYPE).equals(referencedType)) {
             emit("{ [");

--- a/src/test/java/com/google/javascript/clutz/empty_type_args.d.ts
+++ b/src/test/java/com/google/javascript/clutz/empty_type_args.d.ts
@@ -1,0 +1,31 @@
+declare namespace ಠ_ಠ.clutz_internal.empty_type_args {
+  interface ITemplated < T > {
+  }
+}
+declare module 'goog:empty_type_args.ITemplated' {
+  import alias = ಠ_ಠ.clutz_internal.empty_type_args.ITemplated;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz_internal.empty_type_args {
+  class NoMoreTemplateArgs implements ITemplated < number > {
+  }
+}
+declare namespace ಠ_ಠ.clutz_internal.goog {
+  function require(name: 'empty_type_args.NoMoreTemplateArgs'): typeof ಠ_ಠ.clutz_internal.empty_type_args.NoMoreTemplateArgs;
+}
+declare module 'goog:empty_type_args.NoMoreTemplateArgs' {
+  import alias = ಠ_ಠ.clutz_internal.empty_type_args.NoMoreTemplateArgs;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz_internal.empty_type_args {
+  class X {
+    constructor (a : NoMoreTemplateArgs ) ;
+  }
+}
+declare namespace ಠ_ಠ.clutz_internal.goog {
+  function require(name: 'empty_type_args.X'): typeof ಠ_ಠ.clutz_internal.empty_type_args.X;
+}
+declare module 'goog:empty_type_args.X' {
+  import alias = ಠ_ಠ.clutz_internal.empty_type_args.X;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/empty_type_args.js
+++ b/src/test/java/com/google/javascript/clutz/empty_type_args.js
@@ -1,0 +1,21 @@
+goog.provide('empty_type_args.X');
+goog.provide('empty_type_args.ITemplated');
+goog.provide('empty_type_args.NoMoreTemplateArgs');
+
+/**
+ * @interface
+ * @template T
+ */
+empty_type_args.ITemplated = function() {};
+
+/**
+ * @constructor
+ * @implements {empty_type_args.ITemplated<number>}
+ */
+empty_type_args.NoMoreTemplateArgs = function() {};
+
+/**
+ * @constructor
+ * @param {empty_type_args.NoMoreTemplateArgs} a
+ */
+empty_type_args.X = function(a) {};


### PR DESCRIPTION
In Closure, types that filled all template args from a super type are
still represented by a templatized type.

Fixes #123.