### PR TITLE
fix: always generate absolute names.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/aliased_enums.d.ts
+++ b/src/test/java/com/google/javascript/clutz/aliased_enums.d.ts
@@ -1,7 +1,7 @@
 declare namespace ಠ_ಠ.clutz_internal.nested.bar {
   type Enum = number ;
   var Enum : {
-    A : nested.baz.Enum ,
+    A : ಠ_ಠ.clutz_internal.nested.baz.Enum ,
   };
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {
@@ -14,7 +14,7 @@ declare module 'goog:nested.bar.Enum' {
 declare namespace ಠ_ಠ.clutz_internal.nested.baz {
   type Enum = number ;
   var Enum : {
-    A : Enum ,
+    A : ಠ_ಠ.clutz_internal.nested.baz.Enum ,
   };
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/ctor_func.d.ts
+++ b/src/test/java/com/google/javascript/clutz/ctor_func.d.ts
@@ -3,8 +3,8 @@ declare namespace ಠ_ಠ.clutz_internal.ctor_func {
     private noStructuralTyping_: any;
     constructor (a : string , b : number ) ;
   }
-  var ctorFuncField : { new (a : string , b : number ) : Ctor < any > } ;
-  function ctorFuncParam (ctor : { new (a : number ) : Ctor < any > } ) : void ;
+  var ctorFuncField : { new (a : string , b : number ) : ಠ_ಠ.clutz_internal.ctor_func.Ctor < any > } ;
+  function ctorFuncParam (ctor : { new (a : number ) : ಠ_ಠ.clutz_internal.ctor_func.Ctor < any > } ) : void ;
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {
   function require(name: 'ctor_func'): typeof ಠ_ಠ.clutz_internal.ctor_func;

--- a/src/test/java/com/google/javascript/clutz/empty_type_args.d.ts
+++ b/src/test/java/com/google/javascript/clutz/empty_type_args.d.ts
@@ -7,7 +7,7 @@ declare module 'goog:empty_type_args.ITemplated' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz_internal.empty_type_args {
-  class NoMoreTemplateArgs implements ITemplated < number > {
+  class NoMoreTemplateArgs implements ಠ_ಠ.clutz_internal.empty_type_args.ITemplated < number > {
     private noStructuralTyping_: any;
   }
 }
@@ -21,7 +21,7 @@ declare module 'goog:empty_type_args.NoMoreTemplateArgs' {
 declare namespace ಠ_ಠ.clutz_internal.empty_type_args {
   class X {
     private noStructuralTyping_: any;
-    constructor (a : NoMoreTemplateArgs ) ;
+    constructor (a : ಠ_ಠ.clutz_internal.empty_type_args.NoMoreTemplateArgs ) ;
   }
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/enum.d.ts
@@ -1,8 +1,8 @@
 declare namespace ಠ_ಠ.clutz_internal.some {
   type SomeEnum = number ;
   var SomeEnum : {
-    A : SomeEnum ,
-    B : SomeEnum ,
+    A : ಠ_ಠ.clutz_internal.some.SomeEnum ,
+    B : ಠ_ಠ.clutz_internal.some.SomeEnum ,
   };
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/generics.d.ts
+++ b/src/test/java/com/google/javascript/clutz/generics.d.ts
@@ -1,7 +1,7 @@
 declare namespace ಠ_ಠ.clutz_internal.generics {
-  interface ExtendGenericInterface < TYPE > extends GenericInterface < TYPE > {
+  interface ExtendGenericInterface < TYPE > extends ಠ_ಠ.clutz_internal.generics.GenericInterface < TYPE > {
   }
-  class ExtendsGenericClass < TYPE > extends Foo < TYPE , number > {
+  class ExtendsGenericClass < TYPE > extends ಠ_ಠ.clutz_internal.generics.Foo < TYPE , number > {
   }
   class Foo < T , U > {
     private noStructuralTyping_: any;
@@ -12,12 +12,12 @@ declare namespace ಠ_ಠ.clutz_internal.generics {
   }
   interface GenericInterface < TYPE > {
   }
-  class ImplementsGenericInterface < TYPE > implements GenericInterface < TYPE > {
+  class ImplementsGenericInterface < TYPE > implements ಠ_ಠ.clutz_internal.generics.GenericInterface < TYPE > {
     private noStructuralTyping_: any;
   }
   var arrayMissingTypeParam : any [] ;
-  var fooMissingAllTypeParams : Foo < any , any > ;
-  var fooMissingOneTypeParam : Foo < string , any > ;
+  var fooMissingAllTypeParams : ಠ_ಠ.clutz_internal.generics.Foo < any , any > ;
+  var fooMissingOneTypeParam : ಠ_ಠ.clutz_internal.generics.Foo < string , any > ;
   function genericFunction < T > (a : T ) : T ;
   function identity < T > (a : T ) : T ;
   function objectWithGenericKeyType < K , V > (obj : { [ /* warning: coerced from K */ s: string ]: V } ) : void ;

--- a/src/test/java/com/google/javascript/clutz/interface.d.ts
+++ b/src/test/java/com/google/javascript/clutz/interface.d.ts
@@ -14,8 +14,8 @@ declare module 'goog:interface_exp' {
 declare namespace ಠ_ಠ.clutz_internal.interface_exp {
   type SomeEnum = number ;
   var SomeEnum : {
-    A : SomeEnum ,
-    B : SomeEnum ,
+    A : ಠ_ಠ.clutz_internal.interface_exp.SomeEnum ,
+    B : ಠ_ಠ.clutz_internal.interface_exp.SomeEnum ,
   };
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/multi_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/multi_class.d.ts
@@ -4,18 +4,18 @@ declare namespace ಠ_ಠ.clutz_internal.multi_class {
     constructor (n : number ) ;
     a : number ;
   }
-  class B extends A implements I , I2 {
+  class B extends ಠ_ಠ.clutz_internal.multi_class.A implements ಠ_ಠ.clutz_internal.multi_class.I , ಠ_ಠ.clutz_internal.multi_class.I2 {
     b : number ;
     noop ( ) : void ;
   }
-  class C extends B {
+  class C extends ಠ_ಠ.clutz_internal.multi_class.B {
   }
-  class D implements I {
+  class D implements ಠ_ಠ.clutz_internal.multi_class.I {
     private noStructuralTyping_: any;
   }
   interface I {
   }
-  interface I2 extends I {
+  interface I2 extends ಠ_ಠ.clutz_internal.multi_class.I {
   }
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
@@ -3,7 +3,7 @@ declare namespace ಠ_ಠ.clutz_internal.foo.bar {
     private noStructuralTyping_: any;
     field : string ;
     avalue : number ;
-    equals (b : Baz.NestedClass ) : boolean ;
+    equals (b : ಠ_ಠ.clutz_internal.foo.bar.Baz.NestedClass ) : boolean ;
     method (a : string ) : number ;
     static staticMethod (a : string ) : number ;
   }
@@ -14,8 +14,8 @@ declare namespace ಠ_ಠ.clutz_internal.foo.bar.Baz {
   }
   type NestedEnum = number ;
   var NestedEnum : {
-    A : Baz.NestedEnum ,
-    B : Baz.NestedEnum ,
+    A : ಠ_ಠ.clutz_internal.foo.bar.Baz.NestedEnum ,
+    B : ಠ_ಠ.clutz_internal.foo.bar.Baz.NestedEnum ,
   };
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/refer_from_default_ns.d.ts
+++ b/src/test/java/com/google/javascript/clutz/refer_from_default_ns.d.ts
@@ -1,5 +1,5 @@
 declare namespace ಠ_ಠ.clutz_internal {
-  function fn ( ) : fn.String ;
+  function fn ( ) : ಠ_ಠ.clutz_internal.fn.String ;
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {
   function require(name: 'fn'): typeof ಠ_ಠ.clutz_internal.fn;

--- a/src/test/java/com/google/javascript/clutz/shouldResolveNamedTypes/index.d.ts
+++ b/src/test/java/com/google/javascript/clutz/shouldResolveNamedTypes/index.d.ts
@@ -1,7 +1,7 @@
 declare namespace ಠ_ಠ.clutz_internal.namedType {
   class A < U > {
     private noStructuralTyping_: any;
-    fn (a : D < any > ) : any ;
+    fn (a : ಠ_ಠ.clutz_internal.namedType.D < any > ) : any ;
   }
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.d.ts
@@ -1,5 +1,5 @@
 declare namespace ಠ_ಠ.clutz_internal.static_inherit {
-  class Child extends Parent {
+  class Child extends ಠ_ಠ.clutz_internal.static_inherit.Parent {
     static privateParentOverrideField : number ;
     static static_fn (a : number ) : void ;
     /** WARNING: emitted for non-matching super type's static method. Only the first overload is actually callable. */
@@ -15,7 +15,7 @@ declare module 'goog:static_inherit.Child' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz_internal.static_inherit {
-  class GrandChild extends Child {
+  class GrandChild extends ಠ_ಠ.clutz_internal.static_inherit.Child {
     static static_fn (a : boolean ) : void ;
     /** WARNING: emitted for non-matching super type's static method. Only the first overload is actually callable. */
     static static_fn (a : number ) : void ;

--- a/src/test/java/com/google/javascript/clutz/static_provided.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_provided.d.ts
@@ -15,8 +15,8 @@ declare module 'goog:a.b.StaticHolder' {
 declare namespace ಠ_ಠ.clutz_internal.a.b.StaticHolder {
   type AnEnum = number ;
   var AnEnum : {
-    X : AnEnum ,
-    Y : AnEnum ,
+    X : ಠ_ಠ.clutz_internal.a.b.StaticHolder.AnEnum ,
+    Y : ಠ_ಠ.clutz_internal.a.b.StaticHolder.AnEnum ,
   };
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/types_with_externs.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types_with_externs.d.ts
@@ -9,7 +9,7 @@ declare namespace ಠ_ಠ.clutz_internal.typesWithExterns {
   var c : NodeList | IArguments | { length : number } ;
   function elementMaybe ( ) : Element ;
   function id (x : NodeList | IArguments | { length : number } ) : NodeList | IArguments | { length : number } ;
-  var myScope : angular.Scope ;
+  var myScope : ಠ_ಠ.clutz_internal.angular.Scope ;
   function topLevelFunction ( ...a : any [] ) : any ;
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {
@@ -34,7 +34,7 @@ declare module 'goog:typesWithExterns.A' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz_internal.typesWithExterns {
-  class B extends A {
+  class B extends ಠ_ಠ.clutz_internal.typesWithExterns.A {
   }
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {
@@ -45,7 +45,7 @@ declare module 'goog:typesWithExterns.B' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz_internal.typesWithExterns {
-  class C extends A {
+  class C extends ಠ_ಠ.clutz_internal.typesWithExterns.A {
   }
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {
@@ -56,20 +56,20 @@ declare module 'goog:typesWithExterns.C' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz_internal.angular {
-  type $cacheFactory = (a : string , b ? : { capacity : number } ) => $cacheFactory.Cache < any > ;
+  type $cacheFactory = (a : string , b ? : { capacity : number } ) => ಠ_ಠ.clutz_internal.angular.$cacheFactory.Cache < any > ;
   class $injector {
     private noStructuralTyping_: any;
   }
   class Scope {
     private noStructuralTyping_: any;
     $$phase : string ;
-    $apply (opt_exp ? : string | ( (a : Scope ) => any ) ) : any ;
-    $applyAsync (opt_exp ? : string | ( (a : Scope ) => any ) ) : any ;
+    $apply (opt_exp ? : string | ( (a : ಠ_ಠ.clutz_internal.angular.Scope ) => any ) ) : any ;
+    $applyAsync (opt_exp ? : string | ( (a : ಠ_ಠ.clutz_internal.angular.Scope ) => any ) ) : any ;
   }
-  function bootstrap (element : Element | HTMLDocument , opt_modules ? : ( string | ( ( ...a : any [] ) => any ) ) [] ) : $injector ;
+  function bootstrap (element : Element | HTMLDocument , opt_modules ? : ( string | ( ( ...a : any [] ) => any ) ) [] ) : ಠ_ಠ.clutz_internal.angular.$injector ;
 }
 declare namespace ಠ_ಠ.clutz_internal.angular.$cacheFactory {
-  type get = (a : string ) => Cache < any > ;
+  type get = (a : string ) => ಠ_ಠ.clutz_internal.angular.$cacheFactory.Cache < any > ;
 }
 declare namespace ಠ_ಠ.clutz_internal.angular.$cacheFactory {
   type Options = { capacity : number } ;


### PR DESCRIPTION
This makes it much less likely that a type or package gets shadowed by another
type or package with the same name somewhere in the namespace hierarchy.

There is a remaining corner case around re-declared global names like `Element`
or `Object`. The fix would be to alias *all* global names, but that risks
aliasing global names from Closure that do not exist in TypeScript.

Fixes #144.