### PR TITLE
fixes issue with nested namespace.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Constants.java
+++ b/src/main/java/com/google/javascript/clutz/Constants.java
@@ -7,4 +7,12 @@ public class Constants {
    * disturbed by the extended Unicode character.
    */
   static final String INTERNAL_NAMESPACE = "ಠ_ಠ.clutz";
+
+  /**
+   * When providing foo.bar and foo.bar.Klass, we cannot generate a 'var bar: T' declaration,
+   * because it collides with 'namespace foo.bar' declaration. We alias the first using a postfix.
+   * The alias does not affect the external module declaration, thus the user can still import the
+   * symbol using unaliased module name (i.e. import bar from 'goog:foo.bar').
+   */
+  static final String SYMBOL_ALIAS_POSTFIX = "__clutz_alias";
 }

--- a/src/test/java/com/google/javascript/clutz/nested_namespaces.d.ts
+++ b/src/test/java/com/google/javascript/clutz/nested_namespaces.d.ts
@@ -1,0 +1,43 @@
+declare namespace ಠ_ಠ.clutz.nested {
+  var PrivateC__clutz_alias : ಠ_ಠ.clutz.PrivateType;
+}
+declare module 'goog:nested.PrivateC' {
+  import alias = ಠ_ಠ.clutz.nested.PrivateC__clutz_alias;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.nested.PrivateC {
+  type Enum = number ;
+  var Enum : {
+  };
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'nested.PrivateC.Enum'): typeof ಠ_ಠ.clutz.nested.PrivateC.Enum;
+}
+declare module 'goog:nested.PrivateC.Enum' {
+  import alias = ಠ_ಠ.clutz.nested.PrivateC.Enum;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.nested {
+  var foo__clutz_alias : ಠ_ಠ.clutz.PrivateType ;
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'nested.foo'): typeof ಠ_ಠ.clutz.nested.foo__clutz_alias;
+}
+declare module 'goog:nested.foo' {
+  import alias = ಠ_ಠ.clutz.nested.foo__clutz_alias;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.nested.foo {
+  class Klass extends Klass_Instance {
+  }
+  class Klass_Instance {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'nested.foo.Klass'): typeof ಠ_ಠ.clutz.nested.foo.Klass;
+}
+declare module 'goog:nested.foo.Klass' {
+  import alias = ಠ_ಠ.clutz.nested.foo.Klass;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/nested_namespaces.js
+++ b/src/test/java/com/google/javascript/clutz/nested_namespaces.js
@@ -1,0 +1,16 @@
+goog.provide('nested.foo');
+goog.provide('nested.foo.Klass');
+goog.provide('nested.PrivateC');
+goog.provide('nested.PrivateC.Enum');
+
+/** @constructor @private */
+nested.PrivateC = function() {};
+
+/** @enum {number} */
+nested.PrivateC.Enum = {};
+
+/** @type {nested.PrivateC} */
+nested.foo = null;
+
+/** @constructor */
+nested.foo.Klass = function() {};

--- a/src/test/java/com/google/javascript/clutz/nested_namespaces_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/nested_namespaces_usage.ts
@@ -1,0 +1,4 @@
+import foo from 'goog:nested.foo';
+import Klass from 'goog:nested.foo.Klass';
+
+var k = new Klass();


### PR DESCRIPTION
When a foo.bar is provided and we have emitted 'var bar' in namespace
foo, TS does not allow declaring namespace foo.bar. Since all var bar
has no internal references except in module exports, we use an internal
__clutz_alias to avoid the collision.

Note that the module shim still has the correct name, thus the alias in
invisible to any users through ES6 modules.

Closes #217