### PR TITLE
fix: handle empty union types.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -1011,6 +1011,10 @@ public class DeclarationGenerator {
           return !input.isNullType() && !input.isVoidType();
         }
       });
+      if (alts.size() == 0) {
+        emit("any");
+        return;
+      }
       if (alts.size() == 1) {
         visitType(alts.iterator().next());
         return;

--- a/src/test/java/com/google/javascript/clutz/null_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/null_type.d.ts
@@ -1,0 +1,10 @@
+declare namespace ಠ_ಠ.clutz_internal {
+  function nulltypes (a : any , b ? : any ) : void ;
+}
+declare namespace ಠ_ಠ.clutz_internal.goog {
+  function require(name: 'nulltypes'): typeof ಠ_ಠ.clutz_internal.nulltypes;
+}
+declare module 'goog:nulltypes' {
+  import alias = ಠ_ಠ.clutz_internal.nulltypes;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/null_type.js
+++ b/src/test/java/com/google/javascript/clutz/null_type.js
@@ -1,0 +1,7 @@
+goog.provide('nulltypes');
+
+/**
+ * @param {null} a
+ * @param {null=} b
+ */
+nulltypes = function(a, b) {};


### PR DESCRIPTION
Union types can end up having no legal branch, e.g. with `null=`. Emit an `any`
type for those cases - `any` is TypeScript's closest representation for a
Null Type / Bottom Type.

Fixes #141.