### PR TITLE
Ignore private annotation for constructors

### DIFF
--- a/src/test/java/com/google/javascript/clutz/nested_namespaces.d.ts
+++ b/src/test/java/com/google/javascript/clutz/nested_namespaces.d.ts
@@ -23,10 +23,17 @@ declare module 'goog:nested.NotNestedEither' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.nested {
-  var PrivateC__clutz_alias : ಠ_ಠ.clutz.PrivateType;
+  class PrivateC extends PrivateC_Instance {
+  }
+  class PrivateC_Instance {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'nested.PrivateC'): typeof ಠ_ಠ.clutz.nested.PrivateC;
 }
 declare module 'goog:nested.PrivateC' {
-  import alias = ಠ_ಠ.clutz.nested.PrivateC__clutz_alias;
+  import alias = ಠ_ಠ.clutz.nested.PrivateC;
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.nested.PrivateC {
@@ -42,7 +49,7 @@ declare module 'goog:nested.PrivateC.Enum' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.nested {
-  var foo__clutz_alias : ಠ_ಠ.clutz.PrivateType ;
+  var foo__clutz_alias : ಠ_ಠ.clutz.nested.PrivateC ;
 }
 declare namespace ಠ_ಠ.clutz.goog {
   function require(name: 'nested.foo'): typeof ಠ_ಠ.clutz.nested.foo__clutz_alias;

--- a/src/test/java/com/google/javascript/clutz/private_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/private_class.d.ts
@@ -1,7 +1,7 @@
 declare namespace ಠ_ಠ.clutz.privateclass {
   class A extends A_Instance {
   }
-  class A_Instance extends ಠ_ಠ.clutz.PrivateClass {
+  class A_Instance extends ಠ_ಠ.clutz.privateclass.P_Instance {
   }
   class B extends B_Instance {
   }
@@ -9,6 +9,11 @@ declare namespace ಠ_ಠ.clutz.privateclass {
     private noStructuralTyping_: any;
   }
   interface I extends ಠ_ಠ.clutz.PrivateInterface {
+  }
+  class P extends P_Instance {
+  }
+  class P_Instance {
+    private noStructuralTyping_: any;
   }
 }
 declare namespace ಠ_ಠ.clutz.goog {

--- a/src/test/java/com/google/javascript/clutz/private_class.js
+++ b/src/test/java/com/google/javascript/clutz/private_class.js
@@ -3,8 +3,9 @@ goog.provide('privateclass');
 /**
  * @constructor
  * @private
+ * @param {number} parameter
  */
-privateclass.P = function() {};
+privateclass.P = function(parameter) {};
 
 /**
  * @interface

--- a/src/test/java/com/google/javascript/clutz/private_provided_single_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/private_provided_single_class.d.ts
@@ -1,5 +1,12 @@
 declare namespace ಠ_ಠ.clutz.foo {
-  var PrivateClass : ಠ_ಠ.clutz.PrivateType;
+  class PrivateClass extends PrivateClass_Instance {
+  }
+  class PrivateClass_Instance {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'foo.PrivateClass'): typeof ಠ_ಠ.clutz.foo.PrivateClass;
 }
 declare module 'goog:foo.PrivateClass' {
   import alias = ಠ_ಠ.clutz.foo.PrivateClass;

--- a/src/test/java/com/google/javascript/clutz/private_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/private_type.d.ts
@@ -24,6 +24,22 @@ declare module 'goog:privatetype.Foo' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.privatetype {
+  class X_ extends X__Instance {
+    static staticMethod ( ) : void ;
+  }
+  class X__Instance {
+    private noStructuralTyping_: any;
+    method ( ) : void ;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  function require(name: 'privatetype.X_'): typeof ಠ_ಠ.clutz.privatetype.X_;
+}
+declare module 'goog:privatetype.X_' {
+  import alias = ಠ_ಠ.clutz.privatetype.X_;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.privatetype {
   var enumUser : ಠ_ಠ.clutz.PrivateType ;
 }
 declare namespace ಠ_ಠ.clutz.goog {
@@ -34,7 +50,7 @@ declare module 'goog:privatetype.enumUser' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.privatetype {
-  var user : ಠ_ಠ.clutz.PrivateType ;
+  var user : ಠ_ಠ.clutz.privatetype.X_ ;
 }
 declare namespace ಠ_ಠ.clutz.goog {
   function require(name: 'privatetype.user'): typeof ಠ_ಠ.clutz.privatetype.user;

--- a/src/test/java/com/google/javascript/clutz/private_type.js
+++ b/src/test/java/com/google/javascript/clutz/private_type.js
@@ -2,6 +2,7 @@ goog.provide('privatetype');
 goog.provide('privatetype.enumUser');
 goog.provide('privatetype.user');
 goog.provide('privatetype.Foo');
+goog.provide('privatetype.X_');
 
 /**
  * @enum {string}
@@ -17,6 +18,10 @@ privatetype.user = new privatetype.X_();
 
 /** @constructor @private */
 privatetype.X_ = function() {};
+
+privatetype.X_.staticMethod = function() {};
+
+privatetype.X_.prototype.method = function() {};
 
 /** @constructor */
 privatetype.Foo = function(a) {}

--- a/src/test/java/com/google/javascript/clutz/privates.d.ts
+++ b/src/test/java/com/google/javascript/clutz/privates.d.ts
@@ -1,4 +1,9 @@
 declare namespace ಠ_ಠ.clutz.priv {
+  class PrivateClazz extends PrivateClazz_Instance {
+  }
+  class PrivateClazz_Instance {
+    private noStructuralTyping_: any;
+  }
   class PublicClass extends PublicClass_Instance {
   }
   class PublicClass_Instance {
@@ -17,6 +22,13 @@ declare namespace ಠ_ಠ.clutz.priv2 {
   class PublicClass extends PublicClass_Instance {
   }
   class PublicClass_Instance {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.priv2.PublicClass {
+  class PrivateNestedClass_ extends PrivateNestedClass__Instance {
+  }
+  class PrivateNestedClass__Instance {
     private noStructuralTyping_: any;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/types_externs_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types_externs_with_platform.d.ts
@@ -74,7 +74,11 @@ declare namespace ಠ_ಠ.clutz.functionNamespace {
   function dom (nodeOrEvent : Node | null | GlobalEvent ) : functionNamespaceHelperClass ;
 }
 declare namespace ಠ_ಠ.clutz.functionNamespace {
-  var privateClass : ಠ_ಠ.clutz.PrivateType;
+  class privateClass extends privateClass_Instance {
+  }
+  class privateClass_Instance {
+    private noStructuralTyping_: any;
+  }
 }
 declare namespace ಠ_ಠ.clutz {
   class functionNamespaceHelperClass extends functionNamespaceHelperClass_Instance {


### PR DESCRIPTION
I ended up adding an `isConstructor` check in many places where there is an `isPrivate` check. I also made it so it doesn't emit the constructor if it is private. It doesn't prevent calling new on a private class but I felt that was the logic thing to do until typescript supports private constructors.