### PR TITLE
emit $jscomp.scope objects.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/googModule/goog_module.d.ts
+++ b/src/test/java/com/google/javascript/clutz/googModule/goog_module.d.ts
@@ -16,7 +16,7 @@ declare namespace ಠ_ಠ.clutz.googmodule.TheModule {
   var a : number ;
   var b : number ;
   var required : ಠ_ಠ.clutz.googmodule.Required ;
-  var requiredDefault : ಠ_ಠ.clutz.googmodule.requiredModuleDefault ;
+  var requiredDefault : ಠ_ಠ.clutz.$jscomp.scope.A ;
 }
 declare namespace ಠ_ಠ.clutz.goog {
   function require(name: 'googmodule.TheModule'): typeof ಠ_ಠ.clutz.googmodule.TheModule;
@@ -48,4 +48,11 @@ declare namespace ಠ_ಠ.clutz.goog {
 declare module 'goog:googmodule.requiredModuleDefault' {
   import alias = ಠ_ಠ.clutz.googmodule.requiredModuleDefault;
   export default alias;
+}
+declare namespace ಠ_ಠ.clutz.$jscomp.scope {
+  class A extends A_Instance {
+  }
+  class A_Instance {
+    private noStructuralTyping_: any;
+  }
 }

--- a/src/test/java/com/google/javascript/clutz/goog_scope.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_scope.d.ts
@@ -1,0 +1,31 @@
+declare namespace ಠ_ಠ.clutz.foo {
+  class Bar extends Bar_Instance {
+  }
+  class Bar_Instance {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'foo.Bar'): typeof ಠ_ಠ.clutz.foo.Bar;
+}
+declare module 'goog:foo.Bar' {
+  import alias = ಠ_ಠ.clutz.foo.Bar;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.foo {
+  var boom : ಠ_ಠ.clutz.$jscomp.scope.Bar ;
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'foo.boom'): typeof ಠ_ಠ.clutz.foo.boom;
+}
+declare module 'goog:foo.boom' {
+  import alias = ಠ_ಠ.clutz.foo.boom;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.$jscomp.scope {
+  class Bar extends Bar_Instance {
+  }
+  class Bar_Instance {
+    private noStructuralTyping_: any;
+  }
+}

--- a/src/test/java/com/google/javascript/clutz/goog_scope.js
+++ b/src/test/java/com/google/javascript/clutz/goog_scope.js
@@ -1,0 +1,10 @@
+goog.provide("foo.boom");
+goog.provide("foo.Bar");
+
+goog.scope(function() {
+  /** @constructor */ var Bar = function() { };
+  /** @const */ foo.Bar = Bar;
+});
+
+//!! The cannonical type for foo.Bar in closure is $jscomp.scope.
+/** @type {foo.Bar} */ foo.boom = null;


### PR DESCRIPTION
When using the pattern:

goog.provide('foo.Bar');
goog.scope(function() {
  /** @constructor */
  var A = function() {};
  /** @const */ foo.Bar = A;
}

foo.Bar is a valid type symbol, (i.e. it can be used as
/** @type {foo.Bar} */). However that is just a type alias for the
synthetic $jscomp.scope.A type symbol. Moreover, the dealiasing happens
in InlineAliases pass, and the aliasing map is not accessible for
further use.

Previously, we tried to revert the aliasing for previous goog.module,
but that did not handle general goog.scope. Now, we just emit all
$jscomp.scope type symbols used throughout the inputs.

Fixes a previous bug in aggregating typesUsed, where it did not account
for union types (null|Foo).

Fixes #221