### PR TITLE
feat: support renaming aliased enums.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/aliased_enum_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/aliased_enum_usage.ts
@@ -1,8 +1,8 @@
-import Enum from 'goog:nested.bar.Enum';
-import EnumAlias from 'goog:nested.baz.Enum';
+import Enum from 'goog:nested.baz.Enum';
+import HahaEnum from 'goog:nested.bar.HahaEnum';
 
 var a: Enum = Enum.A;
-var a2: EnumAlias = EnumAlias.A;
-// Because the twp enums are just type aliases of the same underlying type, they are assignable to
+var a2: HahaEnum = HahaEnum.A;
+// Because the two enums are just type aliases of the same underlying type, they are assignable to
 // each other. This matches Closure's semantics.
 a = a2;

--- a/src/test/java/com/google/javascript/clutz/aliased_enums.d.ts
+++ b/src/test/java/com/google/javascript/clutz/aliased_enums.d.ts
@@ -1,20 +1,20 @@
 declare namespace ಠ_ಠ.clutz_internal.nested.bar {
-  type Enum = number ;
-  var Enum : {
-    A : ಠ_ಠ.clutz_internal.nested.baz.Enum ,
+  type HahaEnum = number ;
+  var HahaEnum : {
+    A : HahaEnum ,
   };
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'nested.bar.Enum'): typeof ಠ_ಠ.clutz_internal.nested.bar.Enum;
+  function require(name: 'nested.bar.HahaEnum'): typeof ಠ_ಠ.clutz_internal.nested.bar.HahaEnum;
 }
-declare module 'goog:nested.bar.Enum' {
-  import alias = ಠ_ಠ.clutz_internal.nested.bar.Enum;
+declare module 'goog:nested.bar.HahaEnum' {
+  import alias = ಠ_ಠ.clutz_internal.nested.bar.HahaEnum;
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz_internal.nested.baz {
   type Enum = number ;
   var Enum : {
-    A : ಠ_ಠ.clutz_internal.nested.baz.Enum ,
+    A : Enum ,
   };
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/aliased_enums.js
+++ b/src/test/java/com/google/javascript/clutz/aliased_enums.js
@@ -1,12 +1,10 @@
 goog.provide('nested.baz.Enum');
-goog.provide('nested.bar.Enum');
+goog.provide('nested.bar.HahaEnum');
 
 /** @enum */
 nested.baz.Enum = {
   A: 1
 };
 
-// The output is only correct for enums with the same name.
-
 /** @enum */
-nested.bar.Enum = nested.baz.Enum;
+nested.bar.HahaEnum = nested.baz.Enum;

--- a/src/test/java/com/google/javascript/clutz/enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/enum.d.ts
@@ -1,8 +1,8 @@
 declare namespace ಠ_ಠ.clutz_internal.some {
   type SomeEnum = number ;
   var SomeEnum : {
-    A : ಠ_ಠ.clutz_internal.some.SomeEnum ,
-    B : ಠ_ಠ.clutz_internal.some.SomeEnum ,
+    A : SomeEnum ,
+    B : SomeEnum ,
   };
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/interface.d.ts
+++ b/src/test/java/com/google/javascript/clutz/interface.d.ts
@@ -14,8 +14,8 @@ declare module 'goog:interface_exp' {
 declare namespace ಠ_ಠ.clutz_internal.interface_exp {
   type SomeEnum = number ;
   var SomeEnum : {
-    A : ಠ_ಠ.clutz_internal.interface_exp.SomeEnum ,
-    B : ಠ_ಠ.clutz_internal.interface_exp.SomeEnum ,
+    A : SomeEnum ,
+    B : SomeEnum ,
   };
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
@@ -14,8 +14,8 @@ declare namespace ಠ_ಠ.clutz_internal.foo.bar.Baz {
   }
   type NestedEnum = number ;
   var NestedEnum : {
-    A : ಠ_ಠ.clutz_internal.foo.bar.Baz.NestedEnum ,
-    B : ಠ_ಠ.clutz_internal.foo.bar.Baz.NestedEnum ,
+    A : NestedEnum ,
+    B : NestedEnum ,
   };
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {

--- a/src/test/java/com/google/javascript/clutz/static_provided.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_provided.d.ts
@@ -15,8 +15,8 @@ declare module 'goog:a.b.StaticHolder' {
 declare namespace ಠ_ಠ.clutz_internal.a.b.StaticHolder {
   type AnEnum = number ;
   var AnEnum : {
-    X : ಠ_ಠ.clutz_internal.a.b.StaticHolder.AnEnum ,
-    Y : ಠ_ಠ.clutz_internal.a.b.StaticHolder.AnEnum ,
+    X : AnEnum ,
+    Y : AnEnum ,
   };
 }
 declare namespace ಠ_ಠ.clutz_internal.goog {


### PR DESCRIPTION
Enum names are the names of the symbol they get assigned to, not the
names of the underlying type they refer to.

Fixes #139.