### PR TITLE
fix: emit correct code for classes extending Function.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/extends_function_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/extends_function_with_platform.d.ts
@@ -1,0 +1,13 @@
+declare namespace ಠ_ಠ.clutz.foo {
+  class A extends A_Instance {
+  }
+  class A_Instance extends Function {
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'foo.A'): typeof ಠ_ಠ.clutz.foo.A;
+}
+declare module 'goog:foo.A' {
+  import alias = ಠ_ಠ.clutz.foo.A;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/extends_function_with_platform.js
+++ b/src/test/java/com/google/javascript/clutz/extends_function_with_platform.js
@@ -1,0 +1,7 @@
+goog.provide('foo.A');
+
+/**
+ * @constructor
+ * @extends {Function}
+ */
+foo.A = function() {};


### PR DESCRIPTION
Handle a todo to separate the generic type visitor (used for var a:
<...> type positions), from the extends/implements type visitor (used
for class A extends <...> type positions).