### PR TITLE
feat: fix goog.module with default export.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/MultiFileTest.java
+++ b/src/test/java/com/google/javascript/clutz/MultiFileTest.java
@@ -52,8 +52,8 @@ public class MultiFileTest {
   public void googModule() throws Exception {
     String expected = DeclarationGeneratorTests.getTestFileText(input("goog_module.d.ts"));
     assertThatProgram(
-        ImmutableList.of(input("required_module.js"), input("required.js"),
-            input("goog_module.js")),
+        ImmutableList.of(input("required_module.js"), input("required_module_default.js"),
+            input("required.js"), input("goog_module.js")),
         Collections.<File>emptyList())
         .generatesDeclarations(expected);
   }

--- a/src/test/java/com/google/javascript/clutz/googModule/goog_module.d.ts
+++ b/src/test/java/com/google/javascript/clutz/googModule/goog_module.d.ts
@@ -16,6 +16,7 @@ declare namespace ಠ_ಠ.clutz.googmodule.TheModule {
   var a : number ;
   var b : number ;
   var required : ಠ_ಠ.clutz.googmodule.Required ;
+  var requiredDefault : ಠ_ಠ.clutz.googmodule.requiredModuleDefault ;
 }
 declare namespace ಠ_ಠ.clutz.goog {
   function require(name: 'googmodule.TheModule'): typeof ಠ_ಠ.clutz.googmodule.TheModule;
@@ -33,4 +34,18 @@ declare namespace ಠ_ಠ.clutz.goog {
 declare module 'goog:googmodule.requiredModule' {
   import alias = ಠ_ಠ.clutz.googmodule.requiredModule;
   export = alias;
+}
+declare namespace ಠ_ಠ.clutz.googmodule {
+  class requiredModuleDefault extends requiredModuleDefault_Instance {
+  }
+  class requiredModuleDefault_Instance {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'googmodule.requiredModuleDefault'): typeof ಠ_ಠ.clutz.googmodule.requiredModuleDefault;
+}
+declare module 'goog:googmodule.requiredModuleDefault' {
+  import alias = ಠ_ಠ.clutz.googmodule.requiredModuleDefault;
+  export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/googModule/goog_module.js
+++ b/src/test/java/com/google/javascript/clutz/googModule/goog_module.js
@@ -1,6 +1,7 @@
 goog.module('googmodule.TheModule');
 
 var Required = goog.require('googmodule.Required');
+var RequiredDefault = goog.require('googmodule.requiredModuleDefault');
 var requiredModule = goog.require('googmodule.requiredModule');
 
 /** @type {number} */
@@ -11,6 +12,9 @@ exports.b = requiredModule.rm;
 
 /** @type {Required} */
 exports.required;
+
+/** @type {RequiredDefault} */
+exports.requiredDefault;
 
 /** @type {number} */
 var scopedVariable;

--- a/src/test/java/com/google/javascript/clutz/googModule/required_module_default.js
+++ b/src/test/java/com/google/javascript/clutz/googModule/required_module_default.js
@@ -1,0 +1,6 @@
+goog.module('googmodule.requiredModuleDefault');
+
+/** @constructor */
+var A = function() {}
+
+exports = A;


### PR DESCRIPTION
Since default export does not have a fixed symbol name at the export
site, Closure introduces synthetic $jscomp namespace, which needs to be
cleaned-up before emitting.

Closes #186