### PR TITLE
fix(interface alias): support templatized types.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -741,8 +741,10 @@ public class DeclarationGenerator {
       String typeName = Constants.INTERNAL_NAMESPACE + "." + ftype.getDisplayName();
       emit("type");
       emit(unqualifiedName);
+      visitTemplateTypes(ftype);
       emit("=");
       emit(typeName);
+      visitTemplateTypes(ftype);
       emit(";");
       emitBreak();
       if (!ftype.isInterface()) {
@@ -966,10 +968,6 @@ public class DeclarationGenerator {
     }
 
     private void visitType(JSType typeToVisit) {
-      visitType(typeToVisit, /* extendingInstanceClass */ false);
-    }
-
-    private void visitType(JSType typeToVisit, final boolean extendingInstanceClass) {
       // See also JsdocToEs6TypedConverter in the Closure code base. This code is implementing the
       // same algorithm starting from JSType nodes (as opposed to JSDocInfo), and directly
       // generating textual output. Otherwise both algorithms should produce the same output.
@@ -1161,6 +1159,7 @@ public class DeclarationGenerator {
         return null;
       }
       emit(templateTypeName);
+      typesUsed.add(type.getDisplayName());
       emit("<");
       while (it.hasNext()) {
         visitType(it.next());

--- a/src/test/java/com/google/javascript/clutz/goog_scope.js
+++ b/src/test/java/com/google/javascript/clutz/goog_scope.js
@@ -10,6 +10,6 @@ goog.scope(function() {
   /** @const */ foo.IBar = IBar;
 });
 
-//!! The cannonical type for foo.Bar in closure is $jscomp.scope.
+//!! The cannonical type for foo.Bar in closure is $jscomp.scope.Bar.
 /** @type {foo.Bar} */ foo.boom = null;
 /** @type {foo.IBar} */ foo.iboom = null;

--- a/src/test/java/com/google/javascript/clutz/goog_scope_templatized.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_scope_templatized.d.ts
@@ -1,0 +1,28 @@
+declare namespace ಠ_ಠ.clutz.aliasT {
+  type I < T > = ಠ_ಠ.clutz.$jscomp.scope.I < T > ;
+}
+declare module 'goog:aliasT.I' {
+  import alias = ಠ_ಠ.clutz.aliasT.I;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.aliasT {
+  type I2 < T > = ಠ_ಠ.clutz.$jscomp.scope.I < T > ;
+}
+declare module 'goog:aliasT.I2' {
+  import alias = ಠ_ಠ.clutz.aliasT.I2;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.aliasT {
+  var iboom : ಠ_ಠ.clutz.$jscomp.scope.I < string > ;
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'aliasT.iboom'): typeof ಠ_ಠ.clutz.aliasT.iboom;
+}
+declare module 'goog:aliasT.iboom' {
+  import alias = ಠ_ಠ.clutz.aliasT.iboom;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.$jscomp.scope {
+  interface I < T > {
+  }
+}

--- a/src/test/java/com/google/javascript/clutz/goog_scope_templatized.js
+++ b/src/test/java/com/google/javascript/clutz/goog_scope_templatized.js
@@ -1,0 +1,16 @@
+goog.provide("aliasT.iboom");
+goog.provide("aliasT.I");
+goog.provide("aliasT.I2");
+
+goog.scope(function() {
+  /**
+   * @interface
+   * @template T
+   */
+  var I = function() { }
+  /** @const */ aliasT.I = I;
+  /** @const */ aliasT.I2 = aliasT.I;
+});
+
+//!! The cannonical type for aliasT.I<T> in closure is $jscomp.scope.I<T>.
+/** @type {aliasT.I<string>} */ aliasT.iboom = null;


### PR DESCRIPTION
Type aliases need to explicitly list their type parameters:

```typescript
class B<T> {}
type A = B;  // wrong
type A<T> = B<T>  // correct
```