### PR TITLE
rename clutz_internal to clutz.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Constants.java
+++ b/src/main/java/com/google/javascript/clutz/Constants.java
@@ -6,5 +6,5 @@ public class Constants {
    * The namespace prefix. Admittedly this only exists here so that Eclipse's font rendering is not
    * disturbed by the extended Unicode character.
    */
-  static final String INTERNAL_NAMESPACE = "ಠ_ಠ.clutz_internal";
+  static final String INTERNAL_NAMESPACE = "ಠ_ಠ.clutz";
 }

--- a/src/resources/closure.lib.d.ts
+++ b/src/resources/closure.lib.d.ts
@@ -1,7 +1,7 @@
 // Work around for https://github.com/Microsoft/TypeScript/issues/983
-// All clutz namespaces are below ಠ_ಠ.clutz_internal, thus
+// All clutz namespaces are below ಠ_ಠ.clutz, thus
 // this acts as global.
-declare namespace ಠ_ಠ.clutz_internal {
+declare namespace ಠ_ಠ.clutz {
   type GlobalError = Error;
   var GlobalError: ErrorConstructor;
   /** Represents a Closure type that is private, represented by an empty interface. */
@@ -9,10 +9,10 @@ declare namespace ಠ_ಠ.clutz_internal {
 }
 
 // Will be extended if base.js is a dependency.
-declare namespace ಠ_ಠ.clutz_internal.goog {
+declare namespace ಠ_ಠ.clutz.goog {
   var __namespace_needs_to_be_non_value_empty__: void;
 }
 
 // Closure's goog namespace is accessible as a global symbol without the need for
 // an explicit goog.require, during the closure compiler pass.
-declare var goog: typeof ಠ_ಠ.clutz_internal.goog;
+declare var goog: typeof ಠ_ಠ.clutz.goog;

--- a/src/test/java/com/google/javascript/clutz/aliased_enums.d.ts
+++ b/src/test/java/com/google/javascript/clutz/aliased_enums.d.ts
@@ -1,26 +1,26 @@
-declare namespace ಠ_ಠ.clutz_internal.nested.bar {
+declare namespace ಠ_ಠ.clutz.nested.bar {
   type HahaEnum = number ;
   var HahaEnum : {
     A : HahaEnum ,
   };
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'nested.bar.HahaEnum'): typeof ಠ_ಠ.clutz_internal.nested.bar.HahaEnum;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'nested.bar.HahaEnum'): typeof ಠ_ಠ.clutz.nested.bar.HahaEnum;
 }
 declare module 'goog:nested.bar.HahaEnum' {
-  import alias = ಠ_ಠ.clutz_internal.nested.bar.HahaEnum;
+  import alias = ಠ_ಠ.clutz.nested.bar.HahaEnum;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.nested.baz {
+declare namespace ಠ_ಠ.clutz.nested.baz {
   type Enum = number ;
   var Enum : {
     A : Enum ,
   };
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'nested.baz.Enum'): typeof ಠ_ಠ.clutz_internal.nested.baz.Enum;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'nested.baz.Enum'): typeof ಠ_ಠ.clutz.nested.baz.Enum;
 }
 declare module 'goog:nested.baz.Enum' {
-  import alias = ಠ_ಠ.clutz_internal.nested.baz.Enum;
+  import alias = ಠ_ಠ.clutz.nested.baz.Enum;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/base.d.ts
+++ b/src/test/java/com/google/javascript/clutz/base.d.ts
@@ -1,9 +1,9 @@
-declare namespace ಠ_ಠ.clutz_internal.goog {
+declare namespace ಠ_ಠ.clutz.goog {
   function inherits (childCtor : ( ...a : any [] ) => any , parentCtor : ( ...a : any [] ) => any ) : void ;
   function isDef (val : any ) : boolean ;
   function require (name : string ) : void ;
 }
 declare module 'goog:goog' {
-  import alias = ಠ_ಠ.clutz_internal.goog;
+  import alias = ಠ_ಠ.clutz.goog;
   export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/ctor_func.d.ts
+++ b/src/test/java/com/google/javascript/clutz/ctor_func.d.ts
@@ -1,15 +1,15 @@
-declare namespace ಠ_ಠ.clutz_internal.ctor_func {
+declare namespace ಠ_ಠ.clutz.ctor_func {
   class Ctor < T > {
     private noStructuralTyping_: any;
     constructor (a : string , b : number ) ;
   }
-  var ctorFuncField : { new (a : string , b : number ) : ಠ_ಠ.clutz_internal.ctor_func.Ctor < any > } ;
-  function ctorFuncParam (ctor : { new (a : number ) : ಠ_ಠ.clutz_internal.ctor_func.Ctor < any > } ) : void ;
+  var ctorFuncField : { new (a : string , b : number ) : ಠ_ಠ.clutz.ctor_func.Ctor < any > } ;
+  function ctorFuncParam (ctor : { new (a : number ) : ಠ_ಠ.clutz.ctor_func.Ctor < any > } ) : void ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'ctor_func'): typeof ಠ_ಠ.clutz_internal.ctor_func;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'ctor_func'): typeof ಠ_ಠ.clutz.ctor_func;
 }
 declare module 'goog:ctor_func' {
-  import alias = ಠ_ಠ.clutz_internal.ctor_func;
+  import alias = ಠ_ಠ.clutz.ctor_func;
   export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/default_fn.d.ts
+++ b/src/test/java/com/google/javascript/clutz/default_fn.d.ts
@@ -1,10 +1,10 @@
-declare namespace ಠ_ಠ.clutz_internal {
+declare namespace ಠ_ಠ.clutz {
   function default_fn ( ) : number ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'default_fn'): typeof ಠ_ಠ.clutz_internal.default_fn;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'default_fn'): typeof ಠ_ಠ.clutz.default_fn;
 }
 declare module 'goog:default_fn' {
-  import alias = ಠ_ಠ.clutz_internal.default_fn;
+  import alias = ಠ_ಠ.clutz.default_fn;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/default_var.d.ts
+++ b/src/test/java/com/google/javascript/clutz/default_var.d.ts
@@ -1,10 +1,10 @@
-declare namespace ಠ_ಠ.clutz_internal.default_var {
+declare namespace ಠ_ಠ.clutz.default_var {
   var Var : number ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'default_var.Var'): typeof ಠ_ಠ.clutz_internal.default_var.Var;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'default_var.Var'): typeof ಠ_ಠ.clutz.default_var.Var;
 }
 declare module 'goog:default_var.Var' {
-  import alias = ಠ_ಠ.clutz_internal.default_var.Var;
+  import alias = ಠ_ಠ.clutz.default_var.Var;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/dict.d.ts
+++ b/src/test/java/com/google/javascript/clutz/dict.d.ts
@@ -1,4 +1,4 @@
-declare namespace ಠ_ಠ.clutz_internal.dict {
+declare namespace ಠ_ಠ.clutz.dict {
   class ClassWithDottedProperties {
     private noStructuralTyping_: any;
     [key: string]: any;
@@ -13,10 +13,10 @@ declare namespace ಠ_ಠ.clutz_internal.dict {
   var typed : { a : ( ...a : any [] ) => any } ;
   var untyped : {[key: string]: any} ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'dict'): typeof ಠ_ಠ.clutz_internal.dict;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'dict'): typeof ಠ_ಠ.clutz.dict;
 }
 declare module 'goog:dict' {
-  import alias = ಠ_ಠ.clutz_internal.dict;
+  import alias = ಠ_ಠ.clutz.dict;
   export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/empty_type_args.d.ts
+++ b/src/test/java/com/google/javascript/clutz/empty_type_args.d.ts
@@ -1,33 +1,33 @@
-declare namespace ಠ_ಠ.clutz_internal.empty_type_args {
+declare namespace ಠ_ಠ.clutz.empty_type_args {
   interface ITemplated < T > {
   }
 }
 declare module 'goog:empty_type_args.ITemplated' {
-  import alias = ಠ_ಠ.clutz_internal.empty_type_args.ITemplated;
+  import alias = ಠ_ಠ.clutz.empty_type_args.ITemplated;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.empty_type_args {
-  class NoMoreTemplateArgs implements ಠ_ಠ.clutz_internal.empty_type_args.ITemplated < number > {
+declare namespace ಠ_ಠ.clutz.empty_type_args {
+  class NoMoreTemplateArgs implements ಠ_ಠ.clutz.empty_type_args.ITemplated < number > {
     private noStructuralTyping_: any;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'empty_type_args.NoMoreTemplateArgs'): typeof ಠ_ಠ.clutz_internal.empty_type_args.NoMoreTemplateArgs;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'empty_type_args.NoMoreTemplateArgs'): typeof ಠ_ಠ.clutz.empty_type_args.NoMoreTemplateArgs;
 }
 declare module 'goog:empty_type_args.NoMoreTemplateArgs' {
-  import alias = ಠ_ಠ.clutz_internal.empty_type_args.NoMoreTemplateArgs;
+  import alias = ಠ_ಠ.clutz.empty_type_args.NoMoreTemplateArgs;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.empty_type_args {
+declare namespace ಠ_ಠ.clutz.empty_type_args {
   class X {
     private noStructuralTyping_: any;
-    constructor (a : ಠ_ಠ.clutz_internal.empty_type_args.NoMoreTemplateArgs ) ;
+    constructor (a : ಠ_ಠ.clutz.empty_type_args.NoMoreTemplateArgs ) ;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'empty_type_args.X'): typeof ಠ_ಠ.clutz_internal.empty_type_args.X;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'empty_type_args.X'): typeof ಠ_ಠ.clutz.empty_type_args.X;
 }
 declare module 'goog:empty_type_args.X' {
-  import alias = ಠ_ಠ.clutz_internal.empty_type_args.X;
+  import alias = ಠ_ಠ.clutz.empty_type_args.X;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/enum.d.ts
@@ -1,14 +1,14 @@
-declare namespace ಠ_ಠ.clutz_internal.some {
+declare namespace ಠ_ಠ.clutz.some {
   type SomeEnum = number ;
   var SomeEnum : {
     A : SomeEnum ,
     B : SomeEnum ,
   };
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'some.SomeEnum'): typeof ಠ_ಠ.clutz_internal.some.SomeEnum;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'some.SomeEnum'): typeof ಠ_ಠ.clutz.some.SomeEnum;
 }
 declare module 'goog:some.SomeEnum' {
-  import alias = ಠ_ಠ.clutz_internal.some.SomeEnum;
+  import alias = ಠ_ಠ.clutz.some.SomeEnum;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/fn_params.d.ts
+++ b/src/test/java/com/google/javascript/clutz/fn_params.d.ts
@@ -1,4 +1,4 @@
-declare namespace ಠ_ಠ.clutz_internal.fn_params {
+declare namespace ಠ_ಠ.clutz.fn_params {
   function declaredWithType ( ...a : any [] ) : any ;
   function optional (x : string , opt_y ? : number ) : number ;
   function optionalNullable (x : string , opt_y ? : number ) : number ;
@@ -8,10 +8,10 @@ declare namespace ಠ_ಠ.clutz_internal.fn_params {
   function varargs (x : string ,  ...y : ( number ) [] ) : void ;
   function varargs_fns ( ...var_args : ( ( ...a : any [] ) => any ) [] ) : void ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'fn_params'): typeof ಠ_ಠ.clutz_internal.fn_params;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'fn_params'): typeof ಠ_ಠ.clutz.fn_params;
 }
 declare module 'goog:fn_params' {
-  import alias = ಠ_ಠ.clutz_internal.fn_params;
+  import alias = ಠ_ಠ.clutz.fn_params;
   export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/forward_declare.d.ts
+++ b/src/test/java/com/google/javascript/clutz/forward_declare.d.ts
@@ -1,4 +1,4 @@
-declare namespace ಠ_ಠ.clutz_internal.forward {
+declare namespace ಠ_ಠ.clutz.forward {
   class A {
     private noStructuralTyping_: any;
     //!! forward.D may or may not be part of the compilation unit.
@@ -7,10 +7,10 @@ declare namespace ಠ_ಠ.clutz_internal.forward {
     fn (a : any ) : any ;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'forward.A'): typeof ಠ_ಠ.clutz_internal.forward.A;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'forward.A'): typeof ಠ_ಠ.clutz.forward.A;
 }
 declare module 'goog:forward.A' {
-  import alias = ಠ_ಠ.clutz_internal.forward.A;
+  import alias = ಠ_ಠ.clutz.forward.A;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/generics.d.ts
+++ b/src/test/java/com/google/javascript/clutz/generics.d.ts
@@ -1,7 +1,7 @@
-declare namespace ಠ_ಠ.clutz_internal.generics {
-  interface ExtendGenericInterface < TYPE > extends ಠ_ಠ.clutz_internal.generics.GenericInterface < TYPE > {
+declare namespace ಠ_ಠ.clutz.generics {
+  interface ExtendGenericInterface < TYPE > extends ಠ_ಠ.clutz.generics.GenericInterface < TYPE > {
   }
-  class ExtendsGenericClass < TYPE > extends ಠ_ಠ.clutz_internal.generics.Foo < TYPE , number > {
+  class ExtendsGenericClass < TYPE > extends ಠ_ಠ.clutz.generics.Foo < TYPE , number > {
   }
   class Foo < T , U > {
     private noStructuralTyping_: any;
@@ -12,20 +12,20 @@ declare namespace ಠ_ಠ.clutz_internal.generics {
   }
   interface GenericInterface < TYPE > {
   }
-  class ImplementsGenericInterface < TYPE > implements ಠ_ಠ.clutz_internal.generics.GenericInterface < TYPE > {
+  class ImplementsGenericInterface < TYPE > implements ಠ_ಠ.clutz.generics.GenericInterface < TYPE > {
     private noStructuralTyping_: any;
   }
   var arrayMissingTypeParam : any [] ;
-  var fooMissingAllTypeParams : ಠ_ಠ.clutz_internal.generics.Foo < any , any > ;
-  var fooMissingOneTypeParam : ಠ_ಠ.clutz_internal.generics.Foo < string , any > ;
+  var fooMissingAllTypeParams : ಠ_ಠ.clutz.generics.Foo < any , any > ;
+  var fooMissingOneTypeParam : ಠ_ಠ.clutz.generics.Foo < string , any > ;
   function genericFunction < T > (a : T ) : T ;
   function identity < T > (a : T ) : T ;
   function objectWithGenericKeyType < K , V > (obj : { [ /* warning: coerced from K */ s: string ]: V } ) : void ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'generics'): typeof ಠ_ಠ.clutz_internal.generics;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'generics'): typeof ಠ_ಠ.clutz.generics;
 }
 declare module 'goog:generics' {
-  import alias = ಠ_ಠ.clutz_internal.generics;
+  import alias = ಠ_ಠ.clutz.generics;
   export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/goog_require.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_require.d.ts
@@ -1,22 +1,22 @@
-declare namespace ಠ_ಠ.clutz_internal.foo {
+declare namespace ಠ_ಠ.clutz.foo {
   class SimpleClass {
     private noStructuralTyping_: any;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'foo.SimpleClass'): typeof ಠ_ಠ.clutz_internal.foo.SimpleClass;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'foo.SimpleClass'): typeof ಠ_ಠ.clutz.foo.SimpleClass;
 }
 declare module 'goog:foo.SimpleClass' {
-  import alias = ಠ_ಠ.clutz_internal.foo.SimpleClass;
+  import alias = ಠ_ಠ.clutz.foo.SimpleClass;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.foo.simpleNamespace {
+declare namespace ಠ_ಠ.clutz.foo.simpleNamespace {
   var a : number ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'foo.simpleNamespace'): typeof ಠ_ಠ.clutz_internal.foo.simpleNamespace;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'foo.simpleNamespace'): typeof ಠ_ಠ.clutz.foo.simpleNamespace;
 }
 declare module 'goog:foo.simpleNamespace' {
-  import alias = ಠ_ಠ.clutz_internal.foo.simpleNamespace;
+  import alias = ಠ_ಠ.clutz.foo.simpleNamespace;
   export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/interface.d.ts
+++ b/src/test/java/com/google/javascript/clutz/interface.d.ts
@@ -1,27 +1,27 @@
-declare namespace ಠ_ಠ.clutz_internal {
+declare namespace ಠ_ಠ.clutz {
   interface interface_exp {
     method ( ) : number ;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.interface_exp {
+declare namespace ಠ_ಠ.clutz.interface_exp {
   var staticMethod : ( ) => number ;
   var staticProp : number ;
 }
 declare module 'goog:interface_exp' {
-  import alias = ಠ_ಠ.clutz_internal.interface_exp;
+  import alias = ಠ_ಠ.clutz.interface_exp;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.interface_exp {
+declare namespace ಠ_ಠ.clutz.interface_exp {
   type SomeEnum = number ;
   var SomeEnum : {
     A : SomeEnum ,
     B : SomeEnum ,
   };
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'interface_exp.SomeEnum'): typeof ಠ_ಠ.clutz_internal.interface_exp.SomeEnum;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'interface_exp.SomeEnum'): typeof ಠ_ಠ.clutz.interface_exp.SomeEnum;
 }
 declare module 'goog:interface_exp.SomeEnum' {
-  import alias = ಠ_ಠ.clutz_internal.interface_exp.SomeEnum;
+  import alias = ಠ_ಠ.clutz.interface_exp.SomeEnum;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/jsdoc.d.ts
+++ b/src/test/java/com/google/javascript/clutz/jsdoc.d.ts
@@ -1,4 +1,4 @@
-declare namespace ಠ_ಠ.clutz_internal.x {
+declare namespace ಠ_ಠ.clutz.x {
   /**
    * Docs on a ctor.
    *
@@ -24,10 +24,10 @@ declare namespace ಠ_ಠ.clutz_internal.x {
     method (foo : string ) : void ;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'x.Y'): typeof ಠ_ಠ.clutz_internal.x.Y;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'x.Y'): typeof ಠ_ಠ.clutz.x.Y;
 }
 declare module 'goog:x.Y' {
-  import alias = ಠ_ಠ.clutz_internal.x.Y;
+  import alias = ಠ_ಠ.clutz.x.Y;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/lends.d.ts
+++ b/src/test/java/com/google/javascript/clutz/lends.d.ts
@@ -1,10 +1,10 @@
-declare namespace ಠ_ಠ.clutz_internal.lends {
+declare namespace ಠ_ಠ.clutz.lends {
 }
 declare module 'goog:lends' {
-  import alias = ಠ_ಠ.clutz_internal.lends;
+  import alias = ಠ_ಠ.clutz.lends;
   export = alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.lends {
+declare namespace ಠ_ಠ.clutz.lends {
   class A {
     private noStructuralTyping_: any;
     a : string ;
@@ -12,10 +12,10 @@ declare namespace ಠ_ಠ.clutz_internal.lends {
     static b : number ;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'lends.A'): typeof ಠ_ಠ.clutz_internal.lends.A;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'lends.A'): typeof ಠ_ಠ.clutz.lends.A;
 }
 declare module 'goog:lends.A' {
-  import alias = ಠ_ಠ.clutz_internal.lends.A;
+  import alias = ಠ_ಠ.clutz.lends.A;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/multi_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/multi_class.d.ts
@@ -1,27 +1,27 @@
-declare namespace ಠ_ಠ.clutz_internal.multi_class {
+declare namespace ಠ_ಠ.clutz.multi_class {
   class A {
     private noStructuralTyping_: any;
     constructor (n : number ) ;
     a : number ;
   }
-  class B extends ಠ_ಠ.clutz_internal.multi_class.A implements ಠ_ಠ.clutz_internal.multi_class.I , ಠ_ಠ.clutz_internal.multi_class.I2 {
+  class B extends ಠ_ಠ.clutz.multi_class.A implements ಠ_ಠ.clutz.multi_class.I , ಠ_ಠ.clutz.multi_class.I2 {
     b : number ;
     noop ( ) : void ;
   }
-  class C extends ಠ_ಠ.clutz_internal.multi_class.B {
+  class C extends ಠ_ಠ.clutz.multi_class.B {
   }
-  class D implements ಠ_ಠ.clutz_internal.multi_class.I {
+  class D implements ಠ_ಠ.clutz.multi_class.I {
     private noStructuralTyping_: any;
   }
   interface I {
   }
-  interface I2 extends ಠ_ಠ.clutz_internal.multi_class.I {
+  interface I2 extends ಠ_ಠ.clutz.multi_class.I {
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'multi_class'): typeof ಠ_ಠ.clutz_internal.multi_class;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'multi_class'): typeof ಠ_ಠ.clutz.multi_class;
 }
 declare module 'goog:multi_class' {
-  import alias = ಠ_ಠ.clutz_internal.multi_class;
+  import alias = ಠ_ಠ.clutz.multi_class;
   export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/multi_provides.d.ts
+++ b/src/test/java/com/google/javascript/clutz/multi_provides.d.ts
@@ -1,32 +1,32 @@
-declare namespace ಠ_ಠ.clutz_internal.multi_provides.a {
+declare namespace ಠ_ಠ.clutz.multi_provides.a {
   var val : number ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'multi_provides.a'): typeof ಠ_ಠ.clutz_internal.multi_provides.a;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'multi_provides.a'): typeof ಠ_ಠ.clutz.multi_provides.a;
 }
 declare module 'goog:multi_provides.a' {
-  import alias = ಠ_ಠ.clutz_internal.multi_provides.a;
+  import alias = ಠ_ಠ.clutz.multi_provides.a;
   export = alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.multi_provides.a.b.c {
+declare namespace ಠ_ಠ.clutz.multi_provides.a.b.c {
   var three : string ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'multi_provides.a.b.c'): typeof ಠ_ಠ.clutz_internal.multi_provides.a.b.c;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'multi_provides.a.b.c'): typeof ಠ_ಠ.clutz.multi_provides.a.b.c;
 }
 declare module 'goog:multi_provides.a.b.c' {
-  import alias = ಠ_ಠ.clutz_internal.multi_provides.a.b.c;
+  import alias = ಠ_ಠ.clutz.multi_provides.a.b.c;
   export = alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.multi_provides.a.b.c {
+declare namespace ಠ_ಠ.clutz.multi_provides.a.b.c {
   class Two {
     private noStructuralTyping_: any;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'multi_provides.a.b.c.Two'): typeof ಠ_ಠ.clutz_internal.multi_provides.a.b.c.Two;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'multi_provides.a.b.c.Two'): typeof ಠ_ಠ.clutz.multi_provides.a.b.c.Two;
 }
 declare module 'goog:multi_provides.a.b.c.Two' {
-  import alias = ಠ_ಠ.clutz_internal.multi_provides.a.b.c.Two;
+  import alias = ಠ_ಠ.clutz.multi_provides.a.b.c.Two;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/null_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/null_type.d.ts
@@ -1,10 +1,10 @@
-declare namespace ಠ_ಠ.clutz_internal {
+declare namespace ಠ_ಠ.clutz {
   function nulltypes (a : any , b ? : any ) : void ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'nulltypes'): typeof ಠ_ಠ.clutz_internal.nulltypes;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'nulltypes'): typeof ಠ_ಠ.clutz.nulltypes;
 }
 declare module 'goog:nulltypes' {
-  import alias = ಠ_ಠ.clutz_internal.nulltypes;
+  import alias = ಠ_ಠ.clutz.nulltypes;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/nullable.d.ts
+++ b/src/test/java/com/google/javascript/clutz/nullable.d.ts
@@ -1,4 +1,4 @@
-declare namespace ಠ_ಠ.clutz_internal.nullable {
+declare namespace ಠ_ಠ.clutz.nullable {
   var w : boolean ;
   /**
    * Explicitly non-nullable.
@@ -13,10 +13,10 @@ declare namespace ಠ_ಠ.clutz_internal.nullable {
    */
   var z : Object ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'nullable'): typeof ಠ_ಠ.clutz_internal.nullable;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'nullable'): typeof ಠ_ಠ.clutz.nullable;
 }
 declare module 'goog:nullable' {
-  import alias = ಠ_ಠ.clutz_internal.nullable;
+  import alias = ಠ_ಠ.clutz.nullable;
   export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/private_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/private_type.d.ts
@@ -1,12 +1,12 @@
-declare namespace ಠ_ಠ.clutz_internal.privatetype {
-  var user : ಠ_ಠ.clutz_internal.PrivateType ;
+declare namespace ಠ_ಠ.clutz.privatetype {
+  var user : ಠ_ಠ.clutz.PrivateType ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'privatetype.user'): typeof ಠ_ಠ.clutz_internal.privatetype.user;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'privatetype.user'): typeof ಠ_ಠ.clutz.privatetype.user;
 }
 declare module 'goog:privatetype.user' {
-  import alias = ಠ_ಠ.clutz_internal.privatetype.user;
+  import alias = ಠ_ಠ.clutz.privatetype.user;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.foo {
+declare namespace ಠ_ಠ.clutz.foo {
 }

--- a/src/test/java/com/google/javascript/clutz/privates.d.ts
+++ b/src/test/java/com/google/javascript/clutz/privates.d.ts
@@ -1,13 +1,13 @@
-declare namespace ಠ_ಠ.clutz_internal.priv {
+declare namespace ಠ_ಠ.clutz.priv {
   class PublicClass {
     private noStructuralTyping_: any;
     publicField : number ;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'priv'): typeof ಠ_ಠ.clutz_internal.priv;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'priv'): typeof ಠ_ಠ.clutz.priv;
 }
 declare module 'goog:priv' {
-  import alias = ಠ_ಠ.clutz_internal.priv;
+  import alias = ಠ_ಠ.clutz.priv;
   export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
@@ -1,14 +1,14 @@
-declare namespace ಠ_ಠ.clutz_internal.foo.bar {
+declare namespace ಠ_ಠ.clutz.foo.bar {
   class Baz {
     private noStructuralTyping_: any;
     field : string ;
     avalue : number ;
-    equals (b : ಠ_ಠ.clutz_internal.foo.bar.Baz.NestedClass ) : boolean ;
+    equals (b : ಠ_ಠ.clutz.foo.bar.Baz.NestedClass ) : boolean ;
     method (a : string ) : number ;
     static staticMethod (a : string ) : number ;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.foo.bar.Baz {
+declare namespace ಠ_ಠ.clutz.foo.bar.Baz {
   class NestedClass {
     private noStructuralTyping_: any;
   }
@@ -18,10 +18,10 @@ declare namespace ಠ_ಠ.clutz_internal.foo.bar.Baz {
     B : NestedEnum ,
   };
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'foo.bar.Baz'): typeof ಠ_ಠ.clutz_internal.foo.bar.Baz;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'foo.bar.Baz'): typeof ಠ_ಠ.clutz.foo.bar.Baz;
 }
 declare module 'goog:foo.bar.Baz' {
-  import alias = ಠ_ಠ.clutz_internal.foo.bar.Baz;
+  import alias = ಠ_ಠ.clutz.foo.bar.Baz;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/refer_from_default_ns.d.ts
+++ b/src/test/java/com/google/javascript/clutz/refer_from_default_ns.d.ts
@@ -1,22 +1,22 @@
-declare namespace ಠ_ಠ.clutz_internal {
-  function fn ( ) : ಠ_ಠ.clutz_internal.fn.String ;
+declare namespace ಠ_ಠ.clutz {
+  function fn ( ) : ಠ_ಠ.clutz.fn.String ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'fn'): typeof ಠ_ಠ.clutz_internal.fn;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'fn'): typeof ಠ_ಠ.clutz.fn;
 }
 declare module 'goog:fn' {
-  import alias = ಠ_ಠ.clutz_internal.fn;
+  import alias = ಠ_ಠ.clutz.fn;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.fn {
+declare namespace ಠ_ಠ.clutz.fn {
   class String {
     private noStructuralTyping_: any;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'fn.String'): typeof ಠ_ಠ.clutz_internal.fn.String;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'fn.String'): typeof ಠ_ಠ.clutz.fn.String;
 }
 declare module 'goog:fn.String' {
-  import alias = ಠ_ಠ.clutz_internal.fn.String;
+  import alias = ಠ_ಠ.clutz.fn.String;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/shouldPruneProvidesFromNonrootFile/require.d.ts
+++ b/src/test/java/com/google/javascript/clutz/shouldPruneProvidesFromNonrootFile/require.d.ts
@@ -1,13 +1,13 @@
 //!! a.b.ShouldNotAppear must be absent here, it is provide'd in a non-root
-declare namespace ಠ_ಠ.clutz_internal.a.b {
+declare namespace ಠ_ಠ.clutz.a.b {
   class Thing {
     private noStructuralTyping_: any;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'a.b'): typeof ಠ_ಠ.clutz_internal.a.b;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'a.b'): typeof ಠ_ಠ.clutz.a.b;
 }
 declare module 'goog:a.b' {
-  import alias = ಠ_ಠ.clutz_internal.a.b;
+  import alias = ಠ_ಠ.clutz.a.b;
   export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/shouldResolveNamedTypes/index.d.ts
+++ b/src/test/java/com/google/javascript/clutz/shouldResolveNamedTypes/index.d.ts
@@ -1,25 +1,25 @@
-declare namespace ಠ_ಠ.clutz_internal.namedType {
+declare namespace ಠ_ಠ.clutz.namedType {
   class A < U > {
     private noStructuralTyping_: any;
-    fn (a : ಠ_ಠ.clutz_internal.namedType.D < any > ) : any ;
+    fn (a : ಠ_ಠ.clutz.namedType.D < any > ) : any ;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'namedType.A'): typeof ಠ_ಠ.clutz_internal.namedType.A;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'namedType.A'): typeof ಠ_ಠ.clutz.namedType.A;
 }
 declare module 'goog:namedType.A' {
-  import alias = ಠ_ಠ.clutz_internal.namedType.A;
+  import alias = ಠ_ಠ.clutz.namedType.A;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.namedType {
+declare namespace ಠ_ಠ.clutz.namedType {
   class D < T > {
     private noStructuralTyping_: any;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'namedType.D'): typeof ಠ_ಠ.clutz_internal.namedType.D;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'namedType.D'): typeof ಠ_ಠ.clutz.namedType.D;
 }
 declare module 'goog:namedType.D' {
-  import alias = ಠ_ಠ.clutz_internal.namedType.D;
+  import alias = ಠ_ಠ.clutz.namedType.D;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.d.ts
@@ -1,5 +1,5 @@
-declare namespace ಠ_ಠ.clutz_internal.static_inherit {
-  class Child extends ಠ_ಠ.clutz_internal.static_inherit.Parent {
+declare namespace ಠ_ಠ.clutz.static_inherit {
+  class Child extends ಠ_ಠ.clutz.static_inherit.Parent {
     static privateParentOverrideField : number ;
     static static_fn (a : number ) : void ;
     /** WARNING: emitted for non-matching super type's static method. Only the first overload is actually callable. */
@@ -7,15 +7,15 @@ declare namespace ಠ_ಠ.clutz_internal.static_inherit {
     static subTypeField : any [] ;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'static_inherit.Child'): typeof ಠ_ಠ.clutz_internal.static_inherit.Child;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'static_inherit.Child'): typeof ಠ_ಠ.clutz.static_inherit.Child;
 }
 declare module 'goog:static_inherit.Child' {
-  import alias = ಠ_ಠ.clutz_internal.static_inherit.Child;
+  import alias = ಠ_ಠ.clutz.static_inherit.Child;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.static_inherit {
-  class GrandChild extends ಠ_ಠ.clutz_internal.static_inherit.Child {
+declare namespace ಠ_ಠ.clutz.static_inherit {
+  class GrandChild extends ಠ_ಠ.clutz.static_inherit.Child {
     static static_fn (a : boolean ) : void ;
     /** WARNING: emitted for non-matching super type's static method. Only the first overload is actually callable. */
     static static_fn (a : number ) : void ;
@@ -23,14 +23,14 @@ declare namespace ಠ_ಠ.clutz_internal.static_inherit {
     static static_fn (a : string ) : void ;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'static_inherit.GrandChild'): typeof ಠ_ಠ.clutz_internal.static_inherit.GrandChild;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'static_inherit.GrandChild'): typeof ಠ_ಠ.clutz.static_inherit.GrandChild;
 }
 declare module 'goog:static_inherit.GrandChild' {
-  import alias = ಠ_ಠ.clutz_internal.static_inherit.GrandChild;
+  import alias = ಠ_ಠ.clutz.static_inherit.GrandChild;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.static_inherit {
+declare namespace ಠ_ಠ.clutz.static_inherit {
   class Parent {
     private noStructuralTyping_: any;
     static privateChildOverrideField : number ;
@@ -38,10 +38,10 @@ declare namespace ಠ_ಠ.clutz_internal.static_inherit {
     static subTypeField : Object ;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'static_inherit.Parent'): typeof ಠ_ಠ.clutz_internal.static_inherit.Parent;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'static_inherit.Parent'): typeof ಠ_ಠ.clutz.static_inherit.Parent;
 }
 declare module 'goog:static_inherit.Parent' {
-  import alias = ಠ_ಠ.clutz_internal.static_inherit.Parent;
+  import alias = ಠ_ಠ.clutz.static_inherit.Parent;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/static_provided.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_provided.d.ts
@@ -1,38 +1,38 @@
-declare namespace ಠ_ಠ.clutz_internal.a.b {
+declare namespace ಠ_ಠ.clutz.a.b {
   class StaticHolder {
     private noStructuralTyping_: any;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.a.b.StaticHolder {
+declare namespace ಠ_ಠ.clutz.a.b.StaticHolder {
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'a.b.StaticHolder'): typeof ಠ_ಠ.clutz_internal.a.b.StaticHolder;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'a.b.StaticHolder'): typeof ಠ_ಠ.clutz.a.b.StaticHolder;
 }
 declare module 'goog:a.b.StaticHolder' {
-  import alias = ಠ_ಠ.clutz_internal.a.b.StaticHolder;
+  import alias = ಠ_ಠ.clutz.a.b.StaticHolder;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.a.b.StaticHolder {
+declare namespace ಠ_ಠ.clutz.a.b.StaticHolder {
   type AnEnum = number ;
   var AnEnum : {
     X : AnEnum ,
     Y : AnEnum ,
   };
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'a.b.StaticHolder.AnEnum'): typeof ಠ_ಠ.clutz_internal.a.b.StaticHolder.AnEnum;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'a.b.StaticHolder.AnEnum'): typeof ಠ_ಠ.clutz.a.b.StaticHolder.AnEnum;
 }
 declare module 'goog:a.b.StaticHolder.AnEnum' {
-  import alias = ಠ_ಠ.clutz_internal.a.b.StaticHolder.AnEnum;
+  import alias = ಠ_ಠ.clutz.a.b.StaticHolder.AnEnum;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.a.b.StaticHolder {
+declare namespace ಠ_ಠ.clutz.a.b.StaticHolder {
   function aFunction ( ) : boolean ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'a.b.StaticHolder.aFunction'): typeof ಠ_ಠ.clutz_internal.a.b.StaticHolder.aFunction;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'a.b.StaticHolder.aFunction'): typeof ಠ_ಠ.clutz.a.b.StaticHolder.aFunction;
 }
 declare module 'goog:a.b.StaticHolder.aFunction' {
-  import alias = ಠ_ಠ.clutz_internal.a.b.StaticHolder.aFunction;
+  import alias = ಠ_ಠ.clutz.a.b.StaticHolder.aFunction;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/type_alias.d.ts
+++ b/src/test/java/com/google/javascript/clutz/type_alias.d.ts
@@ -1,8 +1,8 @@
-declare namespace ಠ_ಠ.clutz_internal.typedefs {
+declare namespace ಠ_ಠ.clutz.typedefs {
   type strOrFunc = string | ( ( ) => string ) ;
   type strToStr = (a : string ) => string ;
 }
 declare module 'goog:typedefs' {
-  import alias = ಠ_ಠ.clutz_internal.typedefs;
+  import alias = ಠ_ಠ.clutz.typedefs;
   export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/type_guard.d.ts
+++ b/src/test/java/com/google/javascript/clutz/type_guard.d.ts
@@ -1,11 +1,11 @@
-declare namespace ಠ_ಠ.clutz_internal.a {
+declare namespace ಠ_ಠ.clutz.a {
   function b (opt_precision ? : number ) : string ;
   function c (s : number ) : string ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'a'): typeof ಠ_ಠ.clutz_internal.a;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'a'): typeof ಠ_ಠ.clutz.a;
 }
 declare module 'goog:a' {
-  import alias = ಠ_ಠ.clutz_internal.a;
+  import alias = ಠ_ಠ.clutz.a;
   export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/types.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types.d.ts
@@ -1,4 +1,4 @@
-declare namespace ಠ_ಠ.clutz_internal.types {
+declare namespace ಠ_ಠ.clutz.types {
   var a : number ;
   var b : boolean ;
   var c : string ;
@@ -17,10 +17,10 @@ declare namespace ಠ_ಠ.clutz_internal.types {
   var j : { [ n: number ]: string } ;
   var recordType : { a : string , b : any } ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'types'): typeof ಠ_ಠ.clutz_internal.types;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'types'): typeof ಠ_ಠ.clutz.types;
 }
 declare module 'goog:types' {
-  import alias = ಠ_ಠ.clutz_internal.types;
+  import alias = ಠ_ಠ.clutz.types;
   export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/types_with_externs.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types_with_externs.d.ts
@@ -1,4 +1,4 @@
-declare namespace ಠ_ಠ.clutz_internal.typesWithExterns {
+declare namespace ಠ_ಠ.clutz.typesWithExterns {
   type ArrayLike = NodeList | IArguments | { length : number } ;
   class Error extends GlobalError {
   }
@@ -9,72 +9,72 @@ declare namespace ಠ_ಠ.clutz_internal.typesWithExterns {
   var c : NodeList | IArguments | { length : number } ;
   function elementMaybe ( ) : Element ;
   function id (x : NodeList | IArguments | { length : number } ) : NodeList | IArguments | { length : number } ;
-  var myScope : ಠ_ಠ.clutz_internal.angular.Scope ;
+  var myScope : ಠ_ಠ.clutz.angular.Scope ;
   function topLevelFunction ( ...a : any [] ) : any ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'typesWithExterns'): typeof ಠ_ಠ.clutz_internal.typesWithExterns;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'typesWithExterns'): typeof ಠ_ಠ.clutz.typesWithExterns;
 }
 declare module 'goog:typesWithExterns' {
-  import alias = ಠ_ಠ.clutz_internal.typesWithExterns;
+  import alias = ಠ_ಠ.clutz.typesWithExterns;
   export = alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.typesWithExterns {
+declare namespace ಠ_ಠ.clutz.typesWithExterns {
   class A {
     private noStructuralTyping_: any;
     constructor (n : number ) ;
     apply : number ;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'typesWithExterns.A'): typeof ಠ_ಠ.clutz_internal.typesWithExterns.A;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'typesWithExterns.A'): typeof ಠ_ಠ.clutz.typesWithExterns.A;
 }
 declare module 'goog:typesWithExterns.A' {
-  import alias = ಠ_ಠ.clutz_internal.typesWithExterns.A;
+  import alias = ಠ_ಠ.clutz.typesWithExterns.A;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.typesWithExterns {
-  class B extends ಠ_ಠ.clutz_internal.typesWithExterns.A {
+declare namespace ಠ_ಠ.clutz.typesWithExterns {
+  class B extends ಠ_ಠ.clutz.typesWithExterns.A {
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'typesWithExterns.B'): typeof ಠ_ಠ.clutz_internal.typesWithExterns.B;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'typesWithExterns.B'): typeof ಠ_ಠ.clutz.typesWithExterns.B;
 }
 declare module 'goog:typesWithExterns.B' {
-  import alias = ಠ_ಠ.clutz_internal.typesWithExterns.B;
+  import alias = ಠ_ಠ.clutz.typesWithExterns.B;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.typesWithExterns {
-  class C extends ಠ_ಠ.clutz_internal.typesWithExterns.A {
+declare namespace ಠ_ಠ.clutz.typesWithExterns {
+  class C extends ಠ_ಠ.clutz.typesWithExterns.A {
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'typesWithExterns.C'): typeof ಠ_ಠ.clutz_internal.typesWithExterns.C;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'typesWithExterns.C'): typeof ಠ_ಠ.clutz.typesWithExterns.C;
 }
 declare module 'goog:typesWithExterns.C' {
-  import alias = ಠ_ಠ.clutz_internal.typesWithExterns.C;
+  import alias = ಠ_ಠ.clutz.typesWithExterns.C;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz_internal.angular {
-  type $cacheFactory = (a : string , b ? : { capacity : number } ) => ಠ_ಠ.clutz_internal.angular.$cacheFactory.Cache < any > ;
+declare namespace ಠ_ಠ.clutz.angular {
+  type $cacheFactory = (a : string , b ? : { capacity : number } ) => ಠ_ಠ.clutz.angular.$cacheFactory.Cache < any > ;
   class $injector {
     private noStructuralTyping_: any;
   }
   class Scope {
     private noStructuralTyping_: any;
     $$phase : string ;
-    $apply (opt_exp ? : string | ( (a : ಠ_ಠ.clutz_internal.angular.Scope ) => any ) ) : any ;
-    $applyAsync (opt_exp ? : string | ( (a : ಠ_ಠ.clutz_internal.angular.Scope ) => any ) ) : any ;
+    $apply (opt_exp ? : string | ( (a : ಠ_ಠ.clutz.angular.Scope ) => any ) ) : any ;
+    $applyAsync (opt_exp ? : string | ( (a : ಠ_ಠ.clutz.angular.Scope ) => any ) ) : any ;
   }
-  function bootstrap (element : Element | HTMLDocument , opt_modules ? : ( string | ( ( ...a : any [] ) => any ) ) [] ) : ಠ_ಠ.clutz_internal.angular.$injector ;
+  function bootstrap (element : Element | HTMLDocument , opt_modules ? : ( string | ( ( ...a : any [] ) => any ) ) [] ) : ಠ_ಠ.clutz.angular.$injector ;
 }
-declare namespace ಠ_ಠ.clutz_internal.angular.$cacheFactory {
-  type get = (a : string ) => ಠ_ಠ.clutz_internal.angular.$cacheFactory.Cache < any > ;
+declare namespace ಠ_ಠ.clutz.angular.$cacheFactory {
+  type get = (a : string ) => ಠ_ಠ.clutz.angular.$cacheFactory.Cache < any > ;
 }
-declare namespace ಠ_ಠ.clutz_internal.angular.$cacheFactory {
+declare namespace ಠ_ಠ.clutz.angular.$cacheFactory {
   type Options = { capacity : number } ;
 }
-declare namespace ಠ_ಠ.clutz_internal.angular.$cacheFactory {
+declare namespace ಠ_ಠ.clutz.angular.$cacheFactory {
   class Cache < T > {
     private noStructuralTyping_: any;
     destroy ( ) : any ;
@@ -85,6 +85,6 @@ declare namespace ಠ_ಠ.clutz_internal.angular.$cacheFactory {
     removeAll ( ) : any ;
   }
 }
-declare namespace ಠ_ಠ.clutz_internal.angular.$cacheFactory.Cache {
+declare namespace ಠ_ಠ.clutz.angular.$cacheFactory.Cache {
   type Info = { id : string , options : { capacity : number } , size : number } ;
 }

--- a/src/test/java/com/google/javascript/clutz/undefined_provide.d.ts
+++ b/src/test/java/com/google/javascript/clutz/undefined_provide.d.ts
@@ -1,6 +1,6 @@
-declare namespace ಠ_ಠ.clutz_internal.undefined_provide {
+declare namespace ಠ_ಠ.clutz.undefined_provide {
 }
 declare module 'goog:undefined_provide' {
-  import alias = ಠ_ಠ.clutz_internal.undefined_provide;
+  import alias = ಠ_ಠ.clutz.undefined_provide;
   export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/union.d.ts
+++ b/src/test/java/com/google/javascript/clutz/union.d.ts
@@ -1,12 +1,12 @@
-declare namespace ಠ_ಠ.clutz_internal.union {
+declare namespace ಠ_ಠ.clutz.union {
   var fn : ( ( ) => string ) | ( ( ) => number ) [] ;
   var nullableUnion : Object | number ;
   var x : boolean | string ;
 }
-declare namespace ಠ_ಠ.clutz_internal.goog {
-  function require(name: 'union'): typeof ಠ_ಠ.clutz_internal.union;
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'union'): typeof ಠ_ಠ.clutz.union;
 }
 declare module 'goog:union' {
-  import alias = ಠ_ಠ.clutz_internal.union;
+  import alias = ಠ_ಠ.clutz.union;
   export = alias;
 }


### PR DESCRIPTION
Look-of-disapproval provides enough to show this is internal namespace.
Also the namespace shows up in inline IDE docs, so we need something
short.