### PR TITLE
feat: support files that provide non-defined symbols.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -221,8 +221,12 @@ public class DeclarationGenerator {
     TypedScope topScope = compiler.getTopScope();
     for (String provide : provides) {
       TypedVar symbol = topScope.getOwnSlot(provide);
-      checkArgument(symbol != null, "goog.provide not defined: %s", provide);
-      checkArgument(symbol.getType() != null, "all symbols should have a type");
+      if (symbol == null) {
+        // Sometimes goog.provide statements are used as pure markers for dependency management.
+        declareModule(provide, true);
+        continue;
+      }
+      checkArgument(symbol.getType() != null, "all symbols should have a type: %s", provide);
       String namespace = provide;
         // These goog.provide's have only one symbol, so users expect to use default import
       boolean isDefault = !symbol.getType().isObject() ||

--- a/src/test/java/com/google/javascript/clutz/undefined_provide.d.ts
+++ b/src/test/java/com/google/javascript/clutz/undefined_provide.d.ts
@@ -1,0 +1,6 @@
+declare namespace ಠ_ಠ.clutz_internal.undefined_provide {
+}
+declare module 'goog:undefined_provide' {
+  import alias = ಠ_ಠ.clutz_internal.undefined_provide;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/undefined_provide.js
+++ b/src/test/java/com/google/javascript/clutz/undefined_provide.js
@@ -1,0 +1,3 @@
+goog.provide('undefined_provide');
+
+var haha = 12;


### PR DESCRIPTION
This is sometimes used just for the require/provide markers, e.g. to support
AutoJsDeps.