### PR TITLE
emit an index signature for classes implementing IArrayLike.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/extends_arraylike_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/extends_arraylike_with_platform.d.ts
@@ -1,0 +1,40 @@
+declare namespace ಠ_ಠ.clutz.extend.arraylike {
+  class A extends A_Instance {
+  }
+  class A_Instance implements ArrayLike < any > {
+    private noStructuralTyping_: any;
+    [key: string]: any;
+    length : number ;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'extend.arraylike.A'): typeof ಠ_ಠ.clutz.extend.arraylike.A;
+}
+declare module 'goog:extend.arraylike.A' {
+  import alias = ಠ_ಠ.clutz.extend.arraylike.A;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.extend.arraylike {
+  class B extends B_Instance {
+  }
+  class B_Instance implements ಠ_ಠ.clutz.extend.arraylike.I {
+    private noStructuralTyping_: any;
+    [key: string]: any;
+    length : number ;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'extend.arraylike.B'): typeof ಠ_ಠ.clutz.extend.arraylike.B;
+}
+declare module 'goog:extend.arraylike.B' {
+  import alias = ಠ_ಠ.clutz.extend.arraylike.B;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.extend.arraylike {
+  interface I extends ArrayLike < any > {
+  }
+}
+declare module 'goog:extend.arraylike.I' {
+  import alias = ಠ_ಠ.clutz.extend.arraylike.I;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/extends_arraylike_with_platform.js
+++ b/src/test/java/com/google/javascript/clutz/extends_arraylike_with_platform.js
@@ -1,0 +1,27 @@
+goog.provide('extend.arraylike.A');
+goog.provide('extend.arraylike.I');
+goog.provide('extend.arraylike.B');
+
+/**
+ * @constructor
+ * @implements {IArrayLike<?>}
+ */
+extend.arraylike.A = function() {};
+
+/** @type {number} */
+extend.arraylike.A.prototype.length;
+
+/**
+ * @interface
+ * @extends {IArrayLike<?>}
+ */
+extend.arraylike.I = function() {};
+
+/**
+ * @constructor
+ * @implements {extend.arraylike.I}
+ */
+extend.arraylike.B = function() {};
+
+/** @type {number} */
+extend.arraylike.B.prototype.length;


### PR DESCRIPTION
The parametrized type of IArrayLike is not handled (emit as any).

Fixes a bug where interfaces picked up static methods from backing
function assignment.