### PR TITLE
fix shadowing logic.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -256,7 +256,7 @@ public class DeclarationGenerator {
   private Set<String> getShadowedProvides(TreeSet<String> provides) {
     Set<String> shadowedProvides = new TreeSet<>();
     for (String provide : provides) {
-      if (!provides.subSet(provide + ".", provide + "\uFFFF").isEmpty()) {
+      if (!provides.subSet(provide + ".", provide + ".\uFFFF").isEmpty()) {
         shadowedProvides.add(provide);
       }
     }

--- a/src/test/java/com/google/javascript/clutz/nested_namespaces.d.ts
+++ b/src/test/java/com/google/javascript/clutz/nested_namespaces.d.ts
@@ -1,4 +1,28 @@
 declare namespace ಠ_ಠ.clutz.nested {
+  type NotNested = number ;
+  var NotNested : {
+  };
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'nested.NotNested'): typeof ಠ_ಠ.clutz.nested.NotNested;
+}
+declare module 'goog:nested.NotNested' {
+  import alias = ಠ_ಠ.clutz.nested.NotNested;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.nested {
+  type NotNestedEither = number ;
+  var NotNestedEither : {
+  };
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'nested.NotNestedEither'): typeof ಠ_ಠ.clutz.nested.NotNestedEither;
+}
+declare module 'goog:nested.NotNestedEither' {
+  import alias = ಠ_ಠ.clutz.nested.NotNestedEither;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.nested {
   var PrivateC__clutz_alias : ಠ_ಠ.clutz.PrivateType;
 }
 declare module 'goog:nested.PrivateC' {

--- a/src/test/java/com/google/javascript/clutz/nested_namespaces.js
+++ b/src/test/java/com/google/javascript/clutz/nested_namespaces.js
@@ -2,6 +2,8 @@ goog.provide('nested.foo');
 goog.provide('nested.foo.Klass');
 goog.provide('nested.PrivateC');
 goog.provide('nested.PrivateC.Enum');
+goog.provide('nested.NotNested');
+goog.provide('nested.NotNestedEither');
 
 /** @constructor @private */
 nested.PrivateC = function() {};
@@ -14,3 +16,9 @@ nested.foo = null;
 
 /** @constructor */
 nested.foo.Klass = function() {};
+
+/** @enum */
+nested.NotNested = {};
+
+/** @enum */
+nested.NotNestedEither = {};


### PR DESCRIPTION
Previously, "foo.bar" was considered shadowed by "foo.barBuz", which is
incorrect. It is only shadowed by "foo.bar.buz".