### PR TITLE
Best management of IndexSignature.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -1585,7 +1585,7 @@ public class DeclarationGenerator {
 
     /**
      * Returns all interfaces implemented by a class and any
-     * superclasses for any of those interfaces.
+     * superinterface for any of those interfaces.
      */
     public Iterable<ObjectType> getAllDirectlyImplementedInterfaces(FunctionType type) {
       Set<ObjectType> interfaces = new HashSet<>();

--- a/src/resources/closure.lib.d.ts
+++ b/src/resources/closure.lib.d.ts
@@ -20,6 +20,8 @@ declare namespace ಠ_ಠ.clutz {
    * type position PrivateType is used.
    */
   interface PrivateInterface {}
+
+  interface IObject<KEY1, VALUE> {}
 }
 
 // Will be extended if base.js is a dependency.

--- a/src/test/java/com/google/javascript/clutz/dict.d.ts
+++ b/src/test/java/com/google/javascript/clutz/dict.d.ts
@@ -3,7 +3,7 @@ declare namespace ಠ_ಠ.clutz.dict {
   }
   class ClassWithDottedProperties_Instance {
     private noStructuralTyping_: any;
-    [key: string]: any;
+    [ key: string ]: any ;
     foo : number ;
   }
   class DictClass extends DictClass_Instance {
@@ -11,7 +11,7 @@ declare namespace ಠ_ಠ.clutz.dict {
   class DictClass_Instance {
     private noStructuralTyping_: any;
     constructor (n : any ) ;
-    [key: string]: any;
+    [ key: string ]: any ;
     foo ( ) : void ;
   }
   var typed : { a : ( ...a : any [] ) => any } ;

--- a/src/test/java/com/google/javascript/clutz/extends_arraylike_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/extends_arraylike_with_platform.d.ts
@@ -3,7 +3,7 @@ declare namespace ಠ_ಠ.clutz.extend.arraylike {
   }
   class A_Instance implements ArrayLike < any > {
     private noStructuralTyping_: any;
-    [key: string]: any;
+    [ key: number ]: any ;
     length : number ;
   }
 }
@@ -19,7 +19,7 @@ declare namespace ಠ_ಠ.clutz.extend.arraylike {
   }
   class B_Instance implements ಠ_ಠ.clutz.extend.arraylike.I {
     private noStructuralTyping_: any;
-    [key: string]: any;
+    [ key: number ]: any ;
     length : number ;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/generics.d.ts
+++ b/src/test/java/com/google/javascript/clutz/generics.d.ts
@@ -26,7 +26,7 @@ declare namespace ಠ_ಠ.clutz.generics {
   var fooMissingOneTypeParam : ಠ_ಠ.clutz.generics.Foo < string , any > ;
   function genericFunction < T > (a : T ) : T ;
   function identity < T > (a : T ) : T ;
-  function objectWithGenericKeyType < K , V > (obj : { [ /* warning: coerced from K */ s: string ]: V } ) : void ;
+  function objectWithGenericKeyType < K , V > (obj : { [ /* warning: coerced from K */ key: string ]: V } ) : void ;
 }
 declare namespace ಠ_ಠ.clutz.goog {
   function require(name: 'generics'): typeof ಠ_ಠ.clutz.generics;

--- a/src/test/java/com/google/javascript/clutz/index_signature_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/index_signature_with_platform.d.ts
@@ -25,6 +25,19 @@ declare namespace ಠ_ಠ.clutz.index_signature {
     private noStructuralTyping_: any;
     [ key: string ]: T ;
   }
+  interface InterfaceExtendingIArrayLike extends ArrayLike < string > {
+  }
+  class ShouldContainIndexSignature extends ShouldContainIndexSignature_Instance {
+  }
+  class ShouldContainIndexSignature_Instance implements ಠ_ಠ.clutz.index_signature.InterfaceExtendingIArrayLike {
+    private noStructuralTyping_: any;
+    [ key: number ]: string ;
+    length : number ;
+  }
+  class ShouldNotContainIndexSignature extends ShouldNotContainIndexSignature_Instance {
+  }
+  class ShouldNotContainIndexSignature_Instance extends ಠ_ಠ.clutz.index_signature.ImplementsIArrayLike {
+  }
   class SomeType extends SomeType_Instance {
   }
   class SomeType_Instance {

--- a/src/test/java/com/google/javascript/clutz/index_signature_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/index_signature_with_platform.d.ts
@@ -6,14 +6,6 @@ declare namespace ಠ_ಠ.clutz.index_signature {
     [ key: number ]: string ;
     length : number ;
   }
-  class ImplementsIArrayLikeAndIObject extends ImplementsIArrayLikeAndIObject_Instance {
-  }
-  class ImplementsIArrayLikeAndIObject_Instance implements ArrayLike < ಠ_ಠ.clutz.index_signature.SomeType > , IObject < string , ಠ_ಠ.clutz.index_signature.SomeType > {
-    private noStructuralTyping_: any;
-    [ key: number ]: ಠ_ಠ.clutz.index_signature.SomeType ;
-    [ key: string ]: ಠ_ಠ.clutz.index_signature.SomeType ;
-    length : number ;
-  }
   class ImplementsIArrayLikeWithGeneric < T > extends ImplementsIArrayLikeWithGeneric_Instance < T > {
   }
   class ImplementsIArrayLikeWithGeneric_Instance < T > implements ArrayLike < T > {

--- a/src/test/java/com/google/javascript/clutz/index_signature_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/index_signature_with_platform.d.ts
@@ -1,0 +1,48 @@
+declare namespace ಠ_ಠ.clutz.index_signature {
+  class ImplementsIArrayLike extends ImplementsIArrayLike_Instance {
+  }
+  class ImplementsIArrayLike_Instance implements ArrayLike < string > {
+    private noStructuralTyping_: any;
+    [ key: number ]: string ;
+    length : number ;
+  }
+  class ImplementsIArrayLikeAndIObject extends ImplementsIArrayLikeAndIObject_Instance {
+  }
+  class ImplementsIArrayLikeAndIObject_Instance implements ArrayLike < ಠ_ಠ.clutz.index_signature.SomeType > , IObject < string , ಠ_ಠ.clutz.index_signature.SomeType > {
+    private noStructuralTyping_: any;
+    [ key: number ]: ಠ_ಠ.clutz.index_signature.SomeType ;
+    [ key: string ]: ಠ_ಠ.clutz.index_signature.SomeType ;
+    length : number ;
+  }
+  class ImplementsIArrayLikeWithGeneric < T > extends ImplementsIArrayLikeWithGeneric_Instance < T > {
+  }
+  class ImplementsIArrayLikeWithGeneric_Instance < T > implements ArrayLike < T > {
+    private noStructuralTyping_: any;
+    [ key: number ]: T ;
+    length : number ;
+  }
+  class ImplementsIObject extends ImplementsIObject_Instance {
+  }
+  class ImplementsIObject_Instance implements IObject < string , number > {
+    private noStructuralTyping_: any;
+    [ key: string ]: number ;
+  }
+  class ImplementsIObjectWithGeneric < T > extends ImplementsIObjectWithGeneric_Instance < T > {
+  }
+  class ImplementsIObjectWithGeneric_Instance < T > implements IObject < string , T > {
+    private noStructuralTyping_: any;
+    [ key: string ]: T ;
+  }
+  class SomeType extends SomeType_Instance {
+  }
+  class SomeType_Instance {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'index_signature'): typeof ಠ_ಠ.clutz.index_signature;
+}
+declare module 'goog:index_signature' {
+  import alias = ಠ_ಠ.clutz.index_signature;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/index_signature_with_platform.js
+++ b/src/test/java/com/google/javascript/clutz/index_signature_with_platform.js
@@ -8,17 +8,6 @@ index_signature.SomeType = function() {}
 
 /**
  * @constructor
- * @implements {IArrayLike<index_signature.SomeType>}
- * @implements {IObject<string, index_signature.SomeType>}
- * @return {!index_signature.ImplementsIArrayLikeAndIObject}
- */
-index_signature.ImplementsIArrayLikeAndIObject = function() {}
-
-/** @type {number} */
-index_signature.ImplementsIArrayLikeAndIObject.prototype.length;
-
-/**
- * @constructor
  * @implements {IArrayLike<string>}
  * @return {!index_signature.ImplementsIArrayLike}
  */

--- a/src/test/java/com/google/javascript/clutz/index_signature_with_platform.js
+++ b/src/test/java/com/google/javascript/clutz/index_signature_with_platform.js
@@ -1,0 +1,55 @@
+goog.provide('index_signature');
+
+/**
+ * @constructor
+ * @return {!index_signature.SomeType}
+ */
+index_signature.SomeType = function() {}
+
+/**
+ * @constructor
+ * @implements {IArrayLike<index_signature.SomeType>}
+ * @implements {IObject<string, index_signature.SomeType>}
+ * @return {!index_signature.ImplementsIArrayLikeAndIObject}
+ */
+index_signature.ImplementsIArrayLikeAndIObject = function() {}
+
+/** @type {number} */
+index_signature.ImplementsIArrayLikeAndIObject.prototype.length;
+
+/**
+ * @constructor
+ * @implements {IArrayLike<string>}
+ * @return {!index_signature.ImplementsIArrayLike}
+ */
+index_signature.ImplementsIArrayLike = function() {}
+
+/** @type {number} */
+index_signature.ImplementsIArrayLike.prototype.length;
+
+/**
+ * @constructor
+ * @implements {IObject<string, number>}
+ * @return {!index_signature.ImplementsIObject}
+ */
+index_signature.ImplementsIObject = function() {}
+
+/**
+ * @constructor
+ * @template T
+ * @implements {IArrayLike<T>}
+ * @return {!index_signature.ImplementsIArrayLikeWithGeneric}
+ */
+index_signature.ImplementsIArrayLikeWithGeneric = function() {}
+
+/** @type {number} */
+index_signature.ImplementsIArrayLikeWithGeneric.prototype.length;
+
+/**
+ * @constructor
+ * @template T
+ * @implements {IObject<string, T>}
+ * @return {!index_signature.ImplementsIObjectWithGeneric}
+ */
+index_signature.ImplementsIObjectWithGeneric = function() {}
+

--- a/src/test/java/com/google/javascript/clutz/index_signature_with_platform.js
+++ b/src/test/java/com/google/javascript/clutz/index_signature_with_platform.js
@@ -2,14 +2,12 @@ goog.provide('index_signature');
 
 /**
  * @constructor
- * @return {!index_signature.SomeType}
  */
 index_signature.SomeType = function() {}
 
 /**
  * @constructor
  * @implements {IArrayLike<string>}
- * @return {!index_signature.ImplementsIArrayLike}
  */
 index_signature.ImplementsIArrayLike = function() {}
 
@@ -19,7 +17,6 @@ index_signature.ImplementsIArrayLike.prototype.length;
 /**
  * @constructor
  * @implements {IObject<string, number>}
- * @return {!index_signature.ImplementsIObject}
  */
 index_signature.ImplementsIObject = function() {}
 
@@ -27,7 +24,6 @@ index_signature.ImplementsIObject = function() {}
  * @constructor
  * @template T
  * @implements {IArrayLike<T>}
- * @return {!index_signature.ImplementsIArrayLikeWithGeneric}
  */
 index_signature.ImplementsIArrayLikeWithGeneric = function() {}
 
@@ -38,14 +34,12 @@ index_signature.ImplementsIArrayLikeWithGeneric.prototype.length;
  * @constructor
  * @template T
  * @implements {IObject<string, T>}
- * @return {!index_signature.ImplementsIObjectWithGeneric}
  */
 index_signature.ImplementsIObjectWithGeneric = function() {}
 
 /**
  * @constructor
  * @extends {index_signature.ImplementsIArrayLike}
- * @return {!index_signature.ShouldNotContainIndexSignature}
  */
 index_signature.ShouldNotContainIndexSignature = function() {}
 
@@ -58,7 +52,6 @@ index_signature.InterfaceExtendingIArrayLike = function() {};
 /**
  * @constructor
  * @implements {index_signature.InterfaceExtendingIArrayLike}
- * @return {!index_signature.ShouldContainIndexSignature}
  */
 index_signature.ShouldContainIndexSignature = function() {}
 

--- a/src/test/java/com/google/javascript/clutz/index_signature_with_platform.js
+++ b/src/test/java/com/google/javascript/clutz/index_signature_with_platform.js
@@ -42,3 +42,25 @@ index_signature.ImplementsIArrayLikeWithGeneric.prototype.length;
  */
 index_signature.ImplementsIObjectWithGeneric = function() {}
 
+/**
+ * @constructor
+ * @extends {index_signature.ImplementsIArrayLike}
+ * @return {!index_signature.ShouldNotContainIndexSignature}
+ */
+index_signature.ShouldNotContainIndexSignature = function() {}
+
+/**
+ * @interface
+ * @extends {IArrayLike<string>}
+ */
+index_signature.InterfaceExtendingIArrayLike = function() {};
+
+/**
+ * @constructor
+ * @implements {index_signature.InterfaceExtendingIArrayLike}
+ * @return {!index_signature.ShouldContainIndexSignature}
+ */
+index_signature.ShouldContainIndexSignature = function() {}
+
+/** @type {number} */
+index_signature.ShouldContainIndexSignature.prototype.length;

--- a/src/test/java/com/google/javascript/clutz/type_renaming_with_emit_platform_externs.d.ts
+++ b/src/test/java/com/google/javascript/clutz/type_renaming_with_emit_platform_externs.d.ts
@@ -3,7 +3,7 @@ declare namespace ಠ_ಠ.clutz {
   }
   class Arguments_Instance < T > implements IArrayLike < T > {
     private noStructuralTyping_: any;
-    [key: string]: any;
+    [ key: number ]: T ;
     length : number ;
   }
 }
@@ -13,7 +13,7 @@ declare namespace ಠ_ಠ.clutz {
   class Array_Instance < T > implements IArrayLike < T > {
     private noStructuralTyping_: any;
     constructor ( ...var_args : any [] ) ;
-    [key: string]: any;
+    [ key: number ]: T ;
     length : number ;
   }
 }
@@ -43,7 +43,7 @@ declare namespace ಠ_ಠ.clutz {
   }
   class NodeList_Instance < T > implements IArrayLike < T > {
     private noStructuralTyping_: any;
-    [key: string]: any;
+    [ key: number ]: T ;
     item (index : number ) : T ;
     length : number ;
   }

--- a/src/test/java/com/google/javascript/clutz/types.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types.d.ts
@@ -14,7 +14,7 @@ declare namespace ಠ_ಠ.clutz.types {
    * marked const to appear in `compiler.getTopScope().getAllSymbols()`
    */
   var inferredobj : Object ;
-  var j : { [ n: number ]: string } ;
+  var j : { [ key: number ]: string } ;
   var recordType : { a : string , b : any } ;
   var recordTypeOptional : { a : string , optional ? : string } ;
 }


### PR DESCRIPTION
The IndexSignature is supported in closure by implementing IObject interface. IObject has two template types, the first one determines the type of the key and the second one determines the type of the returned value.

Note that `IArrayLike<T>` extends `IObject<number, T>` but closure compiler considers these two interfaces as being independents and a Type in closure can implements both interfaces. We have to process them separately.