### PR TITLE
fix: default exported private values.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -339,8 +339,8 @@ public class DeclarationGenerator {
     TreeWalker treeWalker = new TreeWalker(compiler.getTypeRegistry(), provides);
     if (isDefault) {
       if (isPrivate(symbol.getJSDocInfo())) {
-        emit("// skipping emitting private default export " + symbol.getName() + ".");
-        emitBreak();
+
+        treeWalker.emitPrivateValue(symbol);
       } else {
         treeWalker.walk(symbol);
       }
@@ -1415,6 +1415,14 @@ public class DeclarationGenerator {
           visitTypeAlias(registryType, propName);
         }
       }
+    }
+
+    public void emitPrivateValue(TypedVar symbol) {
+      emit("var");
+      emit(getUnqualifiedName(symbol));
+      emit(":");
+      emit(Constants.INTERNAL_NAMESPACE + ".PrivateType;");
+      emitBreak();
     }
   }
 

--- a/src/test/java/com/google/javascript/clutz/private_provided_single_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/private_provided_single_class.d.ts
@@ -1,0 +1,7 @@
+declare namespace ಠ_ಠ.clutz.foo {
+  var PrivateClass : ಠ_ಠ.clutz.PrivateType;
+}
+declare module 'goog:foo.PrivateClass' {
+  import alias = ಠ_ಠ.clutz.foo.PrivateClass;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/private_provided_single_class.js
+++ b/src/test/java/com/google/javascript/clutz/private_provided_single_class.js
@@ -1,0 +1,7 @@
+goog.provide('foo.PrivateClass');
+
+/**
+ * @constructor
+ * @private
+ */
+foo.PrivateClass = function() {};

--- a/src/test/java/com/google/javascript/clutz/types_with_3p_externs.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types_with_3p_externs.d.ts
@@ -131,5 +131,5 @@ declare namespace ಠ_ಠ.clutz {
   }
 }
 declare namespace ಠ_ಠ.clutz.FunctionNamespace {
-  // skipping emitting private default export FunctionNamespace.privateClass.
+  var privateClass : ಠ_ಠ.clutz.PrivateType;
 }


### PR DESCRIPTION
Second attempt, completely skipping the value, results in broken code.
Instead emit a field of PrivateType.