### PR TITLE
fix: inner classes, enums and interfaces are emitted.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
@@ -4,39 +4,22 @@ declare namespace ಠ_ಠ.clutz_internal.foo.bar {
     avalue : number ;
     equals (b : Baz.NestedClass ) : boolean ;
     method (a : string ) : number ;
-    /* not emitting AnotherNestedEnum because it is an enum and it is not provided */
     static staticMethod (a : string ) : number ;
   }
+}
+declare namespace ಠ_ಠ.clutz_internal.foo.bar.Baz {
+  class NestedClass {
+  }
+  type NestedEnum = number ;
+  var NestedEnum : {
+    A : Baz.NestedEnum ,
+    B : Baz.NestedEnum ,
+  };
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {
   function require(name: 'foo.bar.Baz'): typeof ಠ_ಠ.clutz_internal.foo.bar.Baz;
 }
 declare module 'goog:foo.bar.Baz' {
   import alias = ಠ_ಠ.clutz_internal.foo.bar.Baz;
-  export default alias;
-}
-declare namespace ಠ_ಠ.clutz_internal.foo.bar.Baz {
-  class NestedClass {
-  }
-}
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'foo.bar.Baz.NestedClass'): typeof ಠ_ಠ.clutz_internal.foo.bar.Baz.NestedClass;
-}
-declare module 'goog:foo.bar.Baz.NestedClass' {
-  import alias = ಠ_ಠ.clutz_internal.foo.bar.Baz.NestedClass;
-  export default alias;
-}
-declare namespace ಠ_ಠ.clutz_internal.foo.bar.Baz {
-  type NestedEnum = number ;
-  var NestedEnum : {
-    A : NestedEnum ,
-    B : NestedEnum ,
-  };
-}
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'foo.bar.Baz.NestedEnum'): typeof ಠ_ಠ.clutz_internal.foo.bar.Baz.NestedEnum;
-}
-declare module 'goog:foo.bar.Baz.NestedEnum' {
-  import alias = ಠ_ಠ.clutz_internal.foo.bar.Baz.NestedEnum;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/provide_single_class.js
+++ b/src/test/java/com/google/javascript/clutz/provide_single_class.js
@@ -1,6 +1,8 @@
 goog.provide('foo.bar.Baz');
-goog.provide('foo.bar.Baz.NestedClass');
-goog.provide('foo.bar.Baz.NestedEnum');
+
+// NestedClass and NestedEnum are not provided because this is against JS closure's
+// style guide.
+// https://google.github.io/styleguide/javascriptguide.xml?showone=Providing_Dependencies_With_goog.provide#Providing_Dependencies_With_goog.provide
 
 /** @constructor */
 foo.bar.Baz = function() {
@@ -58,11 +60,3 @@ foo.bar.Baz.NestedEnum = {
   A: 1,
   B: 2
 };
-
-/**
- * This is not goog.provided, and it would be strange to reference an enum type
- * as a static class property.
- * This is just here to assert that we gracefully ignore it.
- * @enum
- */
-foo.bar.Baz.AnotherNestedEnum = {};

--- a/src/test/java/com/google/javascript/clutz/provide_single_class_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/provide_single_class_usage.ts
@@ -1,9 +1,9 @@
 import C from 'goog:foo.bar.Baz';
-import NE from 'goog:foo.bar.Baz.NestedEnum';
 
 var n: number = C.staticMethod("some");
 let x = new C();
 let s: string = x.field;
 n = x.method("some");
 let e: C.NestedEnum = C.NestedEnum.A;
-e = NE.B;
+e = C.NestedEnum.B;
+var c: C.NestedClass = new C.NestedClass();

--- a/src/test/java/com/google/javascript/clutz/static_provided.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_provided.d.ts
@@ -2,6 +2,8 @@ declare namespace ಠ_ಠ.clutz_internal.a.b {
   class StaticHolder {
   }
 }
+declare namespace ಠ_ಠ.clutz_internal.a.b.StaticHolder {
+}
 declare namespace ಠ_ಠ.clutz_internal.goog {
   function require(name: 'a.b.StaticHolder'): typeof ಠ_ಠ.clutz_internal.a.b.StaticHolder;
 }

--- a/src/test/java/com/google/javascript/clutz/static_provided.js
+++ b/src/test/java/com/google/javascript/clutz/static_provided.js
@@ -2,6 +2,9 @@ goog.provide('a.b.StaticHolder');
 goog.provide('a.b.StaticHolder.AnEnum');
 goog.provide('a.b.StaticHolder.aFunction');
 
+// Technically inner provides are against JS closure's style guide, but that is not enforced
+// thus we need to output reasonable code.
+
 /**
  * @constructor
  */

--- a/src/test/java/com/google/javascript/clutz/static_provided_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/static_provided_usage.ts
@@ -1,6 +1,3 @@
-import aFunction from 'goog:a.b.StaticHolder.aFunction';
 import StaticHolder from 'goog:a.b.StaticHolder';
-
-// these are both calling same symbol
-var b: boolean = aFunction();
-b = StaticHolder.aFunction();
+// goog:a.b.StaticHolder.aFunction cannot be required, because it is not provided
+var b: boolean = StaticHolder.aFunction();


### PR DESCRIPTION
Previously, we expected an explicit goog.provide for inner classes,
enums and interfaces, but according to style guide such requirers are
forbidden.

Now we do a second pass over the properties of default exported classes
and emit the inner properties that are not static methods or fields into
a namespace.