### PR TITLE
Fix field-method mismatch for inferred properties.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -1382,17 +1382,20 @@ public class DeclarationGenerator {
         emit(";");
         emitBreak();
       }
+
+      Set<String> superClassFields = getSuperClassFields(type);
+
       // Fields.
       JSType instanceType = type.getTypeOfThis();
       checkArgument(instanceType.isObject(), "expected an ObjectType for this, but got "
           + instanceType + " which is a " + instanceType.getClass().getSimpleName());
-      visitProperties((ObjectType) instanceType, false);
+      visitProperties((ObjectType) instanceType, false, Collections.<String>emptySet(),
+          superClassFields);
       // Bracket-style property access
       if (emitIndexSignature) {
         emit("[key: string]: any;");
         emitBreak();
       }
-      Set<String> superClassFields = getSuperClassFields(type);
 
       // Prototype fields (mostly methods).
       visitProperties(prototype, false, ((ObjectType) instanceType).getOwnPropertyNames(),

--- a/src/test/java/com/google/javascript/clutz/extending_function_field.d.ts
+++ b/src/test/java/com/google/javascript/clutz/extending_function_field.d.ts
@@ -1,0 +1,42 @@
+declare namespace ಠ_ಠ.clutz.a {
+  function messesWithB (b : ಠ_ಠ.clutz.ns.B ) : void ;
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'a.messesWithB'): typeof ಠ_ಠ.clutz.a.messesWithB;
+}
+declare module 'goog:a.messesWithB' {
+  import alias = ಠ_ಠ.clutz.a.messesWithB;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.ns {
+  class A extends A_Instance {
+  }
+  class A_Instance {
+    private noStructuralTyping_: any;
+    fn ( ) : void ;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'ns.A'): typeof ಠ_ಠ.clutz.ns.A;
+}
+declare module 'goog:ns.A' {
+  import alias = ಠ_ಠ.clutz.ns.A;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.ns {
+  class B extends B_Instance {
+  }
+  class B_Instance extends ಠ_ಠ.clutz.ns.A_Instance {
+    //!! IMHO, it is a bug in closure that this property even appears.
+    //!! But we have to emit a field here, instead of method, to match
+    //!! the super type.
+    fn ( ) : void ;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'ns.B'): typeof ಠ_ಠ.clutz.ns.B;
+}
+declare module 'goog:ns.B' {
+  import alias = ಠ_ಠ.clutz.ns.B;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/extending_function_field.js
+++ b/src/test/java/com/google/javascript/clutz/extending_function_field.js
@@ -1,0 +1,24 @@
+goog.provide('a.messesWithB');
+goog.provide('ns.A');
+goog.provide('ns.B');
+
+/**
+ * @param {ns.B} b
+ */
+a.messesWithB = function(b) {
+  b.fn = function() {};
+}
+
+/**
+ * @constructor
+ */
+ns.A = function() {
+  /** @type {function():void} */
+  this.fn;
+}
+
+/**
+ * @constructor
+ * @extends {ns.A}
+ */
+ns.B = function() {};


### PR DESCRIPTION
It is possible that this is also a bug in closure, to consider the
inferred property as member of the derived class, and not part of the subclass.
In any case, clutz should generate a valid TS.