### PR TITLE
feat: support untyped provides.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -228,7 +228,11 @@ public class DeclarationGenerator {
     for (String provide : provides) {
       TypedVar symbol = topScope.getOwnSlot(provide);
       if (symbol == null) {
-        // Sometimes goog.provide statements are used as pure markers for dependency management.
+        // Sometimes goog.provide statements are used as pure markers for dependency management, or
+        // the defined provides do not get a symbol because they don't have a proper type.
+        // Emit an empty namespace and declare an empty module providing that namespace.
+        emitNamespaceBegin(provide);
+        emitNamespaceEnd();
         declareModule(provide, true);
         continue;
       }

--- a/src/test/java/com/google/javascript/clutz/untyped_provide.d.ts
+++ b/src/test/java/com/google/javascript/clutz/untyped_provide.d.ts
@@ -1,0 +1,6 @@
+declare namespace ಠ_ಠ.clutz.untyped.Provide {
+}
+declare module 'goog:untyped.Provide' {
+  import alias = ಠ_ಠ.clutz.untyped.Provide;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/untyped_provide.js
+++ b/src/test/java/com/google/javascript/clutz/untyped_provide.js
@@ -1,0 +1,10 @@
+goog.provide('untyped.Provide');
+// Surprisingly this behaves differently from undefined_provide.js, there's no symbol at all.
+
+/**
+ * Has no type, but interesting structure.
+ */
+untyped.Provide = {
+  SOME_FIELD: 'x',
+  SOME_OTHER_FIELD: 'y'
+};


### PR DESCRIPTION
Surprisingly, these behave differently from undefined provides, in that there
is no symbol at all for the provide (even though it is assigned!). Just emit
an empty namespace.

Fixes #172 for the immediate issue, but still would need to export the actual type shape at some point.