### PR TITLE
support nested namespaces in externs.

### DIFF
--- a/src/resources/third_party_externs.js
+++ b/src/resources/third_party_externs.js
@@ -1,110 +1,109 @@
 /**
  * @const
  */
-var angular = {};
+var namespace = {};
 
 /** @constructor */
-angular.Scope = function() {};
+namespace.Foo = function() {};
 
 /** @type {string} */
-angular.Scope.prototype.$$phase;
+namespace.Foo.prototype.member;
 
 /**
- * @param {(string|function(!angular.Scope))=} opt_exp
- * @return {*}
+ * @param {function(!namespace.Foo)=} opt_exp
  */
-angular.Scope.prototype.$apply = function(opt_exp) {};
+namespace.Foo.prototype.method = function(opt_exp) {};
 
 /**
- * @param {(string|function(!angular.Scope))=} opt_exp
+ * @param {Element|HTMLDocument} arg1
+ * @param {Array.<string|Function>=} opt_arg2
  */
-angular.Scope.prototype.$applyAsync = function(opt_exp) {};
+namespace.bootstrap = function(arg1, opt_arg2) {};
 
-/**
- * @param {Element|HTMLDocument} element
- * @param {Array.<string|Function>=} opt_modules
- * @return {!angular.$injector}
- */
-angular.bootstrap = function(element, opt_modules) {};
 
-/**
- * @constructor
- */
-angular.$injector = function() {};
-
-// TODO(rado): bring the whole angular externs instead of chunks.
+// TODO(rado): add integration tests with angular and polymer externs.
 /**
  * @typedef {
- *   function(string, angular.$cacheFactory.Options=):
- *       !angular.$cacheFactory.Cache}
+ *   function(string, namespace.atypedef.Options=):
+ *       !namespace.atypedef.Cache}
  */
-angular.$cacheFactory;
+namespace.atypedef;
 
 /**
- * @typedef {function(string): ?angular.$cacheFactory.Cache}
+ * @typedef {function(string): ?namespace.atypedef.Cache}
  */
-angular.$cacheFactory.get;
+namespace.atypedef.get;
 
 /** @typedef {{capacity: (number|undefined)}} */
-angular.$cacheFactory.Options;
+namespace.atypedef.Options;
 
 /**
  * @template T
  * @constructor
  */
-angular.$cacheFactory.Cache = function() {};
+namespace.atypedef.Cache = function() {};
 
 /**
- * @return {!angular.$cacheFactory.Cache.Info}
+ * @return {!namespace.atypedef.Cache.Info}
  */
-angular.$cacheFactory.Cache.prototype.info = function() {};
+namespace.atypedef.Cache.prototype.info = function() {};
 
 /**
  * @param {string} key
  * @param {T} value
  */
-angular.$cacheFactory.Cache.prototype.put = function(key, value) {};
+namespace.atypedef.Cache.prototype.put = function(key, value) {};
 
 /**
  * @param {string} key
  * @return {T}
  */
-angular.$cacheFactory.Cache.prototype.get = function(key) {};
+namespace.atypedef.Cache.prototype.get = function(key) {};
 
 /**
  * @param {string} key
  */
-angular.$cacheFactory.Cache.prototype.remove = function(key) {};
+namespace.atypedef.Cache.prototype.remove = function(key) {};
 
-angular.$cacheFactory.Cache.prototype.removeAll = function() {};
-angular.$cacheFactory.Cache.prototype.destroy = function() {};
+namespace.atypedef.Cache.prototype.removeAll = function() {};
+namespace.atypedef.Cache.prototype.destroy = function() {};
 
 /**
  * @typedef {{
  *   id: string,
  *   size: number,
- *   options: angular.$cacheFactory.Options
+ *   options: namespace.atypedef.Options
  *   }}
  */
-angular.$cacheFactory.Cache.Info;
+namespace.atypedef.Cache.Info;
+
+/**
+ * @type {Object}
+ */
+namespace.subNamespace = {};
+
+/**
+ * @type {string}
+ */
+namespace.subNamespace.fieldA = '';
+
+/**
+ * @type {number}
+ */
+namespace.subNamespace.fieldB = 0;
 
 /**
  * @param {!{is: string}} descriptor
  */
-var Polymer = function(descriptor) {};
+var FunctionNamespace = function(descriptor) {};
 
 /**
  * @constructor
  */
-var PolymerDomApi = function() {};
-
-/**
- * @constructor
- */
-var PolymerEventApi = function() {};
+var FunctionNamespaceHelperClass = function() {};
 
 /**
  * @param {?Node|?Event} nodeOrEvent
- * @return {!PolymerDomApi|!PolymerEventApi}
+ * @return {!FunctionNamespaceHelperClass}
  */
-Polymer.dom = function(nodeOrEvent) {};
+FunctionNamespace.dom = function(nodeOrEvent) {};

--- a/src/test/java/com/google/javascript/clutz/types_with_3p_externs.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types_with_3p_externs.d.ts
@@ -9,7 +9,7 @@ declare namespace ಠ_ಠ.clutz.typesWithExterns {
   var c : NodeList | IArguments | { length : number } ;
   function elementMaybe ( ) : Element ;
   function id (x : NodeList | IArguments | { length : number } ) : NodeList | IArguments | { length : number } ;
-  var myScope : ಠ_ಠ.clutz.angular.Scope ;
+  var myScope : ಠ_ಠ.clutz.namespace.Foo ;
   function topLevelFunction ( ...a : any [] ) : any ;
 }
 declare namespace ಠ_ಠ.clutz.goog {
@@ -55,26 +55,22 @@ declare module 'goog:typesWithExterns.C' {
   import alias = ಠ_ಠ.clutz.typesWithExterns.C;
   export default alias;
 }
-declare namespace ಠ_ಠ.clutz.angular {
-  type $cacheFactory = (a : string , b ? : { capacity : number } ) => ಠ_ಠ.clutz.angular.$cacheFactory.Cache < any > ;
-  class $injector {
+declare namespace ಠ_ಠ.clutz.namespace {
+  class Foo {
     private noStructuralTyping_: any;
+    member : string ;
+    method (opt_exp ? : (a : ಠ_ಠ.clutz.namespace.Foo ) => any ) : any ;
   }
-  class Scope {
-    private noStructuralTyping_: any;
-    $$phase : string ;
-    $apply (opt_exp ? : string | ( (a : ಠ_ಠ.clutz.angular.Scope ) => any ) ) : any ;
-    $applyAsync (opt_exp ? : string | ( (a : ಠ_ಠ.clutz.angular.Scope ) => any ) ) : any ;
-  }
-  function bootstrap (element : Element | HTMLDocument , opt_modules ? : ( string | ( ( ...a : any [] ) => any ) ) [] ) : ಠ_ಠ.clutz.angular.$injector ;
+  type atypedef = (a : string , b ? : { capacity : number } ) => ಠ_ಠ.clutz.namespace.atypedef.Cache < any > ;
+  function bootstrap (arg1 : Element | HTMLDocument , opt_arg2 ? : ( string | ( ( ...a : any [] ) => any ) ) [] ) : any ;
 }
-declare namespace ಠ_ಠ.clutz.angular.$cacheFactory {
-  type get = (a : string ) => ಠ_ಠ.clutz.angular.$cacheFactory.Cache < any > ;
+declare namespace ಠ_ಠ.clutz.namespace.atypedef {
+  type get = (a : string ) => ಠ_ಠ.clutz.namespace.atypedef.Cache < any > ;
 }
-declare namespace ಠ_ಠ.clutz.angular.$cacheFactory {
+declare namespace ಠ_ಠ.clutz.namespace.atypedef {
   type Options = { capacity : number } ;
 }
-declare namespace ಠ_ಠ.clutz.angular.$cacheFactory {
+declare namespace ಠ_ಠ.clutz.namespace.atypedef {
   class Cache < T > {
     private noStructuralTyping_: any;
     destroy ( ) : any ;
@@ -85,22 +81,23 @@ declare namespace ಠ_ಠ.clutz.angular.$cacheFactory {
     removeAll ( ) : any ;
   }
 }
-declare namespace ಠ_ಠ.clutz.angular.$cacheFactory.Cache {
+declare namespace ಠ_ಠ.clutz.namespace.atypedef.Cache {
   type Info = { id : string , options : { capacity : number } , size : number } ;
 }
-declare namespace ಠ_ಠ.clutz {
-  function Polymer (descriptor : { is : string } ) : any ;
+declare namespace ಠ_ಠ.clutz.namespace.subNamespace {
+  var fieldA : string ;
+}
+declare namespace ಠ_ಠ.clutz.namespace.subNamespace {
+  var fieldB : number ;
 }
 declare namespace ಠ_ಠ.clutz {
-  class PolymerDomApi {
+  function FunctionNamespace (descriptor : { is : string } ) : any ;
+}
+declare namespace ಠ_ಠ.clutz {
+  class FunctionNamespaceHelperClass {
     private noStructuralTyping_: any;
   }
 }
-declare namespace ಠ_ಠ.clutz {
-  class PolymerEventApi {
-    private noStructuralTyping_: any;
-  }
-}
-declare namespace ಠ_ಠ.clutz.Polymer {
-  function dom (nodeOrEvent : Node | Event ) : PolymerDomApi | PolymerEventApi ;
+declare namespace ಠ_ಠ.clutz.FunctionNamespace {
+  function dom (nodeOrEvent : Node | Event ) : FunctionNamespaceHelperClass ;
 }

--- a/src/test/java/com/google/javascript/clutz/types_with_3p_externs.js
+++ b/src/test/java/com/google/javascript/clutz/types_with_3p_externs.js
@@ -108,6 +108,6 @@ typesWithExterns.Error = function() {};
 
 
 /**
- * @type {angular.Scope}
+ * @type {namespace.Foo}
  */
 typesWithExterns.myScope = null;


### PR DESCRIPTION
Closure APIs do not provide a method to check for namespaces, so we use
the presence of Object type as a heuristic.