### PR TITLE
emitting static overloads skips over private and compatible fields.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -1048,7 +1048,7 @@ public class DeclarationGenerator {
       }
       emit(";");
       emitBreak();
-      if (isStatic) {
+      if (isStatic && !isPrivate(objType.getOwnPropertyJSDocInfo(propName))) {
         emitStaticOverloads(propName, objType, propertyType);
       }
     }
@@ -1087,7 +1087,9 @@ public class DeclarationGenerator {
       }
       // "I, for one, welcome our new static overloads." - H.G. Wells.
       JSType superPropType = superTypeCtor.getPropertyType(propName);
-      if (!superPropType.equals(propertyType)) {
+      if (!propertyType.isSubtype(superPropType)) {
+        // If the super field is private there is no issue, because private fields are not emitted.
+        if (isPrivate(superTypeCtor.getOwnPropertyJSDocInfo(propName))) return;
         if (!propertyType.isFunctionType() || !superPropType.isFunctionType()) {
           errors.add(JSError.make(currentSymbol.getNode(), CLUTZ_OVERRIDDEN_STATIC_FIELD,
               objType.getDisplayName(), propName));

--- a/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.d.ts
@@ -1,8 +1,10 @@
 declare namespace ಠ_ಠ.clutz_internal.static_inherit {
   class Child extends Parent {
+    static privateParentOverrideField : number ;
     static static_fn (a : number ) : void ;
     /** WARNING: emitted for non-matching super type's static method. Only the first overload is actually callable. */
     static static_fn (a : string ) : void ;
+    static subTypeField : any [] ;
   }
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {
@@ -31,7 +33,9 @@ declare module 'goog:static_inherit.GrandChild' {
 declare namespace ಠ_ಠ.clutz_internal.static_inherit {
   class Parent {
     private noStructuralTyping_: any;
+    static privateChildOverrideField : number ;
     static static_fn (a : string ) : void ;
+    static subTypeField : Object ;
   }
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.js
+++ b/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.js
@@ -6,11 +6,37 @@ goog.provide('static_inherit.GrandChild');
 static_inherit.Parent = function() {};
 /** @param {string} a */
 static_inherit.Parent.static_fn = function(a) {};
+/**
+ * @type {string}
+ * @private
+ */
+static_inherit.Parent.privateParentOverrideField;
+/**
+ * @type {number}
+ */
+static_inherit.Parent.privateChildOverrideField;
+/**
+ * @type {Object}
+ */
+static_inherit.Parent.subTypeField;
 
 /** @constructor @extends {static_inherit.Parent} */
 static_inherit.Child = function() {};
 /** @param {number} a */
 static_inherit.Child.static_fn = function(a) {};
+/**
+ * @type {number}
+ */
+static_inherit.Child.privateParentOverrideField;
+/**
+ * @private {string}
+ */
+static_inherit.Child.privateChildOverrideField;
+/**
+ * @type {Array}
+ */
+static_inherit.Child.subTypeField;
+
 
 /** @constructor @extends {static_inherit.Child} */
 static_inherit.GrandChild = function() {};


### PR DESCRIPTION
Instead of throwing errors, we skip over if one (or all) of the
overlapping definitions are private. Also we support overloading when
the types are compatible.