### PR TITLE
Remove call to Token.name()

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
@@ -296,8 +296,7 @@ public final class TypeAnnotationPass extends AbstractPostOrderCallback implemen
           return optionalParam == null ? null : optionalParameter(optionalParam);
         default:
           throw new IllegalArgumentException(
-              "Unsupported node type: " + Token.name(n.getType())
-                  + " " + n.toStringTree());
+              "Unsupported node type:\n" + n.toStringTree());
       }
     }
 


### PR DESCRIPTION
Token.name() is deprecated and is going away soon. And, you don't need it anyway because the toStringTree output shows you the node type.