### PR TITLE
fix broken polymer externs output.

### DIFF
--- a/src/resources/third_party_externs.js
+++ b/src/resources/third_party_externs.js
@@ -87,3 +87,24 @@ angular.$cacheFactory.Cache.prototype.destroy = function() {};
  *   }}
  */
 angular.$cacheFactory.Cache.Info;
+
+/**
+ * @param {!{is: string}} descriptor
+ */
+var Polymer = function(descriptor) {};
+
+/**
+ * @constructor
+ */
+var PolymerDomApi = function() {};
+
+/**
+ * @constructor
+ */
+var PolymerEventApi = function() {};
+
+/**
+ * @param {?Node|?Event} nodeOrEvent
+ * @return {!PolymerDomApi|!PolymerEventApi}
+ */
+Polymer.dom = function(nodeOrEvent) {};

--- a/src/test/java/com/google/javascript/clutz/types_with_externs.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types_with_externs.d.ts
@@ -88,3 +88,19 @@ declare namespace ಠ_ಠ.clutz.angular.$cacheFactory {
 declare namespace ಠ_ಠ.clutz.angular.$cacheFactory.Cache {
   type Info = { id : string , options : { capacity : number } , size : number } ;
 }
+declare namespace ಠ_ಠ.clutz {
+  function Polymer (descriptor : { is : string } ) : any ;
+}
+declare namespace ಠ_ಠ.clutz {
+  class PolymerDomApi {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz {
+  class PolymerEventApi {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.Polymer {
+  function dom (nodeOrEvent : Node | Event ) : PolymerDomApi | PolymerEventApi ;
+}


### PR DESCRIPTION
Changed the extern strategy to go over all symbols and emit ones that
are not covered by the preceeding namespace.

Some tricky edge cases with typedefs acting as namespaces.