### PR TITLE
fix: provided functions can be used as namespaces too.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/fn_inner_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/fn_inner_enum.d.ts
@@ -1,0 +1,15 @@
+declare namespace ಠ_ಠ.clutz.ns {
+  function foo ( ) : boolean ;
+}
+declare namespace ಠ_ಠ.clutz.ns.foo {
+  type Enum = number ;
+  var Enum : {
+  };
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'ns.foo'): typeof ಠ_ಠ.clutz.ns.foo;
+}
+declare module 'goog:ns.foo' {
+  import alias = ಠ_ಠ.clutz.ns.foo;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/fn_inner_enum.js
+++ b/src/test/java/com/google/javascript/clutz/fn_inner_enum.js
@@ -1,0 +1,7 @@
+goog.provide('ns.foo');
+
+/** @return {boolean} */
+ns.foo = function() {}
+
+/** @enum {number} */
+ns.foo.Enum = {};

--- a/src/test/java/com/google/javascript/clutz/privates.d.ts
+++ b/src/test/java/com/google/javascript/clutz/privates.d.ts
@@ -20,8 +20,6 @@ declare namespace ಠ_ಠ.clutz.priv2 {
     private noStructuralTyping_: any;
   }
 }
-declare namespace ಠ_ಠ.clutz.priv2.PublicClass {
-}
 declare namespace ಠ_ಠ.clutz.goog {
   function require(name: 'priv2.PublicClass'): typeof ಠ_ಠ.clutz.priv2.PublicClass;
 }

--- a/src/test/java/com/google/javascript/clutz/static_provided.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_provided.d.ts
@@ -5,8 +5,6 @@ declare namespace ಠ_ಠ.clutz.a.b {
     private noStructuralTyping_: any;
   }
 }
-declare namespace ಠ_ಠ.clutz.a.b.StaticHolder {
-}
 declare namespace ಠ_ಠ.clutz.goog {
   function require(name: 'a.b.StaticHolder'): typeof ಠ_ಠ.clutz.a.b.StaticHolder;
 }


### PR DESCRIPTION
Merge walkInnerSymbol and interface static logic. Emit auxilary
(non-provided) namespace only when non-empty.