### PR TITLE
Improve error handling.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Constants.java
+++ b/src/main/java/com/google/javascript/clutz/Constants.java
@@ -1,0 +1,10 @@
+package com.google.javascript.clutz;
+
+/** Shared constants for Clutz. */
+public class Constants {
+  /**
+   * The namespace prefix. Admittedly this only exists here so that Eclipse's font rendering is not
+   * disturbed by the extended Unicode character.
+   */
+  static final String INTERNAL_NAMESPACE = "ಠ_ಠ.clutz_internal";
+}

--- a/src/main/java/com/google/javascript/clutz/DeclarationGeneratorException.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGeneratorException.java
@@ -1,0 +1,18 @@
+package com.google.javascript.clutz;
+
+import com.google.common.base.Joiner;
+import com.google.javascript.jscomp.JSError;
+
+import java.util.List;
+
+/**
+ * An exception used to communicate errors from {@link DeclarationGenerator#generateDeclarations()}.
+ */
+public class DeclarationGeneratorException extends RuntimeException {
+  final List<JSError> errors;
+
+  public DeclarationGeneratorException(String message, List<JSError> errors) {
+    super(message + "\n" + Joiner.on('\n').join(errors));
+    this.errors = errors;
+  }
+}

--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -5,8 +5,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.io.Files;
 import com.google.javascript.jscomp.CheckLevel;
 import com.google.javascript.jscomp.CompilerOptions;
-import com.google.javascript.jscomp.ErrorHandler;
-import com.google.javascript.jscomp.JSError;
 
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
@@ -24,6 +22,9 @@ public class Options {
 
   @Option(name = "-o", usage = "output to this file", metaVar = "OUTPUT")
   String output = "-";
+
+  @Option(name = "--debug", usage = "run in debug mode (prints stack traces)")
+  boolean debug = false;
 
   @Option(name = "--externs",
       usage = "list of files to read externs definitions (as separate args)",
@@ -52,12 +53,6 @@ public class Options {
     options.setCheckTypes(true);
     options.setInferTypes(true);
     options.setIdeMode(true); // So that we can query types after compilation.
-    options.setErrorHandler(new ErrorHandler() {
-      @Override
-      public void report(CheckLevel level, JSError error) {
-        throw new AssertionError(error.toString());
-      }
-    });
     return options;
   }
 

--- a/src/test/java/com/google/javascript/clutz/ErrorHandlingTest.java
+++ b/src/test/java/com/google/javascript/clutz/ErrorHandlingTest.java
@@ -1,0 +1,29 @@
+package com.google.javascript.clutz;
+
+import static com.google.javascript.clutz.ProgramSubject.assertThatProgram;
+
+import org.junit.Test;
+
+public class ErrorHandlingTest {
+  @Test
+  public void testOverriddenIncompatibleStaticField() {
+    assertThatProgram("goog.provide('X');\n" +
+        "goog.provide('Y');\n"
+        + "/** @constructor */"
+        + "X = function() {};\n"
+        + "/** @type {string} */ X.f;\n"
+        + "/** @constructor @extends {X} */"
+        + "Y = function() {};\n"
+        + "/** @type {number} */ Y.f;\n")
+        .reportsDiagnosticsContaining(DeclarationGenerator.CLUTZ_OVERRIDDEN_STATIC_FIELD.key);
+  }
+
+  @Test
+  public void testMissingSymbolOrExtern() {
+    assertThatProgram(
+            "goog.provide('foo.x');\n"
+            + "/** @param {some.Unknown} y */\n"
+            + "foo.x = function(y) {};\n")
+        .reportsDiagnosticsContaining(DeclarationGenerator.CLUTZ_MISSING_TYPES.key);
+  }
+}

--- a/src/test/java/com/google/javascript/clutz/MultiFileTest.java
+++ b/src/test/java/com/google/javascript/clutz/MultiFileTest.java
@@ -26,7 +26,7 @@ public class MultiFileTest {
     assertThatProgram(
         singletonList(input("require.js")),
         singletonList(input("provide.js")))
-        .generatesDeclarations(false, expected);
+        .generatesDeclarations(expected);
   }
 
   @Test
@@ -35,7 +35,7 @@ public class MultiFileTest {
     assertThatProgram(
         ImmutableList.of(input("index.js"), input("dep.js")),
         Collections.<File>emptyList())
-        .generatesDeclarations(false, expected);
+        .generatesDeclarations(expected);
   }
 
   private File input(String filename) {

--- a/src/test/java/com/google/javascript/clutz/ProgramSubject.java
+++ b/src/test/java/com/google/javascript/clutz/ProgramSubject.java
@@ -1,15 +1,14 @@
 package com.google.javascript.clutz;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assert_;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 
+import com.google.common.base.Joiner;
 import com.google.common.truth.FailureStrategy;
 import com.google.common.truth.Subject;
 import com.google.common.truth.SubjectFactory;
-import com.google.javascript.clutz.DeclarationGenerator;
-import com.google.javascript.clutz.Depgraph;
-import com.google.javascript.clutz.Options;
 import com.google.javascript.jscomp.SourceFile;
 
 import java.io.File;
@@ -17,10 +16,20 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 /**
  * A subject that supports assertions on {@link DeclarationGenerator}'s results.
  */
 class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
+
+  /** A stripped down version of Closure's base.js for Clutz tests. */
+  private static final SourceFile CLUTZ_GOOG_BASE =
+      SourceFile.fromFile("src/test/java/com/google/javascript/clutz/base.js", UTF_8);
+
+  public static ProgramSubject assertThatProgram(String sourceText) {
+    return assert_().about(ProgramSubject.FACTORY).that(new Program(sourceText));
+  }
 
   public static ProgramSubject assertThatProgram(File singleInput) {
     return assertThatProgram(singletonList(singleInput), Collections.<File>emptyList());
@@ -40,19 +49,47 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
       };
   static final List<SourceFile> NO_EXTERNS = Collections.emptyList();
 
+  private boolean withExterns = false;
+
   public ProgramSubject(FailureStrategy failureStrategy, ProgramSubject.Program subject) {
     super(failureStrategy, subject);
   }
 
-  public void generatesDeclarations(Boolean withExterns, String expected) {
+  public ProgramSubject withExterns() {
+    ProgramSubject result = assert_().about(ProgramSubject.FACTORY).that(getSubject());
+    result.withExterns = true;
+    return result;
+  }
+
+  public void generatesDeclarations(String expected) {
+    String actual = parse();
+    String stripped =
+        DeclarationGeneratorTests.GOLDEN_FILE_COMMENTS_REGEXP.matcher(actual).replaceAll("");
+    if (!stripped.equals(expected)) {
+      failureStrategy.failComparing("compilation result doesn't match", expected, stripped);
+    }
+  }
+
+  public void reportsDiagnosticsContaining(String message) {
+    String unexpectedRes = null;
+    try {
+      unexpectedRes = parse();
+      failureStrategy.failComparing("expected errors, but got a successful result",
+          message, unexpectedRes);
+    } catch (DeclarationGeneratorException e) {
+      assertThat(Joiner.on('\n').join(e.errors)).contains(message);
+    }
+  }
+
+  private String parse() throws AssertionError {
     Options opts = new Options(!withExterns);
 
     List<SourceFile> sourceFiles = new ArrayList<>();
 
     // base.js is needed for the type declaration of goog.require for
     // all tests, except the base.js one itself.
-    if (!getSubject().roots.get(0).getName().equals("base.js")) {
-      sourceFiles.add(SourceFile.fromFile("src/test/java/com/google/javascript/clutz/base.js", UTF_8));
+    if (getSubject().roots.isEmpty() || !getSubject().roots.get(0).getName().equals("base.js")) {
+      sourceFiles.add(CLUTZ_GOOG_BASE);
     }
 
     for (File nonroot : getSubject().nonroots) {
@@ -66,22 +103,32 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
       roots.add(root.getPath());
     }
 
+    if (getSubject().sourceText != null) {
+      sourceFiles.add(SourceFile.fromCode("main.js", getSubject().sourceText));
+      roots.add("main.js");
+    }
 
     String actual = new DeclarationGenerator(opts)
         .generateDeclarations(sourceFiles, NO_EXTERNS, new Depgraph(roots));
-    actual = DeclarationGenerator.GOLDEN_FILE_COMMENTS_REGEXP.matcher(actual).replaceAll("");
-    if (!actual.equals(expected)) {
-      failureStrategy.failComparing("compilation result doesn't match", expected, actual);
-    }
+    return actual;
   }
 
   static class Program {
     private final List<File> roots;
     private final List<File> nonroots;
+    @Nullable
+    private final String sourceText;
+
+    Program(String sourceText) {
+      this.roots = Collections.emptyList();
+      this.nonroots = Collections.emptyList();
+      this.sourceText = sourceText;
+    }
 
     Program(List<File> roots, List<File> nonroots) {
       this.roots = roots;
       this.nonroots = nonroots;
+      this.sourceText = null;
     }
   }
 }

--- a/src/test/java/com/google/javascript/clutz/refer_from_default_ns.js
+++ b/src/test/java/com/google/javascript/clutz/refer_from_default_ns.js
@@ -3,7 +3,7 @@ goog.provide('fn.String');
 
 /** @return {fn.String} */
 fn = function() {
-  return new fn.String();  
+  return new fn.String();
 };
 
 /** @constructor */


### PR DESCRIPTION
- print nicer messages when run from the command line, no stack traces
  by default.
- use JSCompiler's error management framework. It's generally sound and
  exposes the structures we need. Just the error manager/error handler
  system is a bit odd.
- collect all errors that occur during a translation, don't bail on the
  first one.
- track error locations. This is not entirely exact as it tracks the
  containing symbol's location in walk(), not the property's location,
  but it's better than nothing.
- Move the disapproval namespace into a different file as it slightly
  screws up font rendering in Eclipse for me (yeah, I know).
- add tests for error handling. For the time being, this seems simpler
  than extending the .js/.d.ts format.
- extend Program to allow compiling from strings again
- extend ProgramSubject to optionally check for errors