### PR TITLE
Best management of TemplateType.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -3,6 +3,8 @@ package com.google.javascript.clutz;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.any;
+import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Sets.newHashSet;
 import static com.google.javascript.rhino.jstype.JSTypeNative.ARRAY_TYPE;
 import static com.google.javascript.rhino.jstype.JSTypeNative.OBJECT_TYPE;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -14,7 +16,6 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
@@ -873,6 +874,9 @@ public class DeclarationGenerator {
   }
 
   private ObjectType getSuperType(FunctionType type) {
+    if (type == null) {
+      return null;
+    }
     ObjectType proto = type.getPrototype();
     if (proto == null) return null;
     ObjectType implicitProto = proto.getImplicitPrototype();
@@ -1067,7 +1071,9 @@ public class DeclarationGenerator {
         emit("{");
         indent();
         emitBreak();
-        visitProperties(ftype, true);
+        // we pass an empty set because static function can never refer to a TemplateType defined
+        // on the class
+        visitProperties(ftype, true, Collections.<String>emptySet());
         unindent();
         emit("}");
         emitBreak();
@@ -1112,7 +1118,8 @@ public class DeclarationGenerator {
       }
 
       boolean implementsIArrayLike = any(ftype.getAllImplementedInterfaces(), IS_IARRYLIKE);
-      visitObjectType(ftype, ftype.getPrototype(), implementsIArrayLike || ftype.isDict());
+      visitObjectType(ftype, ftype.getPrototype(), implementsIArrayLike || ftype.isDict(),
+          getTemplateTypeNames(ftype));
     }
 
     private void emitCommaSeparatedInterfaces(Iterator<ObjectType> it) {
@@ -1140,23 +1147,34 @@ public class DeclarationGenerator {
     }
 
     private void visitTemplateTypes(ObjectType type) {
+      visitTemplateTypes(type, Collections.<String>emptySet());
+    }
+
+    private void visitTemplateTypes(ObjectType type, Set<String> alreadyEmittedTemplateType) {
       if (type.hasAnyTemplateTypes() && !type.getTemplateTypeMap().isEmpty()) {
-        List<String> templateKeys = new ArrayList<>();
-        for (TemplateType templateType: type.getTemplateTypeMap().getTemplateKeys()) {
+        List<String> realTemplateType = new ArrayList<>();
+
+        for (TemplateType templateType : type.getTemplateTypeMap().getTemplateKeys()) {
           String displayName = templateType.getDisplayName();
+
+          // Some TemplateType are already defined in a upper level (on Type definitions for
+          // instance) and we want to avoid to hide them by emitting them again.
+          if (alreadyEmittedTemplateType.contains(displayName)) {
+            continue;
+          }
+
           if (displayName.contains("IObject#")) {
-            String normalizedName = normalizeIObjectTemplateName(type, displayName);
-            if (normalizedName != null) {
-              templateKeys.add(normalizedName);
-            }
-          } else {
-            templateKeys.add(displayName);
+            displayName = normalizeIObjectTemplateName(type, displayName);
+          }
+
+          if (displayName != null) {
+            realTemplateType.add(displayName);
           }
         }
 
-        if (!templateKeys.isEmpty()) {
+        if (!realTemplateType.isEmpty()) {
           emit("<");
-          emit(Joiner.on(" , ").join(templateKeys));
+          emit(Joiner.on(" , ").join(realTemplateType));
           emit(">");
         }
       }
@@ -1516,7 +1534,7 @@ public class DeclarationGenerator {
     }
 
     private void visitObjectType(FunctionType type, ObjectType prototype,
-                                 boolean emitIndexSignature) {
+        boolean emitIndexSignature, Set<String> classTemplateTypeNames) {
       emit("{");
       indent();
       emitBreak();
@@ -1531,7 +1549,7 @@ public class DeclarationGenerator {
       if (type.isConstructor() && (type).getParameters().iterator().hasNext()) {
         maybeEmitJsDoc(type.getJSDocInfo(), /* ignoreParams */ false);
         emit("constructor");
-        visitFunctionParameters(type, false);
+        visitFunctionParameters(type, false, classTemplateTypeNames);
         emit(";");
         emitBreak();
       }
@@ -1543,7 +1561,7 @@ public class DeclarationGenerator {
       checkArgument(instanceType.isObject(), "expected an ObjectType for this, but got "
           + instanceType + " which is a " + instanceType.getClass().getSimpleName());
       visitProperties((ObjectType) instanceType, false, Collections.<String>emptySet(),
-          superClassFields);
+          superClassFields, classTemplateTypeNames);
       // Bracket-style property access
       if (emitIndexSignature) {
         emit("[key: string]: any;");
@@ -1552,20 +1570,20 @@ public class DeclarationGenerator {
 
       // Prototype fields (mostly methods).
       visitProperties(prototype, false, ((ObjectType) instanceType).getOwnPropertyNames(),
-          superClassFields);
+          superClassFields, classTemplateTypeNames);
       // Statics are handled in INSTANCE_CLASS_SUFFIX class.
       unindent();
       emit("}");
       emitBreak();
     }
 
-    private void visitProperties(ObjectType objType, boolean isStatic) {
+    private void visitProperties(ObjectType objType, boolean isStatic, Set<String> templateTypeNames) {
       visitProperties(objType, isStatic, Collections.<String>emptySet(),
-          Collections.<String>emptySet());
+          Collections.<String>emptySet(), templateTypeNames);
     }
 
     private void visitProperties(ObjectType objType, boolean isStatic, Set<String> skipNames,
-                                 Set<String> forceProps) {
+        Set<String> forceProps, Set<String> classTemplateTypeNames) {
       for (String propName : getSortedPropertyNamesToEmit(objType)) {
         // Extern processing goes through all known symbols, thus statics that are representable as
         // a namespace, are skipped here and emitted as namespaces only.
@@ -1578,7 +1596,8 @@ public class DeclarationGenerator {
             || "constructor".equals(propName)) {
           continue;
         }
-        visitProperty(propName, objType, isStatic, forceProps.contains(propName));
+        visitProperty(propName, objType, isStatic, forceProps.contains(propName),
+            classTemplateTypeNames);
       }
     }
 
@@ -1604,16 +1623,18 @@ public class DeclarationGenerator {
         }
       }
       // visit prototype properties.
-      for (String field : superType.getConstructor().getPrototype().getOwnPropertyNames()) {
-        // getPropertyType works with non-owned property names, i.e. names from the prototype chain.
-        if (!superType.getPropertyType(field).isFunctionType()) {
-          fields.add(field);
+      if (superType.getConstructor() != null && superType.getConstructor().getPrototype() != null && superType.getConstructor().getPrototype().getOwnPropertyNames() != null) {
+        for (String field : superType.getConstructor().getPrototype().getOwnPropertyNames()) {
+          // getPropertyType works with non-owned property names, i.e. names from the prototype chain.
+          if (!superType.getPropertyType(field).isFunctionType()) {
+            fields.add(field);
+          }
         }
       }
     }
 
     private void visitProperty(String propName, ObjectType objType, boolean isStatic,
-                               boolean forcePropDeclaration) {
+        boolean forcePropDeclaration, Set<String> classTemplateTypeNames) {
       JSType propertyType = objType.getPropertyType(propName);
       // Some symbols might be emitted as provides, so don't duplicate them
       String qualifiedName = objType.getDisplayName() + "." + propName;
@@ -1626,24 +1647,43 @@ public class DeclarationGenerator {
       // The static methods from the function prototype are provided by lib.d.ts.
       if (isStatic && isFunctionPrototypeProp(propName)) return;
       maybeEmitJsDoc(objType.getOwnPropertyJSDocInfo(propName), /* ignoreParams */ false);
-      emitProperty(propName, propertyType, isStatic, forcePropDeclaration);
+      emitProperty(propName, propertyType, isStatic, forcePropDeclaration, classTemplateTypeNames);
     }
 
     private void emitProperty(String propName, JSType propertyType, boolean isStatic,
-                              boolean forcePropDeclaration) {
+        boolean forcePropDeclaration, Set<String> classTemplateTypeNames) {
       if (isStatic) emit("static");
       emit(propName);
       if (!propertyType.isFunctionType() || forcePropDeclaration) {
         visitTypeDeclaration(propertyType, false);
       } else {
-        visitFunctionDeclaration((FunctionType) propertyType);
+        // Avoid to re-emit templateType define on the Type level if method is not static.
+        Set<String> objTemplateTypes =
+            isStatic
+              ? Collections.<String>emptySet()
+              : classTemplateTypeNames;
+        visitFunctionDeclaration((FunctionType) propertyType, objTemplateTypes);
       }
       emit(";");
       emitBreak();
     }
 
-    private void visitFunctionDeclaration(FunctionType ftype) {
-      visitFunctionParameters(ftype);
+    private Set<String> getTemplateTypeNames(ObjectType objType) {
+      return objType.getTemplateTypeMap() != null
+          ? newHashSet(
+              transform(
+                  objType.getTemplateTypeMap().getTemplateKeys(),
+                  new Function<JSType, String>() {
+                    @Override
+                    public String apply(JSType jsType) {
+                      return jsType != null ? jsType.getDisplayName() : "";
+                    }
+                  }))
+          : Collections.<String>emptySet();
+    }
+
+    private void visitFunctionDeclaration(FunctionType ftype, Set<String> objTemplateTypes) {
+      visitFunctionParameters(ftype, true, objTemplateTypes);
       JSType type = ftype.getReturnType();
       if (type != null) {
         emit(":");
@@ -1663,12 +1703,13 @@ public class DeclarationGenerator {
     }
 
     private void visitFunctionParameters(FunctionType ftype) {
-      visitFunctionParameters(ftype, true);
+      visitFunctionParameters(ftype, true, Sets.<String>newHashSet());
     }
 
-    private void visitFunctionParameters(FunctionType ftype, boolean emitTemplatizedTypes) {
+    private void visitFunctionParameters(FunctionType ftype, boolean emitTemplatizedTypes,
+        Set<String> alreadyEmittedTemplateType) {
       if (emitTemplatizedTypes) {
-        visitTemplateTypes(ftype);
+        visitTemplateTypes(ftype, alreadyEmittedTemplateType);
       }
       emit("(");
       Iterator<Node> parameters = ftype.getParameters().iterator();
@@ -1677,7 +1718,7 @@ public class DeclarationGenerator {
       if (functionSource != null) {
         // functionSource AST: FUNCTION -> (NAME, PARAM_LIST, BLOCK ...)
         Iterable<Node> parameterNodes = functionSource.getFirstChild().getNext().children();
-        names = Iterables.transform(parameterNodes, NODE_GET_STRING).iterator();
+        names = transform(parameterNodes, NODE_GET_STRING).iterator();
       }
       int paramCount = 0;
       while (parameters.hasNext()) {
@@ -1782,7 +1823,7 @@ public class DeclarationGenerator {
     private void visitFunctionExpression(String propName, FunctionType ftype) {
       emit("function");
       emit(propName);
-      visitFunctionDeclaration(ftype);
+      visitFunctionDeclaration(ftype, Collections.<String>emptySet());
       emit(";");
       emitBreak();
     }

--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -874,9 +874,6 @@ public class DeclarationGenerator {
   }
 
   private ObjectType getSuperType(FunctionType type) {
-    if (type == null) {
-      return null;
-    }
     ObjectType proto = type.getPrototype();
     if (proto == null) return null;
     ObjectType implicitProto = proto.getImplicitPrototype();

--- a/src/main/main.iml
+++ b/src/main/main.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/java" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/test/java/com/google/javascript/clutz/methods_generics.d.ts
+++ b/src/test/java/com/google/javascript/clutz/methods_generics.d.ts
@@ -1,1 +1,34 @@
-// intentionally empty. We are testing externs conversion
+declare namespace ಠ_ಠ.clutz.method_generics {
+  class Foo < T > extends Foo_Instance < T > {
+    /**
+     * Static method: T and R must be defined on the method in the resulting typescript code
+     */
+    static staticBar < T , R > (bar : R ) : T ;
+  }
+  class Foo_Instance < T > {
+    private noStructuralTyping_: any;
+    constructor (a : T ) ;
+    /**
+     * T is defined on the constructor and should not be redefined on the method level in the resulting
+     * typescript code. R should be defined on the method level.
+     */
+    bar < R > (foo : T , bar : R ) : void ;
+    /**
+     * T is defined on the constructor and should not be redefined on the method level in the resulting
+     * typescript code.
+     */
+    pop ( ) : T ;
+    /**
+     * T is defined on the constructor and should not be redefined on the method level in the resulting
+     * typescript code.
+     */
+    push (value : T ) : void ;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'method_generics'): typeof ಠ_ಠ.clutz.method_generics;
+}
+declare module 'goog:method_generics' {
+  import alias = ಠ_ಠ.clutz.method_generics;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/methods_generics.d.ts
+++ b/src/test/java/com/google/javascript/clutz/methods_generics.d.ts
@@ -1,0 +1,1 @@
+// intentionally empty. We are testing externs conversion

--- a/src/test/java/com/google/javascript/clutz/methods_generics.js
+++ b/src/test/java/com/google/javascript/clutz/methods_generics.js
@@ -1,1 +1,46 @@
-// intentionally empty. We are testing externs conversion
+goog.provide('method_generics');
+
+/**
+ * @param {T} a
+ * @template T
+ * @constructor
+ */
+method_generics.Foo = function(a) {};
+
+/**
+ * T is defined on the constructor and should not be redefined on the method level in the resulting
+ * typescript code.
+ *
+ * @return {T}
+ * @template T
+ */
+method_generics.Foo.prototype.pop = function() {};
+
+/**
+ * T is defined on the constructor and should not be redefined on the method level in the resulting
+ * typescript code.
+ *
+ * @param {T} value
+ * @template T
+ */
+method_generics.Foo.prototype.push = function(value) {};
+
+/**
+ * T is defined on the constructor and should not be redefined on the method level in the resulting
+ * typescript code. R should be defined on the method level.
+ *
+ * @param {T} foo
+ * @param {R} bar
+ * @template T,R
+ */
+method_generics.Foo.prototype.bar = function(foo, bar) {};
+
+
+/**
+ * Static method: T and R must be defined on the method in the resulting typescript code
+ *
+ * @param {R} bar
+ * @return {T}
+ * @template T,R
+ */
+method_generics.Foo.staticBar = function(bar) {};

--- a/src/test/java/com/google/javascript/clutz/methods_generics.js
+++ b/src/test/java/com/google/javascript/clutz/methods_generics.js
@@ -1,0 +1,1 @@
+// intentionally empty. We are testing externs conversion


### PR DESCRIPTION
Don't redefine TemplateType at method level if the same TemplateType is defined on the declaring Type.