### PR TITLE
Set input language to ES6

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -50,6 +50,8 @@ public class Options {
     options.setClosurePass(true);
     options.setCheckGlobalNamesLevel(CheckLevel.ERROR);
     options.setCheckGlobalThisLevel(CheckLevel.ERROR);
+    options.setLanguage(CompilerOptions.LanguageMode.ECMASCRIPT6);
+    options.setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT5);
     options.setCheckTypes(true);
     options.setInferTypes(true);
     options.setIdeMode(true); // So that we can query types after compilation.


### PR DESCRIPTION
This enables handling and understanding the broadest set of valid input JS.

Needs the setLanguageOut call because the compiler doesn't want to produce ES6.