### PR TITLE
fix: do not emit .prototype as a type.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -982,6 +982,14 @@ public class DeclarationGenerator {
             } else {
               name = getAbsoluteName(type);
             }
+            // Under special conditions (see prototype_inferred_type.js) closure can infer
+            // the type be the prototype object. TypeScript has nothing that matches the shape
+            // of the prototype object (surprisingly typeof A.prototype is A). The best we can do is
+            // any.
+            if (name.endsWith(".prototype")) {
+              emit("any");
+              return null;
+            }
             emit(extendingInstanceClass ?
                 name + INSTANCE_CLASS_SUFFIX : name);
           } else {

--- a/src/test/java/com/google/javascript/clutz/prototype_inferred_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/prototype_inferred_type.d.ts
@@ -1,0 +1,18 @@
+declare namespace ಠ_ಠ.clutz.foo {
+  class Klass extends Klass_Instance {
+    /**
+     * Crazy pattern, I have only seen it used by jquery.fn = jquery.prototype
+     */
+    static foo : any ;
+  }
+  class Klass_Instance {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'foo.Klass'): typeof ಠ_ಠ.clutz.foo.Klass;
+}
+declare module 'goog:foo.Klass' {
+  import alias = ಠ_ಠ.clutz.foo.Klass;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/prototype_inferred_type.js
+++ b/src/test/java/com/google/javascript/clutz/prototype_inferred_type.js
@@ -1,0 +1,7 @@
+goog.provide('foo.Klass');
+
+/** @constructor */
+foo.Klass = function() {};
+
+/** Crazy pattern, I have only seen it used by jquery.fn = jquery.prototype */
+foo.Klass.foo = foo.Klass.prototype;


### PR DESCRIPTION
This can happen very rarely (Foo.prototype is not a valid type symbol in
Closure either), but jquery externs manages to produce it by
setting:

jQuery.fn = jQuery.prototype.

Closes #206