### PR TITLE
Normalize template types names to support IObject# template keys.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/type_renaming_with_emit_platform_externs.d.ts
+++ b/src/test/java/com/google/javascript/clutz/type_renaming_with_emit_platform_externs.d.ts
@@ -8,8 +8,22 @@ declare namespace ಠ_ಠ.clutz {
   }
 }
 declare namespace ಠ_ಠ.clutz {
-  interface IArrayLike < VALUE2 > {
+  class Array < T > extends Array_Instance < T > {
+  }
+  class Array_Instance < T > implements IArrayLike < T > {
+    private noStructuralTyping_: any;
+    constructor ( ...var_args : any [] ) ;
+    [key: string]: any;
     length : number ;
+  }
+}
+declare namespace ಠ_ಠ.clutz {
+  interface IArrayLike < VALUE2 > extends IObject < number , VALUE2 > {
+    length : number ;
+  }
+}
+declare namespace ಠ_ಠ.clutz {
+  interface IObject < KEY1 , VALUE > {
   }
 }
 declare namespace ಠ_ಠ.clutz {
@@ -32,6 +46,14 @@ declare namespace ಠ_ಠ.clutz {
     [key: string]: any;
     item (index : number ) : T ;
     length : number ;
+  }
+}
+declare namespace ಠ_ಠ.clutz {
+  class Object extends Object_Instance {
+  }
+  class Object_Instance {
+    private noStructuralTyping_: any;
+    constructor (opt_value ? : any ) ;
   }
 }
 declare namespace ಠ_ಠ.clutz {

--- a/src/test/java/com/google/javascript/clutz/type_renaming_with_emit_platform_externs.externs.js
+++ b/src/test/java/com/google/javascript/clutz/type_renaming_with_emit_platform_externs.externs.js
@@ -5,7 +5,14 @@
  */
 
 /**
+ * @interface
+ * @template KEY1, VALUE1
+ */
+function IObject() {}
+
+/**
  * @record
+ * @extends {IObject<number, VALUE2>}
  * @template VALUE2
  */
 function IArrayLike() {}
@@ -54,10 +61,30 @@ function MessageEvent() {}
  */
 MessageEvent.prototype.data;
 
-
 /**
  * @interface
  * @template TYPE
  */
 function IThenable() {}
+
+/**
+ * @constructor
+ * @param {*=} opt_value
+ * @return {!Object}
+ */
+function Object(opt_value) {}
+
+/**
+ * @constructor
+ * @implements {IArrayLike<T>}
+ * @param {...*} var_args
+ * @return {!Array<?>}
+ * @template T
+ */
+function Array(var_args) {}
+
+/**
+ * @type {number}
+ */
+Array.prototype.length;
 


### PR DESCRIPTION
Closure compiler adds wrong TemplateType (like IObject#KEY or
IObject#Value) for sereval types. The goal of this change is to detect
and skip these TemplateTypes.