### PR TITLE
fix: functions that are declared as fields and extended as methods.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/function_extends_field.d.ts
+++ b/src/test/java/com/google/javascript/clutz/function_extends_field.d.ts
@@ -1,0 +1,34 @@
+declare namespace ಠ_ಠ.clutz.fn.field {
+  class A extends A_Instance {
+  }
+  class A_Instance {
+    private noStructuralTyping_: any;
+    f : any ;
+    g : any ;
+    h ( ) : number ;
+    pf : any ;
+    pg : any ;
+    ph ( ) : number ;
+  }
+  class B extends B_Instance {
+  }
+  class B_Instance extends ಠ_ಠ.clutz.fn.field.A_Instance {
+    f : ( ) => number ;
+    h ( ) : number ;
+    pf : ( ) => number ;
+    ph ( ) : number ;
+  }
+  class C extends C_Instance {
+  }
+  class C_Instance extends ಠ_ಠ.clutz.fn.field.B_Instance {
+    g : ( ) => number ;
+    pg : ( ) => number ;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'fn.field'): typeof ಠ_ಠ.clutz.fn.field;
+}
+declare module 'goog:fn.field' {
+  import alias = ಠ_ಠ.clutz.fn.field;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/function_extends_field.js
+++ b/src/test/java/com/google/javascript/clutz/function_extends_field.js
@@ -1,0 +1,45 @@
+goog.provide('fn.field');
+
+/** @constructor */
+fn.field.A = function() {
+  this.f = null;
+  this.g = null;
+  /** @type {function(): number} */
+  this.h = function() {return 0;};
+};
+
+fn.field.A.prototype.pf = null;
+fn.field.A.prototype.pg = null;
+/** @type {function(): number} */
+fn.field.A.prototype.ph = function() {return 0;};
+
+/**
+ * @constructor
+ * @extends {fn.field.A}
+ */
+fn.field.B = function() {
+}
+
+/** @return {number} */
+fn.field.B.prototype.f = function() { return 0; }
+
+/** @return {number} */
+fn.field.B.prototype.h = function() { return 0; }
+
+/** @return {number} */
+fn.field.B.prototype.pf = function() { return 0; }
+
+/** @return {number} */
+fn.field.B.prototype.ph = function() { return 0; }
+/**
+ * @constructor
+ * @extends {fn.field.B}
+ */
+fn.field.C = function() {
+}
+
+/** @return {number} */
+fn.field.C.prototype.g = function() { return 0; }
+
+/** @return {number} */
+fn.field.C.prototype.pg = function() { return 0; }


### PR DESCRIPTION
Closure does not err in this pattern, but TS is more restrictive and
disallows methods shadowing properties from a base class. To emit
correct TS, we emit never emit a method if it has the same name as a
field on a base class.