### PR TITLE
feat: use ErrorFormat to generate nicer error messages.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -105,6 +105,7 @@ public class DeclarationGenerator {
         // Includes the message.
         e.printStackTrace(System.err);
       } else {
+        // Includes source snippets and colorized errors.
         System.err.println(e.getMessage());
       }
       System.exit(1);
@@ -163,7 +164,8 @@ public class DeclarationGenerator {
     });
 
     if (externs.isEmpty()) {
-      externs = opts.skipParseExterns ? Collections.<SourceFile>emptyList() : getDefaultExterns(opts);
+      externs =
+          opts.skipParseExterns ? Collections.<SourceFile>emptyList() : getDefaultExterns(opts);
     } else {
       Preconditions.checkArgument(!opts.skipParseExterns,
           "Cannot pass --skipParseExterns and --externs.");
@@ -177,13 +179,14 @@ public class DeclarationGenerator {
       if (missingTypes) {
         errors.add(0, JSError.make(CLUTZ_MISSING_TYPES));
       }
-      throw new DeclarationGeneratorException("Source code does not compile with JSCompiler",
-          errors);
+      throw new DeclarationGeneratorException(compiler,
+          "Source code does not compile with JSCompiler", errors);
     }
 
     String dts = produceDts(compiler, depgraph);
     if (!errors.isEmpty()) {
-      throw new DeclarationGeneratorException("Errors while generating definitions", errors);
+      throw new DeclarationGeneratorException(compiler, "Errors while generating definitions",
+          errors);
     }
     return dts;
   }

--- a/src/main/java/com/google/javascript/clutz/DeclarationGeneratorException.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGeneratorException.java
@@ -1,7 +1,12 @@
 package com.google.javascript.clutz;
 
+import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.collect.Iterables;
+import com.google.javascript.jscomp.ErrorFormat;
 import com.google.javascript.jscomp.JSError;
+import com.google.javascript.jscomp.MessageFormatter;
+import com.google.javascript.jscomp.SourceExcerptProvider;
 
 import java.util.List;
 
@@ -9,10 +14,20 @@ import java.util.List;
  * An exception used to communicate errors from {@link DeclarationGenerator#generateDeclarations()}.
  */
 public class DeclarationGeneratorException extends RuntimeException {
-  final List<JSError> errors;
+  public DeclarationGeneratorException(SourceExcerptProvider excerptProv, String message,
+      List<JSError> errors) {
+    super(message + "\n" + formatErrors(excerptProv, errors));
+  }
 
-  public DeclarationGeneratorException(String message, List<JSError> errors) {
-    super(message + "\n" + Joiner.on('\n').join(errors));
-    this.errors = errors;
+  private static String formatErrors(SourceExcerptProvider excerptProv, List<JSError> errors) {
+    final MessageFormatter formatter = ErrorFormat.MULTILINE.toFormatter(excerptProv, true);
+    String formattedErrors =
+        Joiner.on('\n').join(Iterables.transform(errors, new Function<JSError, String>() {
+          @Override
+          public String apply(JSError error) {
+            return formatter.formatError(error);
+          }
+        }));
+    return formattedErrors;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/ErrorHandlingTest.java
+++ b/src/test/java/com/google/javascript/clutz/ErrorHandlingTest.java
@@ -7,23 +7,34 @@ import org.junit.Test;
 public class ErrorHandlingTest {
   @Test
   public void testOverriddenIncompatibleStaticField() {
-    assertThatProgram("goog.provide('X');\n" +
-        "goog.provide('Y');\n"
-        + "/** @constructor */"
-        + "X = function() {};\n"
-        + "/** @type {string} */ X.f;\n"
-        + "/** @constructor @extends {X} */"
-        + "Y = function() {};\n"
-        + "/** @type {number} */ Y.f;\n")
-        .reportsDiagnosticsContaining(DeclarationGenerator.CLUTZ_OVERRIDDEN_STATIC_FIELD.key);
+    assertThatProgram(
+            "goog.provide('X');",
+            "goog.provide('Y');",
+            "/** @constructor */",
+            "X = function() {};",
+            "/** @type {string} */ X.f;",
+            "/** @constructor @extends {X} */",
+            "Y = function() {};",
+            "/** @type {number} */ Y.f;")
+        .reportsDiagnosticsContaining(
+            "statically declared field that does not match the type of a parent field");
   }
 
   @Test
   public void testMissingSymbolOrExtern() {
     assertThatProgram(
-            "goog.provide('foo.x');\n"
-            + "/** @param {some.Unknown} y */\n"
-            + "foo.x = function(y) {};\n")
-        .reportsDiagnosticsContaining(DeclarationGenerator.CLUTZ_MISSING_TYPES.key);
+            "goog.provide('foo.x');",
+            "/** @param {some.Unknown} y */",
+            "foo.x = function(y) {};")
+        .reportsDiagnosticsContaining("missing some types");
+  }
+
+  @Test
+  public void testReportsSourceSnippets() {
+    assertThatProgram(
+            "goog.provide('foo.x');",
+            "/** @param {some.Unknown} y */",
+            "foo.x = function(y) {};")
+        .reportsDiagnosticsContaining("foo.x = function");
   }
 }

--- a/src/test/java/com/google/javascript/clutz/ProgramSubject.java
+++ b/src/test/java/com/google/javascript/clutz/ProgramSubject.java
@@ -27,7 +27,8 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
   private static final SourceFile CLUTZ_GOOG_BASE =
       SourceFile.fromFile("src/test/java/com/google/javascript/clutz/base.js", UTF_8);
 
-  public static ProgramSubject assertThatProgram(String sourceText) {
+  public static ProgramSubject assertThatProgram(String... sourceLines) {
+    String sourceText = Joiner.on('\n').join(sourceLines);
     return assert_().about(ProgramSubject.FACTORY).that(new Program(sourceText));
   }
 
@@ -72,14 +73,14 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
     }
   }
 
-  public void reportsDiagnosticsContaining(String message) {
+  public void reportsDiagnosticsContaining(String expectedDiagnostics) {
     String unexpectedRes = null;
     try {
       unexpectedRes = parse();
-      failureStrategy.failComparing("expected errors, but got a successful result",
-          message, unexpectedRes);
+      failureStrategy.failComparing("expected diagnostics, but got a successful result",
+          expectedDiagnostics, unexpectedRes);
     } catch (DeclarationGeneratorException e) {
-      assertThat(Joiner.on('\n').join(e.errors)).contains(message);
+      assertThat(e.getMessage()).contains(expectedDiagnostics);
     }
   }
 


### PR DESCRIPTION
The new ones contain source snippets pointing at the incorrect sources,
and no longer have "(unknown)" placeholders for absent sources.
They also contain shell colour codes.

Fixes #162.