### PR TITLE
fix: skip emitting private default provides.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -338,7 +338,12 @@ public class DeclarationGenerator {
     emitNamespaceBegin(namespace);
     TreeWalker treeWalker = new TreeWalker(compiler.getTypeRegistry(), provides);
     if (isDefault) {
-      treeWalker.walk(symbol);
+      if (isPrivate(symbol.getJSDocInfo())) {
+        emit("// skipping emitting private default export " + symbol.getName() + ".");
+        emitBreak();
+      } else {
+        treeWalker.walk(symbol);
+      }
     } else {
       // JSCompiler treats "foo.x" as one variable name, so collect all provides that start with
       // $provide + "." but are not sub-properties.

--- a/src/resources/third_party_externs.js
+++ b/src/resources/third_party_externs.js
@@ -128,3 +128,9 @@ ClassNamespace.constObj = {};
  * @type {number}
  */
 ClassNamespace.constObj.num;
+
+/**
+ * @constructor
+ * @private
+ */
+FunctionNamespace.privateClass = function() {};

--- a/src/test/java/com/google/javascript/clutz/types_with_3p_externs.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types_with_3p_externs.d.ts
@@ -130,3 +130,6 @@ declare namespace ಠ_ಠ.clutz {
     private noStructuralTyping_: any;
   }
 }
+declare namespace ಠ_ಠ.clutz.FunctionNamespace {
+  // skipping emitting private default export FunctionNamespace.privateClass.
+}


### PR DESCRIPTION
Private default provides are not common, but when going through externs
we output each class and interface as a default provide.