### PR TITLE
feat: handle private types in public APIs.

### DIFF
--- a/src/resources/closure.lib.d.ts
+++ b/src/resources/closure.lib.d.ts
@@ -4,6 +4,8 @@
 declare namespace ಠ_ಠ.clutz_internal {
   type GlobalError = Error;
   var GlobalError: ErrorConstructor;
+  /** Represents a Closure type that is private, represented by an empty interface. */
+  interface PrivateType {}
 }
 
 // Will be extended if base.js is a dependency.

--- a/src/test/java/com/google/javascript/clutz/private_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/private_type.d.ts
@@ -1,0 +1,12 @@
+declare namespace ಠ_ಠ.clutz_internal.privatetype {
+  var user : ಠ_ಠ.clutz_internal.PrivateType ;
+}
+declare namespace ಠ_ಠ.clutz_internal.goog {
+  function require(name: 'privatetype.user'): typeof ಠ_ಠ.clutz_internal.privatetype.user;
+}
+declare module 'goog:privatetype.user' {
+  import alias = ಠ_ಠ.clutz_internal.privatetype.user;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz_internal.foo {
+}

--- a/src/test/java/com/google/javascript/clutz/private_type.js
+++ b/src/test/java/com/google/javascript/clutz/private_type.js
@@ -1,0 +1,7 @@
+goog.provide('privatetype.user');
+
+/** @type {privatetype.X_} */
+privatetype.user = new foo.X_();
+
+/** @constructor @private */
+privatetype.X_ = function() {};


### PR DESCRIPTION
Surprisingly, Closure allows private types to be used in public APIs.
Emit an empty object type literal for them, i.e. a type that allows no
use but being passed around and is incompatible with everything else.

Fixes #140.