### PR TITLE
feat: use system clang-format unless testing.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,11 @@ dependencies {
   testCompile 'com.google.truth:truth:0.25'
 }
 
+tasks.withType(Test) {
+  systemProperty 'gents.clangFormat',
+                 System.getProperty('gents.clangFormat', 'node_modules/.bin/clang-format')
+}
+
 test {
   testLogging {
     exceptionFormat = 'full'

--- a/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
+++ b/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
@@ -35,11 +35,12 @@ import org.kohsuke.args4j.CmdLineException;
  */
 public class TypeScriptGenerator {
   /**
-   * Command line clang-format string to format stdin.
-   * The filename 'a.ts' is only used to inform clang-format of the file type (TS).
+   * Command line clang-format string to format stdin. The filename 'a.ts' is only used to inform
+   * clang-format of the file type (TS).
    */
-  private static final String[] CLANG_FORMAT = {"node_modules/.bin/clang-format",
-      "-assume-filename=a.ts", "-style=Google"};
+  private static final String[] CLANG_FORMAT = {
+    "clang-format", "-assume-filename=a.ts", "-style=Google"
+  };
 
   static {
     // In some environments (Mac OS X programs started from Finder, like your IDE) PATH does


### PR DESCRIPTION
When running for real, gents should use the local clang-format that the user is using.
Only during tests we should use the node_modules installed version.