### PR TITLE
feat: mismatched inherited static properties.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/base.js
+++ b/src/test/java/com/google/javascript/clutz/base.js
@@ -1,4 +1,4 @@
-// Changing this defintion to false or removing or renaming it will cause closure to remove
+// Changing this definition to false or removing or renaming it will cause closure to remove
 // goog from the list of provided symbols, thus breaking the output.
 /**
  * @define {boolean}

--- a/src/test/java/com/google/javascript/clutz/ctor_func.d.ts
+++ b/src/test/java/com/google/javascript/clutz/ctor_func.d.ts
@@ -1,0 +1,14 @@
+declare namespace ಠ_ಠ.clutz_internal.ctor_func {
+  class Ctor {
+    constructor (a : string , b : number ) ;
+  }
+  var ctorFuncField : { new (a : string , b : number ) : Ctor } ;
+  function ctorFuncParam (ctor : { new (a : number ) : Ctor } ) : void ;
+}
+declare namespace ಠ_ಠ.clutz_internal.goog {
+  function require(name: 'ctor_func'): typeof ಠ_ಠ.clutz_internal.ctor_func;
+}
+declare module 'goog:ctor_func' {
+  import alias = ಠ_ಠ.clutz_internal.ctor_func;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/ctor_func.js
+++ b/src/test/java/com/google/javascript/clutz/ctor_func.js
@@ -1,0 +1,14 @@
+goog.provide('ctor_func');
+
+/**
+ * @param {string} a
+ * @param {number} b
+ * @constructor
+ */
+ctor_func.Ctor = function(a, b) {};
+
+/** @type {function(new:ctor_func.Ctor,string,number)} */
+ctor_func.ctorFuncField = ctor_func.Ctor;
+
+/** @param {function(new:ctor_func.Ctor, number)} ctor */
+ctor_func.ctorFuncParam = function(ctor) {};

--- a/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.d.ts
@@ -1,0 +1,42 @@
+declare namespace ಠ_ಠ.clutz_internal.static_inherit {
+  class Child extends Parent {
+    static static_fn (a : number ) : void ;
+    /** WARNING: emitted for non-matching super type's static method. Only the first overload is actually callable. */
+    static static_fn (a : string ) : void ;
+  }
+}
+declare namespace ಠ_ಠ.clutz_internal.goog {
+  function require(name: 'static_inherit.Child'): typeof ಠ_ಠ.clutz_internal.static_inherit.Child;
+}
+declare module 'goog:static_inherit.Child' {
+  import alias = ಠ_ಠ.clutz_internal.static_inherit.Child;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz_internal.static_inherit {
+  class GrandChild extends Child {
+    static static_fn (a : boolean ) : void ;
+    /** WARNING: emitted for non-matching super type's static method. Only the first overload is actually callable. */
+    static static_fn (a : number ) : void ;
+    /** WARNING: emitted for non-matching super type's static method. Only the first overload is actually callable. */
+    static static_fn (a : string ) : void ;
+  }
+}
+declare namespace ಠ_ಠ.clutz_internal.goog {
+  function require(name: 'static_inherit.GrandChild'): typeof ಠ_ಠ.clutz_internal.static_inherit.GrandChild;
+}
+declare module 'goog:static_inherit.GrandChild' {
+  import alias = ಠ_ಠ.clutz_internal.static_inherit.GrandChild;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz_internal.static_inherit {
+  class Parent {
+    static static_fn (a : string ) : void ;
+  }
+}
+declare namespace ಠ_ಠ.clutz_internal.goog {
+  function require(name: 'static_inherit.Parent'): typeof ಠ_ಠ.clutz_internal.static_inherit.Parent;
+}
+declare module 'goog:static_inherit.Parent' {
+  import alias = ಠ_ಠ.clutz_internal.static_inherit.Parent;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.js
+++ b/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.js
@@ -1,0 +1,18 @@
+goog.provide('static_inherit.Parent');
+goog.provide('static_inherit.Child');
+goog.provide('static_inherit.GrandChild');
+
+/** @constructor */
+static_inherit.Parent = function() {};
+/** @param {string} a */
+static_inherit.Parent.static_fn = function(a) {};
+
+/** @constructor @extends {static_inherit.Parent} */
+static_inherit.Child = function() {};
+/** @param {number} a */
+static_inherit.Child.static_fn = function(a) {};
+
+/** @constructor @extends {static_inherit.Child} */
+static_inherit.GrandChild = function() {};
+/** @param {boolean} a */
+static_inherit.GrandChild.static_fn = function(a) {};


### PR DESCRIPTION
In TypeScript, the "static" side of classes must correctly inherit from
any of its parents. In Closure, the methods are completely separate and
do not have to match. To paper over the difference, emit overloads so
that TypeScript allows the inheritance.

This pretends functions exist that do not, and it will fail for
functions that only differ in return type, but it should be good enough
for most code, for now.

Fixes #120.