### PR TITLE
Add option to specify application entry points to the closure compiler.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -41,6 +41,13 @@ public class Options {
       usage = "emits platform externs, instead of omitting them in favor of TS lib.d.ts")
   boolean emitPlatformExterns;
 
+  @Option(name = "--closure_entry_points",
+      usage = "only generate output for the given entry points to the program. Must be" +
+              " goog.provide'd symbols.",
+      metaVar = "ENTRYPOINT...",
+      handler = StringArrayOptionHandler.class)
+  List<String> entryPoints = new ArrayList<>();
+
   @Argument
   List<String> arguments = new ArrayList<>();
 
@@ -49,6 +56,10 @@ public class Options {
   public CompilerOptions getCompilerOptions() {
     final CompilerOptions options = new CompilerOptions();
     options.setClosurePass(true);
+
+    if (!this.entryPoints.isEmpty()) {
+      options.setManageClosureDependencies(this.entryPoints);
+    }
 
     // All diagnostics are WARNINGs (or off) and thus ignored unless debug == true.
     // Only report issues (and fail for them) that are specifically causing problems for Clutz.

--- a/src/test/java/com/google/javascript/clutz/OptionsTest.java
+++ b/src/test/java/com/google/javascript/clutz/OptionsTest.java
@@ -42,6 +42,17 @@ public class OptionsTest {
   }
 
   @Test
+  public void testClosureEntryPoint() throws Exception {
+    Options opts = new Options(new String[] {
+            "foo.js", "--closure_entry_points", "ns.entryPoint1", "ns.entryPoint2", "--externs", "extern1.js", "extern2.js", "-o", "output.d.ts"
+    });
+    assertThat(opts.arguments).containsExactly("foo.js");
+    assertThat(opts.entryPoints).containsExactly("ns.entryPoint1", "ns.entryPoint2");
+    assertThat(opts.externs).containsExactly("extern1.js", "extern2.js").inOrder();
+    assertThat(opts.output).isEqualTo("output.d.ts");
+  }
+
+  @Test
   public void testHandleEmptyCommandLine() throws Exception {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     System.setErr(new PrintStream(out));


### PR DESCRIPTION
I noticed support for depgraphs, but for those of us who do not use bazel or blaze, I added an option to provide an entry point to the closure compiler. This allows you to easily pass in all your js sources, but only generate definitions for the specified entry point.

I'm open to suggestions for better ways of doing this.

