### PR TITLE
Emit class A (statics) and class A_Instance per closure class A.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/ClutzErrorManagerTest.java
+++ b/src/test/java/com/google/javascript/clutz/ClutzErrorManagerTest.java
@@ -5,20 +5,6 @@ import static com.google.javascript.clutz.ProgramSubject.assertThatProgram;
 import org.junit.Test;
 
 public class ClutzErrorManagerTest {
-  @Test
-  public void testOverriddenIncompatibleStaticField() {
-    assertThatProgram(
-            "goog.provide('X');",
-            "goog.provide('Y');",
-            "/** @constructor */",
-            "X = function() {};",
-            "/** @type {string} */ X.f;",
-            "/** @constructor @extends {X} */",
-            "Y = function() {};",
-            "/** @type {number} */ Y.f;")
-        .diagnosticStream()
-        .containsMatch("ERROR.*statically declared field that does not match the type of a parent");
-  }
 
   @Test
   public void testMissingSymbolOrExtern() {

--- a/src/test/java/com/google/javascript/clutz/abstract_method.d.ts
+++ b/src/test/java/com/google/javascript/clutz/abstract_method.d.ts
@@ -1,5 +1,7 @@
 declare namespace ಠ_ಠ.clutz.abstract_method {
-  class Child extends ಠ_ಠ.clutz.abstract_method.Clazz {
+  class Child extends Child_Instance {
+  }
+  class Child_Instance extends ಠ_ಠ.clutz.abstract_method.Clazz_Instance {
     bar (a : number ) : string ;
   }
 }
@@ -11,11 +13,10 @@ declare module 'goog:abstract_method.Child' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.abstract_method {
-  class Clazz implements ಠ_ಠ.clutz.abstract_method.Interface {
+  class Clazz extends Clazz_Instance {
+  }
+  class Clazz_Instance implements ಠ_ಠ.clutz.abstract_method.Interface {
     private noStructuralTyping_: any;
-    //!! In Closure, abstract methods are just methods that have type Function, which corresponds
-    //!! to a TS method that takes any arguments and returns any. Luckily this is compatible for
-    //!! both the super and the subtype.
     bar ( ...a : any [] ) : any ;
     foo ( ) : string ;
   }

--- a/src/test/java/com/google/javascript/clutz/ctor_func.d.ts
+++ b/src/test/java/com/google/javascript/clutz/ctor_func.d.ts
@@ -1,5 +1,7 @@
 declare namespace ಠ_ಠ.clutz.ctor_func {
-  class Ctor < T > {
+  class Ctor < T > extends Ctor_Instance < T > {
+  }
+  class Ctor_Instance < T > {
     private noStructuralTyping_: any;
     constructor (a : string , b : number ) ;
   }

--- a/src/test/java/com/google/javascript/clutz/dict.d.ts
+++ b/src/test/java/com/google/javascript/clutz/dict.d.ts
@@ -1,10 +1,14 @@
 declare namespace ಠ_ಠ.clutz.dict {
-  class ClassWithDottedProperties {
+  class ClassWithDottedProperties extends ClassWithDottedProperties_Instance {
+  }
+  class ClassWithDottedProperties_Instance {
     private noStructuralTyping_: any;
     [key: string]: any;
     foo : number ;
   }
-  class DictClass {
+  class DictClass extends DictClass_Instance {
+  }
+  class DictClass_Instance {
     private noStructuralTyping_: any;
     constructor (n : any ) ;
     [key: string]: any;

--- a/src/test/java/com/google/javascript/clutz/empty_type_args.d.ts
+++ b/src/test/java/com/google/javascript/clutz/empty_type_args.d.ts
@@ -7,7 +7,9 @@ declare module 'goog:empty_type_args.ITemplated' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.empty_type_args {
-  class NoMoreTemplateArgs implements ಠ_ಠ.clutz.empty_type_args.ITemplated < number > {
+  class NoMoreTemplateArgs extends NoMoreTemplateArgs_Instance {
+  }
+  class NoMoreTemplateArgs_Instance implements ಠ_ಠ.clutz.empty_type_args.ITemplated < number > {
     private noStructuralTyping_: any;
   }
 }
@@ -19,7 +21,9 @@ declare module 'goog:empty_type_args.NoMoreTemplateArgs' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.empty_type_args {
-  class X {
+  class X extends X_Instance {
+  }
+  class X_Instance {
     private noStructuralTyping_: any;
     constructor (a : ಠ_ಠ.clutz.empty_type_args.NoMoreTemplateArgs ) ;
   }

--- a/src/test/java/com/google/javascript/clutz/forward_declare.d.ts
+++ b/src/test/java/com/google/javascript/clutz/forward_declare.d.ts
@@ -1,5 +1,7 @@
 declare namespace ಠ_ಠ.clutz.forward {
-  class A {
+  class A extends A_Instance {
+  }
+  class A_Instance {
     private noStructuralTyping_: any;
     //!! forward.D may or may not be part of the compilation unit.
     //!! If it is part of it might be a generic at which point TS will error

--- a/src/test/java/com/google/javascript/clutz/generics.d.ts
+++ b/src/test/java/com/google/javascript/clutz/generics.d.ts
@@ -1,9 +1,13 @@
 declare namespace ಠ_ಠ.clutz.generics {
   interface ExtendGenericInterface < TYPE > extends ಠ_ಠ.clutz.generics.GenericInterface < TYPE > {
   }
-  class ExtendsGenericClass < TYPE > extends ಠ_ಠ.clutz.generics.Foo < TYPE , number > {
+  class ExtendsGenericClass < TYPE > extends ExtendsGenericClass_Instance < TYPE > {
   }
-  class Foo < T , U > {
+  class ExtendsGenericClass_Instance < TYPE > extends ಠ_ಠ.clutz.generics.Foo_Instance < TYPE , number > {
+  }
+  class Foo < T , U > extends Foo_Instance < T , U > {
+  }
+  class Foo_Instance < T , U > {
     private noStructuralTyping_: any;
     constructor (a : number ) ;
     get ( ) : T ;
@@ -12,7 +16,9 @@ declare namespace ಠ_ಠ.clutz.generics {
   }
   interface GenericInterface < TYPE > {
   }
-  class ImplementsGenericInterface < TYPE > implements ಠ_ಠ.clutz.generics.GenericInterface < TYPE > {
+  class ImplementsGenericInterface < TYPE > extends ImplementsGenericInterface_Instance < TYPE > {
+  }
+  class ImplementsGenericInterface_Instance < TYPE > implements ಠ_ಠ.clutz.generics.GenericInterface < TYPE > {
     private noStructuralTyping_: any;
   }
   var arrayMissingTypeParam : any [] ;

--- a/src/test/java/com/google/javascript/clutz/goog_require.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_require.d.ts
@@ -1,5 +1,7 @@
 declare namespace ಠ_ಠ.clutz.foo {
-  class SimpleClass {
+  class SimpleClass extends SimpleClass_Instance {
+  }
+  class SimpleClass_Instance {
     private noStructuralTyping_: any;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/inner_typedef.d.ts
+++ b/src/test/java/com/google/javascript/clutz/inner_typedef.d.ts
@@ -1,5 +1,7 @@
 declare namespace ಠ_ಠ.clutz.innerTypeDef {
-  class Foo {
+  class Foo extends Foo_Instance {
+  }
+  class Foo_Instance {
     private noStructuralTyping_: any;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/interface.d.ts
+++ b/src/test/java/com/google/javascript/clutz/interface.d.ts
@@ -4,7 +4,9 @@ declare namespace ಠ_ಠ.clutz {
   }
 }
 declare namespace ಠ_ಠ.clutz.interface_exp {
-  class SomeClazz {
+  class SomeClazz extends SomeClazz_Instance {
+  }
+  class SomeClazz_Instance {
     private noStructuralTyping_: any;
   }
   function staticMethod ( ) : number ;

--- a/src/test/java/com/google/javascript/clutz/jsdoc.d.ts
+++ b/src/test/java/com/google/javascript/clutz/jsdoc.d.ts
@@ -4,7 +4,9 @@ declare namespace ಠ_ಠ.clutz.x {
    *
    * Across multiple paragraphs.
    */
-  class Y {
+  class Y extends Y_Instance {
+  }
+  class Y_Instance {
     private noStructuralTyping_: any;
     /**
      * Docs on a ctor.

--- a/src/test/java/com/google/javascript/clutz/lends.d.ts
+++ b/src/test/java/com/google/javascript/clutz/lends.d.ts
@@ -5,11 +5,13 @@ declare module 'goog:lends' {
   export = alias;
 }
 declare namespace ಠ_ಠ.clutz.lends {
-  class A {
+  class A extends A_Instance {
+    static b : number ;
+  }
+  class A_Instance {
     private noStructuralTyping_: any;
     a : string ;
     c : boolean ;
-    static b : number ;
   }
 }
 declare namespace ಠ_ಠ.clutz.goog {

--- a/src/test/java/com/google/javascript/clutz/multi_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/multi_class.d.ts
@@ -1,16 +1,24 @@
 declare namespace ಠ_ಠ.clutz.multi_class {
-  class A {
+  class A extends A_Instance {
+  }
+  class A_Instance {
     private noStructuralTyping_: any;
     constructor (n : number ) ;
     a : number ;
   }
-  class B extends ಠ_ಠ.clutz.multi_class.A implements ಠ_ಠ.clutz.multi_class.I , ಠ_ಠ.clutz.multi_class.I2 {
+  class B extends B_Instance {
+  }
+  class B_Instance extends ಠ_ಠ.clutz.multi_class.A_Instance implements ಠ_ಠ.clutz.multi_class.I , ಠ_ಠ.clutz.multi_class.I2 {
     b : number ;
     noop ( ) : void ;
   }
-  class C extends ಠ_ಠ.clutz.multi_class.B {
+  class C extends C_Instance {
   }
-  class D implements ಠ_ಠ.clutz.multi_class.I {
+  class C_Instance extends ಠ_ಠ.clutz.multi_class.B_Instance {
+  }
+  class D extends D_Instance {
+  }
+  class D_Instance implements ಠ_ಠ.clutz.multi_class.I {
     private noStructuralTyping_: any;
   }
   interface I {

--- a/src/test/java/com/google/javascript/clutz/multi_provides.d.ts
+++ b/src/test/java/com/google/javascript/clutz/multi_provides.d.ts
@@ -19,7 +19,9 @@ declare module 'goog:multi_provides.a.b.c' {
   export = alias;
 }
 declare namespace ಠ_ಠ.clutz.multi_provides.a.b.c {
-  class Two {
+  class Two extends Two_Instance {
+  }
+  class Two_Instance {
     private noStructuralTyping_: any;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/privates.d.ts
+++ b/src/test/java/com/google/javascript/clutz/privates.d.ts
@@ -1,5 +1,7 @@
 declare namespace ಠ_ಠ.clutz.priv {
-  class PublicClass {
+  class PublicClass extends PublicClass_Instance {
+  }
+  class PublicClass_Instance {
     private noStructuralTyping_: any;
     publicField : number ;
   }
@@ -12,7 +14,9 @@ declare module 'goog:priv' {
   export = alias;
 }
 declare namespace ಠ_ಠ.clutz.priv2 {
-  class PublicClass {
+  class PublicClass extends PublicClass_Instance {
+  }
+  class PublicClass_Instance {
     private noStructuralTyping_: any;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/provide_instance.d.ts
+++ b/src/test/java/com/google/javascript/clutz/provide_instance.d.ts
@@ -1,5 +1,7 @@
 declare namespace ಠ_ಠ.clutz.provides {
-  class C {
+  class C extends C_Instance {
+  }
+  class C_Instance {
     private noStructuralTyping_: any;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
@@ -1,16 +1,20 @@
 declare namespace ಠ_ಠ.clutz.foo.bar {
-  class Baz {
+  class Baz extends Baz_Instance {
+    static FUNCTION_PROP_ ( ...a : any [] ) : any ;
+    static staticMethod (a : string ) : number ;
+  }
+  class Baz_Instance {
     private noStructuralTyping_: any;
     field : string ;
     avalue : number ;
     equals (b : ಠ_ಠ.clutz.foo.bar.Baz.NestedClass ) : boolean ;
     method (a : string ) : number ;
-    static FUNCTION_PROP_ ( ...a : any [] ) : any ;
-    static staticMethod (a : string ) : number ;
   }
 }
 declare namespace ಠ_ಠ.clutz.foo.bar.Baz {
-  class NestedClass {
+  class NestedClass extends NestedClass_Instance {
+  }
+  class NestedClass_Instance {
     private noStructuralTyping_: any;
   }
   type NestedEnum = number ;

--- a/src/test/java/com/google/javascript/clutz/refer_from_default_ns.d.ts
+++ b/src/test/java/com/google/javascript/clutz/refer_from_default_ns.d.ts
@@ -9,7 +9,9 @@ declare module 'goog:fn' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.fn {
-  class String {
+  class String extends String_Instance {
+  }
+  class String_Instance {
     private noStructuralTyping_: any;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/shouldPruneProvidesFromNonrootFile/require.d.ts
+++ b/src/test/java/com/google/javascript/clutz/shouldPruneProvidesFromNonrootFile/require.d.ts
@@ -1,6 +1,8 @@
 //!! a.b.ShouldNotAppear must be absent here, it is provide'd in a non-root
 declare namespace ಠ_ಠ.clutz.a.b {
-  class Thing {
+  class Thing extends Thing_Instance {
+  }
+  class Thing_Instance {
     private noStructuralTyping_: any;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/shouldResolveNamedTypes/index.d.ts
+++ b/src/test/java/com/google/javascript/clutz/shouldResolveNamedTypes/index.d.ts
@@ -1,5 +1,7 @@
 declare namespace ಠ_ಠ.clutz.namedType {
-  class A < U > {
+  class A < U > extends A_Instance < U > {
+  }
+  class A_Instance < U > {
     private noStructuralTyping_: any;
     fn (a : ಠ_ಠ.clutz.namedType.D < any > ) : any ;
   }
@@ -12,7 +14,9 @@ declare module 'goog:namedType.A' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.namedType {
-  class D < T > {
+  class D < T > extends D_Instance < T > {
+  }
+  class D_Instance < T > {
     private noStructuralTyping_: any;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/shouldWorkWithOutOfOrderProvides/index.d.ts
+++ b/src/test/java/com/google/javascript/clutz/shouldWorkWithOutOfOrderProvides/index.d.ts
@@ -1,5 +1,7 @@
 declare namespace ಠ_ಠ.clutz.dep {
-  class D {
+  class D extends D_Instance {
+  }
+  class D_Instance {
     private noStructuralTyping_: any;
   }
 }
@@ -11,7 +13,9 @@ declare module 'goog:dep.D' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.main {
-  class A {
+  class A extends A_Instance {
+  }
+  class A_Instance {
     private noStructuralTyping_: any;
     fn (a : ಠ_ಠ.clutz.dep.D ) : void ;
   }

--- a/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch.d.ts
@@ -1,11 +1,11 @@
 declare namespace ಠ_ಠ.clutz.static_inherit {
-  class Child extends ಠ_ಠ.clutz.static_inherit.Parent {
+  class Child extends Child_Instance {
     static privateParentOverrideField : number ;
     static static_fn (a : number ) : void ;
-    /** WARNING: emitted for non-matching super type's static method. Only the first overload is actually callable. */
-    static static_fn (a : string ) : void ;
     static subTypeField : any [] ;
     static subTypeFieldMirrorType : ಠ_ಠ.clutz.static_inherit.Child ;
+  }
+  class Child_Instance extends ಠ_ಠ.clutz.static_inherit.Parent_Instance {
   }
 }
 declare namespace ಠ_ಠ.clutz.goog {
@@ -16,13 +16,11 @@ declare module 'goog:static_inherit.Child' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.static_inherit {
-  class GrandChild extends ಠ_ಠ.clutz.static_inherit.Child {
+  class GrandChild extends GrandChild_Instance {
     static static_fn (a : boolean ) : void ;
-    /** WARNING: emitted for non-matching super type's static method. Only the first overload is actually callable. */
-    static static_fn (a : number ) : void ;
-    /** WARNING: emitted for non-matching super type's static method. Only the first overload is actually callable. */
-    static static_fn (a : string ) : void ;
     static subTypeFieldMirrorType : ಠ_ಠ.clutz.static_inherit.GrandChild ;
+  }
+  class GrandChild_Instance extends ಠ_ಠ.clutz.static_inherit.Child_Instance {
   }
 }
 declare namespace ಠ_ಠ.clutz.goog {
@@ -33,12 +31,14 @@ declare module 'goog:static_inherit.GrandChild' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.static_inherit {
-  class Parent {
-    private noStructuralTyping_: any;
+  class Parent extends Parent_Instance {
     static privateChildOverrideField : number ;
     static static_fn (a : string ) : void ;
     static subTypeField : Object ;
     static subTypeFieldMirrorType : ಠ_ಠ.clutz.static_inherit.Parent ;
+  }
+  class Parent_Instance {
+    private noStructuralTyping_: any;
   }
 }
 declare namespace ಠ_ಠ.clutz.goog {

--- a/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch_nested_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch_nested_type.d.ts
@@ -1,13 +1,14 @@
 declare namespace ಠ_ಠ.clutz.sim_nested {
-  class Child extends ಠ_ಠ.clutz.sim_nested.Parent {
+  class Child extends Child_Instance {
+  }
+  class Child_Instance extends ಠ_ಠ.clutz.sim_nested.Parent_Instance {
   }
 }
 declare namespace ಠ_ಠ.clutz.sim_nested.Child {
   type Nested = number ;
   var Nested : {
     B : Nested ,
-  } &
-  (/* Incompatible inherited static property */ typeof ಠ_ಠ.clutz.sim_nested.Parent.Nested );
+  };
 }
 declare namespace ಠ_ಠ.clutz.goog {
   function require(name: 'sim_nested.Child'): typeof ಠ_ಠ.clutz.sim_nested.Child;
@@ -20,8 +21,7 @@ declare namespace ಠ_ಠ.clutz.sim_nested.Child {
   type NestedAndProvided = number ;
   var NestedAndProvided : {
     B : NestedAndProvided ,
-  } &
-  (/* Incompatible inherited static property */ typeof ಠ_ಠ.clutz.sim_nested.Parent.NestedAndProvided );
+  };
 }
 declare namespace ಠ_ಠ.clutz.goog {
   function require(name: 'sim_nested.Child.NestedAndProvided'): typeof ಠ_ಠ.clutz.sim_nested.Child.NestedAndProvided;
@@ -31,7 +31,9 @@ declare module 'goog:sim_nested.Child.NestedAndProvided' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.sim_nested {
-  class Parent {
+  class Parent extends Parent_Instance {
+  }
+  class Parent_Instance {
     private noStructuralTyping_: any;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/static_provided.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_provided.d.ts
@@ -1,5 +1,7 @@
 declare namespace ಠ_ಠ.clutz.a.b {
-  class StaticHolder {
+  class StaticHolder extends StaticHolder_Instance {
+  }
+  class StaticHolder_Instance {
     private noStructuralTyping_: any;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/types_with_3p_externs.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types_with_3p_externs.d.ts
@@ -1,6 +1,8 @@
 declare namespace ಠ_ಠ.clutz.typesWithExterns {
   type ArrayLike = NodeList | IArguments | { length : number } ;
-  class Error extends GlobalError {
+  class Error extends Error_Instance {
+  }
+  class Error_Instance extends GlobalError {
   }
   interface ExtendsIThenable extends PromiseLike < any > {
   }
@@ -20,7 +22,9 @@ declare module 'goog:typesWithExterns' {
   export = alias;
 }
 declare namespace ಠ_ಠ.clutz.typesWithExterns {
-  class A {
+  class A extends A_Instance {
+  }
+  class A_Instance {
     private noStructuralTyping_: any;
     constructor (n : number ) ;
     apply : number ;
@@ -34,7 +38,9 @@ declare module 'goog:typesWithExterns.A' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.typesWithExterns {
-  class B extends ಠ_ಠ.clutz.typesWithExterns.A {
+  class B extends B_Instance {
+  }
+  class B_Instance extends ಠ_ಠ.clutz.typesWithExterns.A_Instance {
   }
 }
 declare namespace ಠ_ಠ.clutz.goog {
@@ -45,7 +51,9 @@ declare module 'goog:typesWithExterns.B' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.typesWithExterns {
-  class C extends ಠ_ಠ.clutz.typesWithExterns.A {
+  class C extends C_Instance {
+  }
+  class C_Instance extends ಠ_ಠ.clutz.typesWithExterns.A_Instance {
   }
 }
 declare namespace ಠ_ಠ.clutz.goog {
@@ -56,12 +64,14 @@ declare module 'goog:typesWithExterns.C' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.namespace {
-  class Foo {
+  class Foo extends Foo_Instance {
+    static staticField : string ;
+    static staticMethod ( ) : string ;
+  }
+  class Foo_Instance {
     private noStructuralTyping_: any;
     member : string ;
     method (opt_exp ? : (a : ಠ_ಠ.clutz.namespace.Foo ) => any ) : any ;
-    static staticField : string ;
-    static staticMethod ( ) : string ;
   }
   type atypedef = (a : string , b ? : { capacity : number } ) => ಠ_ಠ.clutz.namespace.atypedef.Cache < any > ;
   function bootstrap (arg1 : Element | HTMLDocument , opt_arg2 ? : ( string | ( ( ...a : any [] ) => any ) ) [] ) : any ;
@@ -73,7 +83,9 @@ declare namespace ಠ_ಠ.clutz.namespace.atypedef {
   type Options = { capacity : number } ;
 }
 declare namespace ಠ_ಠ.clutz.namespace.atypedef {
-  class Cache < T > {
+  class Cache < T > extends Cache_Instance < T > {
+  }
+  class Cache_Instance < T > {
     private noStructuralTyping_: any;
     destroy ( ) : any ;
     get (key : string ) : T ;
@@ -96,7 +108,9 @@ declare namespace ಠ_ಠ.clutz {
   function FunctionNamespace (descriptor : { is : string } ) : any ;
 }
 declare namespace ಠ_ಠ.clutz {
-  class FunctionNamespaceHelperClass {
+  class FunctionNamespaceHelperClass extends FunctionNamespaceHelperClass_Instance {
+  }
+  class FunctionNamespaceHelperClass_Instance {
     private noStructuralTyping_: any;
   }
 }


### PR DESCRIPTION
This fixes all sorts of static overwrite issues and removes a number of
cludgy solutions (like intersection types on enums, overloading function
declarations).

Closes #184