### PR TITLE
feat: prevent structural typing w/ private fields.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -321,7 +321,7 @@ public class DeclarationGenerator {
     // but not in TS, so we have to generate a namespace-class pair in TS.
     if (isDefault && hasNestedTypes(symbol.getType())) {
       emitNamespaceBegin(symbol.getName());
-      treeWalker.walkInnerClassesAndEnums((ObjectType) symbol.getType(), symbol.getName(), provides);
+      treeWalker.walkInnerClassesAndEnums((ObjectType) symbol.getType(), symbol.getName());
       emitNamespaceEnd();
     }
     return treeWalker.valueSymbolsWalked;
@@ -1159,9 +1159,9 @@ public class DeclarationGenerator {
       emit(")");
     }
 
-    public void walkInnerClassesAndEnums(ObjectType type, String namespace, Set<String> provides) {
+    public void walkInnerClassesAndEnums(ObjectType type, String innerNamespace) {
       for (String propName : getSortedPropertyNames(type)) {
-        if (provides.contains(namespace + '.' + propName)) continue;
+        if (provides.contains(innerNamespace + '.' + propName)) continue;
         JSType pType = type.getPropertyType(propName);
         if (pType.isEnumType()) {
           visitEnumType((EnumType) pType);

--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -971,6 +971,13 @@ public class DeclarationGenerator {
       emit("{");
       indent();
       emitBreak();
+      // Prevent accidental structural typing - emit every class with a private field.
+      if (type.isNominalConstructor() && !type.isInterface()
+          // But only for non-extending classes (TypeScript doesn't like overriding private fields)
+          && getSuperType((FunctionType) type) == null) {
+        emit("private noStructuralTyping_: any;");
+        emitBreak();
+      }
       // Constructors.
       if (type.isConstructor() && ((FunctionType)type).getParameters().iterator().hasNext()) {
         emit("constructor");

--- a/src/test/java/com/google/javascript/clutz/ctor_func.d.ts
+++ b/src/test/java/com/google/javascript/clutz/ctor_func.d.ts
@@ -1,5 +1,6 @@
 declare namespace ಠ_ಠ.clutz_internal.ctor_func {
   class Ctor < T > {
+    private noStructuralTyping_: any;
     constructor (a : string , b : number ) ;
   }
   var ctorFuncField : { new (a : string , b : number ) : Ctor < any > } ;

--- a/src/test/java/com/google/javascript/clutz/dict.d.ts
+++ b/src/test/java/com/google/javascript/clutz/dict.d.ts
@@ -1,9 +1,11 @@
 declare namespace ಠ_ಠ.clutz_internal.dict {
   class ClassWithDottedProperties {
+    private noStructuralTyping_: any;
     [key: string]: any;
     foo : number ;
   }
   class DictClass {
+    private noStructuralTyping_: any;
     constructor (n : any ) ;
     [key: string]: any;
     foo ( ) : void ;

--- a/src/test/java/com/google/javascript/clutz/empty_type_args.d.ts
+++ b/src/test/java/com/google/javascript/clutz/empty_type_args.d.ts
@@ -8,6 +8,7 @@ declare module 'goog:empty_type_args.ITemplated' {
 }
 declare namespace ಠ_ಠ.clutz_internal.empty_type_args {
   class NoMoreTemplateArgs implements ITemplated < number > {
+    private noStructuralTyping_: any;
   }
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {
@@ -19,6 +20,7 @@ declare module 'goog:empty_type_args.NoMoreTemplateArgs' {
 }
 declare namespace ಠ_ಠ.clutz_internal.empty_type_args {
   class X {
+    private noStructuralTyping_: any;
     constructor (a : NoMoreTemplateArgs ) ;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/fn_params.js
+++ b/src/test/java/com/google/javascript/clutz/fn_params.js
@@ -32,12 +32,6 @@ fn_params.varargs = function(x, y) {
 fn_params.varargs_fns = function(var_args) {};
 
 /**
- * @const
- * @private
- */
-fn_params.private_property = 123;
-
-/**
  * @type {!Function}
  */
 fn_params.declaredWithType = function() {};

--- a/src/test/java/com/google/javascript/clutz/forward_declare.d.ts
+++ b/src/test/java/com/google/javascript/clutz/forward_declare.d.ts
@@ -1,5 +1,6 @@
 declare namespace ಠ_ಠ.clutz_internal.forward {
   class A {
+    private noStructuralTyping_: any;
     //!! forward.D may or may not be part of the compilation unit.
     //!! If it is part of it might be a generic at which point TS will error
     //!! if we output just forward.D, so we output any to be on the safe side.

--- a/src/test/java/com/google/javascript/clutz/generics.d.ts
+++ b/src/test/java/com/google/javascript/clutz/generics.d.ts
@@ -4,6 +4,7 @@ declare namespace ಠ_ಠ.clutz_internal.generics {
   class ExtendsGenericClass < TYPE > extends Foo < TYPE , number > {
   }
   class Foo < T , U > {
+    private noStructuralTyping_: any;
     constructor (a : number ) ;
     get ( ) : T ;
     loop < V , W > (t : T , v : V ) : any ;
@@ -12,6 +13,7 @@ declare namespace ಠ_ಠ.clutz_internal.generics {
   interface GenericInterface < TYPE > {
   }
   class ImplementsGenericInterface < TYPE > implements GenericInterface < TYPE > {
+    private noStructuralTyping_: any;
   }
   var arrayMissingTypeParam : any [] ;
   var fooMissingAllTypeParams : Foo < any , any > ;

--- a/src/test/java/com/google/javascript/clutz/goog_require.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_require.d.ts
@@ -1,5 +1,6 @@
 declare namespace ಠ_ಠ.clutz_internal.foo {
   class SimpleClass {
+    private noStructuralTyping_: any;
   }
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/lends.d.ts
+++ b/src/test/java/com/google/javascript/clutz/lends.d.ts
@@ -6,6 +6,7 @@ declare module 'goog:lends' {
 }
 declare namespace ಠ_ಠ.clutz_internal.lends {
   class A {
+    private noStructuralTyping_: any;
     a : string ;
     c : boolean ;
     static b : number ;

--- a/src/test/java/com/google/javascript/clutz/multi_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/multi_class.d.ts
@@ -1,5 +1,6 @@
 declare namespace ಠ_ಠ.clutz_internal.multi_class {
   class A {
+    private noStructuralTyping_: any;
     constructor (n : number ) ;
     a : number ;
   }
@@ -10,6 +11,7 @@ declare namespace ಠ_ಠ.clutz_internal.multi_class {
   class C extends B {
   }
   class D implements I {
+    private noStructuralTyping_: any;
   }
   interface I {
   }

--- a/src/test/java/com/google/javascript/clutz/multi_class.js
+++ b/src/test/java/com/google/javascript/clutz/multi_class.js
@@ -43,6 +43,3 @@ goog.inherits(multi_class.C, multi_class.B);
  * @implements {multi_class.I}
  */
 multi_class.D = function() {};
-
-/** @private @constructor */
-multi_class.PrivateClass = function() {};

--- a/src/test/java/com/google/javascript/clutz/multi_provides.d.ts
+++ b/src/test/java/com/google/javascript/clutz/multi_provides.d.ts
@@ -20,6 +20,7 @@ declare module 'goog:multi_provides.a.b.c' {
 }
 declare namespace ಠ_ಠ.clutz_internal.multi_provides.a.b.c {
   class Two {
+    private noStructuralTyping_: any;
   }
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/privates.d.ts
+++ b/src/test/java/com/google/javascript/clutz/privates.d.ts
@@ -1,0 +1,13 @@
+declare namespace ಠ_ಠ.clutz_internal.priv {
+  class PublicClass {
+    private noStructuralTyping_: any;
+    publicField : number ;
+  }
+}
+declare namespace ಠ_ಠ.clutz_internal.goog {
+  function require(name: 'priv'): typeof ಠ_ಠ.clutz_internal.priv;
+}
+declare module 'goog:priv' {
+  import alias = ಠ_ಠ.clutz_internal.priv;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/privates.js
+++ b/src/test/java/com/google/javascript/clutz/privates.js
@@ -1,0 +1,25 @@
+goog.provide('priv');
+
+/** @private */
+priv.field = 12;
+
+/** @private */
+priv.fn = function() {};
+
+/** @private @constructor */
+priv.PrivateClazz = function() {};
+
+/** @constructor */
+priv.PublicClass = function() {};
+
+/** @private @type {number} */
+priv.PublicClass.staticField_;
+
+/** @private @type {number} */
+priv.PublicClass.prototype.field;
+
+/** @public @type {number} */
+priv.PublicClass.prototype.publicField;
+
+/** @private @return {number} */
+priv.PublicClass.prototype.method_ = function() { return this.field; };

--- a/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
@@ -1,5 +1,6 @@
 declare namespace ಠ_ಠ.clutz_internal.foo.bar {
   class Baz {
+    private noStructuralTyping_: any;
     field : string ;
     avalue : number ;
     equals (b : Baz.NestedClass ) : boolean ;
@@ -9,6 +10,7 @@ declare namespace ಠ_ಠ.clutz_internal.foo.bar {
 }
 declare namespace ಠ_ಠ.clutz_internal.foo.bar.Baz {
   class NestedClass {
+    private noStructuralTyping_: any;
   }
   type NestedEnum = number ;
   var NestedEnum : {

--- a/src/test/java/com/google/javascript/clutz/provide_single_class.js
+++ b/src/test/java/com/google/javascript/clutz/provide_single_class.js
@@ -14,8 +14,6 @@ foo.bar.Baz = function() {
   // concerned `avalue` lives on the prototype object.
   /** @type {string} */
   this.avalue = 0;
-  /** @private {number} */
-  this.hideMe_ = 0;
 };
 
 /**
@@ -46,11 +44,6 @@ foo.bar.Baz.prototype.method = function(a) {
 foo.bar.Baz.prototype.equals = function(b) {
   return false;
 };
-
-/**
- * @private
- */
-foo.bar.Baz.prototype.thisIsPrivate_ = function() {};
 
 /** @constructor */
 foo.bar.Baz.NestedClass = function() {};

--- a/src/test/java/com/google/javascript/clutz/refer_from_default_ns.d.ts
+++ b/src/test/java/com/google/javascript/clutz/refer_from_default_ns.d.ts
@@ -10,6 +10,7 @@ declare module 'goog:fn' {
 }
 declare namespace ಠ_ಠ.clutz_internal.fn {
   class String {
+    private noStructuralTyping_: any;
   }
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/shouldPruneProvidesFromNonrootFile/require.d.ts
+++ b/src/test/java/com/google/javascript/clutz/shouldPruneProvidesFromNonrootFile/require.d.ts
@@ -1,6 +1,7 @@
 //!! a.b.ShouldNotAppear must be absent here, it is provide'd in a non-root
 declare namespace ಠ_ಠ.clutz_internal.a.b {
   class Thing {
+    private noStructuralTyping_: any;
   }
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/shouldResolveNamedTypes/index.d.ts
+++ b/src/test/java/com/google/javascript/clutz/shouldResolveNamedTypes/index.d.ts
@@ -1,5 +1,6 @@
 declare namespace ಠ_ಠ.clutz_internal.namedType {
   class A < U > {
+    private noStructuralTyping_: any;
     fn (a : D < any > ) : any ;
   }
 }
@@ -12,6 +13,7 @@ declare module 'goog:namedType.A' {
 }
 declare namespace ಠ_ಠ.clutz_internal.namedType {
   class D < T > {
+    private noStructuralTyping_: any;
   }
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.d.ts
@@ -30,6 +30,7 @@ declare module 'goog:static_inherit.GrandChild' {
 }
 declare namespace ಠ_ಠ.clutz_internal.static_inherit {
   class Parent {
+    private noStructuralTyping_: any;
     static static_fn (a : string ) : void ;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/static_provided.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_provided.d.ts
@@ -1,5 +1,6 @@
 declare namespace ಠ_ಠ.clutz_internal.a.b {
   class StaticHolder {
+    private noStructuralTyping_: any;
   }
 }
 declare namespace ಠ_ಠ.clutz_internal.a.b.StaticHolder {

--- a/src/test/java/com/google/javascript/clutz/types_with_externs.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types_with_externs.d.ts
@@ -21,6 +21,7 @@ declare module 'goog:typesWithExterns' {
 }
 declare namespace ಠ_ಠ.clutz_internal.typesWithExterns {
   class A {
+    private noStructuralTyping_: any;
     constructor (n : number ) ;
     apply : number ;
   }
@@ -56,8 +57,10 @@ declare module 'goog:typesWithExterns.C' {
 }
 declare namespace ಠ_ಠ.clutz_internal.angular {
   class $injector {
+    private noStructuralTyping_: any;
   }
   class Scope {
+    private noStructuralTyping_: any;
     $$phase : string ;
     $apply (opt_exp ? : string | ( (a : Scope ) => any ) ) : any ;
     $applyAsync (opt_exp ? : string | ( (a : Scope ) => any ) ) : any ;


### PR DESCRIPTION
When a type has private fields, add special fields called
`private no(ClassSide)?StructuralTyping_: any;` to avoid accidentally
applying structural typing to a type that does not support that.

Also move all tests for `@private` annotations into their own file, so later
maintainers have a chance to find that code.