### PR TITLE
fix(scope): support class/interface alias.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
+++ b/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
@@ -47,7 +47,7 @@ public class DeclarationSyntaxTest {
     }
 
     final List<String> tscCommand =
-        Lists.newArrayList(TSC.toString(), "--noEmit", "--skipDefaultLibCheck");
+        Lists.newArrayList(TSC.toString(), "--noEmit", "--skipDefaultLibCheck", "--noImplicitAny");
     tscCommand.add("src/resources/closure.lib.d.ts");
     tscCommand.addAll(goldenFilePaths);
     runChecked(tscCommand);
@@ -57,7 +57,8 @@ public class DeclarationSyntaxTest {
   public void testDeclarationUsage() throws Exception {
     List<File> inputs = DeclarationGeneratorTests.getTestInputFiles(TS_SOURCES);
     final List<String> tscCommand =
-        Lists.newArrayList(TSC.toString(), "--noEmit", "--skipDefaultLibCheck", "-m", "commonjs");
+        Lists.newArrayList(TSC.toString(), "--noEmit", "--skipDefaultLibCheck", "--noImplicitAny",
+            "-m", "commonjs");
     tscCommand.add("src/resources/closure.lib.d.ts");
     for (File input : inputs) {
       tscCommand.add(input.getPath());

--- a/src/test/java/com/google/javascript/clutz/googModule/goog_module.d.ts
+++ b/src/test/java/com/google/javascript/clutz/googModule/goog_module.d.ts
@@ -36,11 +36,8 @@ declare module 'goog:googmodule.requiredModule' {
   export = alias;
 }
 declare namespace ಠ_ಠ.clutz.googmodule {
-  class requiredModuleDefault extends requiredModuleDefault_Instance {
-  }
-  class requiredModuleDefault_Instance {
-    private noStructuralTyping_: any;
-  }
+  type requiredModuleDefault = ಠ_ಠ.clutz.$jscomp.scope.A ;
+  var requiredModuleDefault : typeof ಠ_ಠ.clutz.$jscomp.scope.A ;
 }
 declare namespace ಠ_ಠ.clutz.goog {
   function require(name: 'googmodule.requiredModuleDefault'): typeof ಠ_ಠ.clutz.googmodule.requiredModuleDefault;

--- a/src/test/java/com/google/javascript/clutz/goog_scope.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_scope.d.ts
@@ -1,15 +1,19 @@
 declare namespace ಠ_ಠ.clutz.foo {
-  class Bar extends Bar_Instance {
-  }
-  class Bar_Instance {
-    private noStructuralTyping_: any;
-  }
+  type Bar = ಠ_ಠ.clutz.$jscomp.scope.Bar ;
+  var Bar : typeof ಠ_ಠ.clutz.$jscomp.scope.Bar ;
 }
 declare namespace ಠ_ಠ.clutz.goog {
   function require(name: 'foo.Bar'): typeof ಠ_ಠ.clutz.foo.Bar;
 }
 declare module 'goog:foo.Bar' {
   import alias = ಠ_ಠ.clutz.foo.Bar;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.foo {
+  type IBar = ಠ_ಠ.clutz.$jscomp.scope.IBar ;
+}
+declare module 'goog:foo.IBar' {
+  import alias = ಠ_ಠ.clutz.foo.IBar;
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.foo {
@@ -22,10 +26,24 @@ declare module 'goog:foo.boom' {
   import alias = ಠ_ಠ.clutz.foo.boom;
   export default alias;
 }
+declare namespace ಠ_ಠ.clutz.foo {
+  var iboom : ಠ_ಠ.clutz.$jscomp.scope.IBar ;
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'foo.iboom'): typeof ಠ_ಠ.clutz.foo.iboom;
+}
+declare module 'goog:foo.iboom' {
+  import alias = ಠ_ಠ.clutz.foo.iboom;
+  export default alias;
+}
 declare namespace ಠ_ಠ.clutz.$jscomp.scope {
   class Bar extends Bar_Instance {
   }
   class Bar_Instance {
     private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.$jscomp.scope {
+  interface IBar {
   }
 }

--- a/src/test/java/com/google/javascript/clutz/goog_scope.js
+++ b/src/test/java/com/google/javascript/clutz/goog_scope.js
@@ -1,10 +1,15 @@
 goog.provide("foo.boom");
+goog.provide("foo.iboom");
 goog.provide("foo.Bar");
+goog.provide("foo.IBar");
 
 goog.scope(function() {
   /** @constructor */ var Bar = function() { };
   /** @const */ foo.Bar = Bar;
+  /** @interface */ var IBar = function() { }
+  /** @const */ foo.IBar = IBar;
 });
 
 //!! The cannonical type for foo.Bar in closure is $jscomp.scope.
 /** @type {foo.Bar} */ foo.boom = null;
+/** @type {foo.IBar} */ foo.iboom = null;

--- a/src/test/java/com/google/javascript/clutz/goog_scope_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_scope_usage.ts
@@ -1,0 +1,5 @@
+import Bar from 'goog:foo.Bar';
+import boom from 'goog:foo.boom';
+
+var a: Bar = boom;
+var b: Bar = new Bar();


### PR DESCRIPTION
Instead of producing two incompatible types for the alias, now we emit a
"type alias, constructor var" pair.