### PR TITLE
feat: simplify & fix interface walking.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/interface.d.ts
+++ b/src/test/java/com/google/javascript/clutz/interface.d.ts
@@ -4,7 +4,10 @@ declare namespace ಠ_ಠ.clutz {
   }
 }
 declare namespace ಠ_ಠ.clutz.interface_exp {
-  var staticMethod : ( ) => number ;
+  class SomeClazz {
+    private noStructuralTyping_: any;
+  }
+  function staticMethod ( ) : number ;
   var staticProp : number ;
 }
 declare module 'goog:interface_exp' {

--- a/src/test/java/com/google/javascript/clutz/interface.js
+++ b/src/test/java/com/google/javascript/clutz/interface.js
@@ -18,3 +18,6 @@ interface_exp.SomeEnum = {
   A: 1,
   B: 2
 };
+
+/** @constructor */
+interface_exp.SomeClazz = function() {};


### PR DESCRIPTION
Interfaces containing static properties can simply be treated like
namespaces with no default export (`isDefault == false`).

Fixes #179.