### PR TITLE
emit namespaces for top-level extern symbols.

### DIFF
--- a/src/resources/third_party_externs.js
+++ b/src/resources/third_party_externs.js
@@ -1,0 +1,33 @@
+/**
+ * @const
+ */
+var angular = {};
+
+/** @constructor */
+angular.Scope = function() {};
+
+/** @type {string} */
+angular.Scope.prototype.$$phase;
+
+/**
+ * @param {(string|function(!angular.Scope))=} opt_exp
+ * @return {*}
+ */
+angular.Scope.prototype.$apply = function(opt_exp) {};
+
+/**
+ * @param {(string|function(!angular.Scope))=} opt_exp
+ */
+angular.Scope.prototype.$applyAsync = function(opt_exp) {};
+
+/**
+ * @param {Element|HTMLDocument} element
+ * @param {Array.<string|Function>=} opt_modules
+ * @return {!angular.$injector}
+ */
+angular.bootstrap = function(element, opt_modules) {};
+
+/**
+ * @constructor
+ */
+angular.$injector = function() {};

--- a/src/test/java/com/google/javascript/clutz/ProgramSubject.java
+++ b/src/test/java/com/google/javascript/clutz/ProgramSubject.java
@@ -48,6 +48,8 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
         }
       };
   static final List<SourceFile> NO_EXTERNS = Collections.emptyList();
+  static final List<SourceFile> THIRD_PARTY_EXTERNS =
+          singletonList(SourceFile.fromFile("src/resources/third_party_externs.js"));
 
   private boolean withExterns = false;
 
@@ -108,8 +110,14 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
       roots.add("main.js");
     }
 
+    List<SourceFile> externs = NO_EXTERNS;
+    if (withExterns) {
+      externs = DeclarationGenerator.getDefaultExterns(opts);
+      externs.addAll(THIRD_PARTY_EXTERNS);
+    }
+
     String actual = new DeclarationGenerator(opts)
-        .generateDeclarations(sourceFiles, NO_EXTERNS, new Depgraph(roots));
+        .generateDeclarations(sourceFiles, externs, new Depgraph(roots));
     return actual;
   }
 

--- a/src/test/java/com/google/javascript/clutz/types_with_externs.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types_with_externs.d.ts
@@ -9,6 +9,7 @@ declare namespace ಠ_ಠ.clutz_internal.typesWithExterns {
   var c : NodeList | IArguments | { length : number } ;
   function elementMaybe ( ) : Element ;
   function id (x : NodeList | IArguments | { length : number } ) : NodeList | IArguments | { length : number } ;
+  var myScope : angular.Scope ;
   function topLevelFunction ( ...a : any [] ) : any ;
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {
@@ -52,4 +53,14 @@ declare namespace ಠ_ಠ.clutz_internal.goog {
 declare module 'goog:typesWithExterns.C' {
   import alias = ಠ_ಠ.clutz_internal.typesWithExterns.C;
   export default alias;
+}
+declare namespace ಠ_ಠ.clutz_internal.angular {
+  class $injector {
+  }
+  class Scope {
+    $$phase : string ;
+    $apply (opt_exp ? : string | ( (a : Scope ) => any ) ) : any ;
+    $applyAsync (opt_exp ? : string | ( (a : Scope ) => any ) ) : any ;
+  }
+  function bootstrap (element : Element | HTMLDocument , opt_modules ? : string | ( ( ...a : any [] ) => any ) [] ) : $injector ;
 }

--- a/src/test/java/com/google/javascript/clutz/types_with_externs.js
+++ b/src/test/java/com/google/javascript/clutz/types_with_externs.js
@@ -105,3 +105,9 @@ typesWithExterns.ExtendsIThenable = function() {};
  * @extends {Error}
  */
 typesWithExterns.Error = function() {};
+
+
+/**
+ * @type {angular.Scope}
+ */
+typesWithExterns.myScope = null;


### PR DESCRIPTION
skip platform based externs as they might mirror types in lib.d.ts.