### PR TITLE
do not throw on out-of-order sources.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -58,6 +58,9 @@ public class Options {
     // Report duplicate definitions, e.g. for accidentally duplicated externs.
     options.setWarningLevel(DiagnosticGroups.DUPLICATE_VARS, CheckLevel.ERROR);
 
+    // Late Provides are errors by default, but they do not prevent clutz from transpiling.
+    options.setWarningLevel("lateProvide", CheckLevel.OFF);
+
     options.setLanguage(CompilerOptions.LanguageMode.ECMASCRIPT6);
     options.setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT5);
     options.setCheckTypes(true);

--- a/src/test/java/com/google/javascript/clutz/MultiFileTest.java
+++ b/src/test/java/com/google/javascript/clutz/MultiFileTest.java
@@ -38,6 +38,16 @@ public class MultiFileTest {
         .generatesDeclarations(expected);
   }
 
+  @Test
+  public void shouldWorkWithOutOfOrderProvides() throws Exception {
+    String expected = DeclarationGeneratorTests.getTestFileText(input("index.d.ts"));
+    assertThatProgram(
+        ImmutableList.of(input("index.js"), input("dep.js")),
+        Collections.<File>emptyList())
+        .generatesDeclarations(expected);
+  }
+
+
   private File input(String filename) {
     Path testDir = FileSystems.getDefault().getPath("src", "test", "java");
     String packageName = ProgramSubject.class.getPackage().getName();

--- a/src/test/java/com/google/javascript/clutz/ProgramSubject.java
+++ b/src/test/java/com/google/javascript/clutz/ProgramSubject.java
@@ -81,7 +81,7 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
 
   void generatesDeclarations(String expected) {
     String[] parseResult = parse();
-    assertThat(parseResult[1].isEmpty());
+    assertThat(parseResult[1]).isEmpty();
     String actual = parseResult[0];
     String stripped =
         DeclarationGeneratorTests.GOLDEN_FILE_COMMENTS_REGEXP.matcher(actual).replaceAll("");

--- a/src/test/java/com/google/javascript/clutz/abstract_method.js
+++ b/src/test/java/com/google/javascript/clutz/abstract_method.js
@@ -11,7 +11,7 @@ goog.provide('abstract_method.Child');
  * @throws {Error} when invoked to indicate the method should be overridden.
  */
 goog.abstractMethod = function() {
-  throw Error('unimplemented abstract method');
+  // throws
 };
 
 /** @interface */
@@ -42,4 +42,4 @@ abstract_method.Child = function() {};
 /**
  * @override
  */
-abstract_method.Child.prototype.bar = function(a) { return String(a) };
+abstract_method.Child.prototype.bar = function(a) { return a.toString() };

--- a/src/test/java/com/google/javascript/clutz/shouldWorkWithOutOfOrderProvides/dep.js
+++ b/src/test/java/com/google/javascript/clutz/shouldWorkWithOutOfOrderProvides/dep.js
@@ -1,0 +1,6 @@
+goog.provide('dep.D');
+
+/**
+ * @constructor
+ */
+dep.D = function() {};

--- a/src/test/java/com/google/javascript/clutz/shouldWorkWithOutOfOrderProvides/index.d.ts
+++ b/src/test/java/com/google/javascript/clutz/shouldWorkWithOutOfOrderProvides/index.d.ts
@@ -1,0 +1,25 @@
+declare namespace ಠ_ಠ.clutz.dep {
+  class D {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'dep.D'): typeof ಠ_ಠ.clutz.dep.D;
+}
+declare module 'goog:dep.D' {
+  import alias = ಠ_ಠ.clutz.dep.D;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.main {
+  class A {
+    private noStructuralTyping_: any;
+    fn (a : ಠ_ಠ.clutz.dep.D ) : void ;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'main.A'): typeof ಠ_ಠ.clutz.main.A;
+}
+declare module 'goog:main.A' {
+  import alias = ಠ_ಠ.clutz.main.A;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/shouldWorkWithOutOfOrderProvides/index.js
+++ b/src/test/java/com/google/javascript/clutz/shouldWorkWithOutOfOrderProvides/index.js
@@ -1,0 +1,11 @@
+goog.provide('main.A');
+goog.require('dep.D');
+
+/**
+ * @constructor
+ */
+main.A = function() {
+};
+
+/** @param {dep.D} a*/
+main.A.prototype.fn = function(a) {};


### PR DESCRIPTION
JS compiler complains about late provides, but still emits correct type
information, so we turn off that check.

Fixes bug in error-checking on all unit tests (wrong assertion), and a
few js code changes that were necessitated by that.