### PR TITLE
Fix extern namespace.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -304,6 +304,9 @@ public class DeclarationGenerator {
       // parent symbol.
       if (symbol.getName().contains(".prototype")) continue;
 
+      // Sub-parts of namespaces in externs can appear as unknown if they miss a @const.
+      if (symbol.getType().isUnknownType()) continue;
+
       String parentPath = getNamespace(symbol.getName());
       boolean isDefault = isDefaultExport(symbol);
 

--- a/src/test/java/com/google/javascript/clutz/extern_ns.d.ts
+++ b/src/test/java/com/google/javascript/clutz/extern_ns.d.ts
@@ -1,0 +1,9 @@
+//!! emitting var ns: any inside namespace ಠ_ಠ.clutz would be an error here.
+declare namespace ಠ_ಠ.clutz.ns {
+  interface I {
+  }
+}
+declare namespace ಠ_ಠ.clutz.nsConst {
+  interface I {
+  }
+}

--- a/src/test/java/com/google/javascript/clutz/extern_ns.externs.js
+++ b/src/test/java/com/google/javascript/clutz/extern_ns.externs.js
@@ -1,0 +1,10 @@
+var ns = {};
+
+/** @interface */
+ns.I = function() {};
+
+/** @const */
+var nsConst = {};
+
+/** @interface */
+nsConst.I = function() {};

--- a/src/test/java/com/google/javascript/clutz/extern_ns.js
+++ b/src/test/java/com/google/javascript/clutz/extern_ns.js
@@ -1,0 +1,1 @@
+// this file is intentionally empty.


### PR DESCRIPTION
Externs do not use goog.require so namespaces need to be manually
declared with vars. Depending on the presence of @const there are two
different paths in clutz and for each one we have to make sure not to
generate a var typing that would clash with the namespace.