### PR TITLE
Avoid ConcurrentModificationException.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -382,9 +382,10 @@ public class DeclarationGenerator {
 
     // Enum values like Enum.A will appear as stand-alone symbols, but we do not need to emit them.
     externSymbolNames.removeAll(enumElementSymbols);
-    for (TypedVar symbol : externSymbols) {
-      if (enumElementSymbols.contains(symbol.getName())) {
-        externSymbols.remove(symbol);
+    Iterator<TypedVar> it = externSymbols.iterator();
+    while (it.hasNext()) {
+      if (enumElementSymbols.contains(it.next().getName())) {
+        it.remove();
       }
     }
 


### PR DESCRIPTION
It would probably be ideal to additionally test this, but the method itself is private and the calling method does not seem to have any tests yet. Please advice. 

Also, it seems subideal to have to iterate linearly through `externSymbols`, but that was already the case and I did not want to make this change larger than necessary.