### PR TITLE
adds an usage of invalid names.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/invalid_names_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/invalid_names_usage.ts
@@ -1,0 +1,6 @@
+import * as names from "goog:invalid.names";
+
+// The invalid symbol object can only be accessed through an index operator.
+// To avoid noImplicitAny errors we need to explicitly type <any>.
+var fn: () => void = (<any> names)['0'];
+fn();


### PR DESCRIPTION
The file was supposed to be part of
https://github.com/angular/clutz/commit/613701db83a14669bdda271b663a4cc559e8d8da

It is important to show how usage of invalid names works in presence of
noImplicitAny.