### PR TITLE
Adding a package.json, so that gradle build succeeds.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "clutz",
+  "version": "0.0.0"
+}


### PR DESCRIPTION
Some of the tests depend on the npm TypeScript package being installed.
There is no package.json, so npm fails to install TypeScript. This adds
a very minimal pakage.json, so that npm can install TypeScript and gradle
build can succeed.

Resolves: #288