### PR TITLE
Add Event to the list of globalSymbolAliases.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -96,6 +96,16 @@ public class DeclarationGenerator {
       "v8.js", "webgl.js", "webstorage.js", "whatwg_encoding.js",
       "window.js");
 
+  /**
+   * List of global platfom platform symbols that are redirected through an alias in closure.lib.d.ts
+   * This allows the following pattern to work:
+   * namespace foo {
+   *   class Error extends Error {}
+   * }
+   * by replacing the second Error with GlobalError.
+   */
+  private static final Set<String> globalSymbolAliases = ImmutableSet.of("Error", "Event");
+
   public static void main(String[] args) {
     Options options = null;
     try {
@@ -1618,9 +1628,8 @@ public class DeclarationGenerator {
 
     public Void emitObjectType(ObjectType type, boolean extendingInstanceClass,
                                boolean inExtendsImplementsPosition) {
-      if (type.getDisplayName() != null && type.getDisplayName().equals("Error")) {
-        // global Error is aliased as GlobalError in closure.lib.d.ts.
-        emit("GlobalError");
+      if (type.getDisplayName() != null && globalSymbolAliases.contains(type.getDisplayName())) {
+        emit("Global" + type.getDisplayName());
         return null;
       }
       // Closure doesn't require that all the type params be declared, but TS does

--- a/src/resources/closure.lib.d.ts
+++ b/src/resources/closure.lib.d.ts
@@ -4,6 +4,8 @@
 declare namespace ಠ_ಠ.clutz {
   type GlobalError = Error;
   var GlobalError: ErrorConstructor;
+  type GlobalEvent = Event;
+  var GlobalEvent: typeof Event;
   /** Represents the type returned when goog.require-ing an unknown symbol */
   type ClosureSymbolNotGoogProvided = void;
   /** Represents a Closure type that is private, represented by an empty interface. */

--- a/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
@@ -262,13 +262,13 @@ declare namespace ಠ_ಠ.clutz {
   }
   class WebWorker_Instance implements EventTarget {
     private noStructuralTyping_: any;
-    addEventListener (type : string , listener : EventListener | ( (a : Event ) => boolean ) , opt_useCapture ? : boolean ) : void ;
-    dispatchEvent (evt : Event ) : boolean ;
+    addEventListener (type : string , listener : EventListener | ( (a : GlobalEvent ) => boolean ) , opt_useCapture ? : boolean ) : void ;
+    dispatchEvent (evt : GlobalEvent ) : boolean ;
     /**
      * Sent when the worker thread encounters an error.
      * TODO(tbreisacher): Should this change to function(!ErrorEvent)?
      */
-    onerror : (a : Event ) => any ;
+    onerror : (a : GlobalEvent ) => any ;
     /**
      * Sent when the worker thread posts a message to its creator.
      */
@@ -277,7 +277,7 @@ declare namespace ಠ_ಠ.clutz {
      * Posts a message to the worker thread.
      */
     postMessage (message : string ) : any ;
-    removeEventListener (type : string , listener : EventListener | ( (a : Event ) => boolean ) , opt_useCapture ? : boolean ) : void ;
+    removeEventListener (type : string , listener : EventListener | ( (a : GlobalEvent ) => boolean ) , opt_useCapture ? : boolean ) : void ;
     /**
      * Stops the worker process
      */
@@ -295,15 +295,15 @@ declare namespace ಠ_ಠ.clutz {
     /**
      * Sent when the worker encounters an error.
      */
-    onerror : (a : Event ) => any ;
+    onerror : (a : GlobalEvent ) => any ;
     /**
      * Sent when the worker goes offline.
      */
-    onoffline : (a : Event ) => any ;
+    onoffline : (a : GlobalEvent ) => any ;
     /**
      * Sent when the worker goes online.
      */
-    ononline : (a : Event ) => any ;
+    ononline : (a : GlobalEvent ) => any ;
     self : WorkerGlobalScope ;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/types_externs_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types_externs_with_platform.d.ts
@@ -79,7 +79,7 @@ declare namespace ಠ_ಠ.clutz {
   function functionNamespace (descriptor : { is : string } ) : any ;
 }
 declare namespace ಠ_ಠ.clutz.functionNamespace {
-  function dom (nodeOrEvent : Node | Event ) : functionNamespaceHelperClass ;
+  function dom (nodeOrEvent : Node | GlobalEvent ) : functionNamespaceHelperClass ;
 }
 declare namespace ಠ_ಠ.clutz.functionNamespace {
   var privateClass : ಠ_ಠ.clutz.PrivateType;


### PR DESCRIPTION
Clutz will emit GlobalEvent instead of Event, where GlobalEvent is an
type alias for Event.

This allows the following pattern to work:

namespace goog {
  class Event extends Event {}
}