### PR TITLE
fix(type alias): count the type alias as type used.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -731,6 +731,7 @@ public class DeclarationGenerator {
         emit(";");
         emitBreak();
       }
+      typesUsed.add(ftype.getDisplayName());
     }
 
     private void maybeEmitJsDoc(JSDocInfo docs, boolean ignoreParams) {

--- a/src/test/java/com/google/javascript/clutz/goog_module_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_module_class.d.ts
@@ -1,0 +1,18 @@
+declare namespace ಠ_ಠ.clutz.module {
+  type Foo = ಠ_ಠ.clutz.$jscomp.scope.A ;
+  var Foo : typeof ಠ_ಠ.clutz.$jscomp.scope.A ;
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'module.Foo'): typeof ಠ_ಠ.clutz.module.Foo;
+}
+declare module 'goog:module.Foo' {
+  import alias = ಠ_ಠ.clutz.module.Foo;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.$jscomp.scope {
+  class A extends A_Instance {
+  }
+  class A_Instance {
+    private noStructuralTyping_: any;
+  }
+}

--- a/src/test/java/com/google/javascript/clutz/goog_module_class.js
+++ b/src/test/java/com/google/javascript/clutz/goog_module_class.js
@@ -1,0 +1,6 @@
+goog.module('module.Foo');
+
+class A {
+}
+
+exports = A;


### PR DESCRIPTION
Adds a test for goog.module + ES6 classes pattern.