### PR TITLE
feat: handle nested enum type name collisions.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch_nested_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch_nested_type.d.ts
@@ -1,0 +1,36 @@
+declare namespace ಠ_ಠ.clutz.sim_nested {
+  class Child extends ಠ_ಠ.clutz.sim_nested.Parent {
+  }
+}
+declare namespace ಠ_ಠ.clutz.sim_nested.Child {
+  type Nested = number ;
+  var Nested : {
+    B : Nested ,
+  } &
+  (/* Incompatible inherited static property */ typeof ಠ_ಠ.clutz.sim_nested.Parent.Nested );
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'sim_nested.Child'): typeof ಠ_ಠ.clutz.sim_nested.Child;
+}
+declare module 'goog:sim_nested.Child' {
+  import alias = ಠ_ಠ.clutz.sim_nested.Child;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.sim_nested {
+  class Parent {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.sim_nested.Parent {
+  type Nested = string ;
+  var Nested : {
+    A : Nested ,
+  };
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'sim_nested.Parent'): typeof ಠ_ಠ.clutz.sim_nested.Parent;
+}
+declare module 'goog:sim_nested.Parent' {
+  import alias = ಠ_ಠ.clutz.sim_nested.Parent;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch_nested_type.js
+++ b/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch_nested_type.js
@@ -1,0 +1,12 @@
+goog.provide('sim_nested.Parent');
+goog.provide('sim_nested.Child');
+
+/** @constructor */
+sim_nested.Parent = function() {};
+/** @enum {string} */
+sim_nested.Parent.Nested = {A: 'a'};
+
+/** @constructor @extends {sim_nested.Parent} */
+sim_nested.Child = function() {};
+/** @enum {number} */
+sim_nested.Child.Nested = {B: 12};


### PR DESCRIPTION
Nested types need to correctly inherit the "class static side" in TS.
Closure code however commonly re-defines incompatible enums in
subclasses, leading to TS side errors.

This change only fixes the problem for enums. It's unclear if we can
fix it for inherited `class`es, as that'd mean overloading a class ctor
function. However it turns out enums are the only common issue in the
actual, real world Closure code base.

Semi-fixes #154.