### PR TITLE
emit all constructor fields as class fields

### DIFF
--- a/src/test/java/com/google/javascript/gents/singleTests/classes.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/classes.ts
@@ -2,6 +2,7 @@
  * Anonymous class
  */
 class A {
+  a: any;
   constructor(a: number) {
     this.a = a;
   }
@@ -11,6 +12,8 @@ class A {
  * Named class
  */
 class B {
+  a: any;
+  b: any;
   constructor(a, b) {
     this.a = a;
     this.b = b;
@@ -21,6 +24,7 @@ class B {
  * Named class extension
  */
 class C extends A {
+  b: any;
   constructor(a, b) {
     super(a);
     this.b = b;
@@ -31,6 +35,7 @@ class C extends A {
  * Anonymous class extension
  */
 class D extends B {
+  c: any;
   constructor(a, b, c) {
     super(a, b);
     this.c = c;

--- a/src/test/java/com/google/javascript/gents/singleTests/fields.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/fields.ts
@@ -15,5 +15,7 @@ class A {
     let y = 1;
     this.z = y + 1;
   }
-  foo() { this.x = this.a; }
+  foo() {
+    this.x = this.a;
+  }
 }

--- a/src/test/java/com/google/javascript/gents/singleTests/fields.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/fields.ts
@@ -7,14 +7,13 @@ class A {
   z: number;
   c: number = 4;
   d: string;
+  // These are undeclared fields
+  u: any;
+  n: any = 12;
+  x: any;
   constructor(public a: number) {
     let y = 1;
     this.z = y + 1;
   }
-  foo() {
-    // These are undeclared fields
-    this.u;
-    this.n = 12;
-    this.x = this.a;
-  }
+  foo() { this.x = this.a; }
 }

--- a/src/test/java/com/google/javascript/gents/singleTests/proto_methods.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/proto_methods.ts
@@ -3,6 +3,7 @@ let goog: any = {};
  * Nested anonymous class in ES6 syntax
  */
 goog.A = class {
+  a: any;
   constructor(a: number) {
     this.a = a;
   }
@@ -18,6 +19,7 @@ goog.A = class {
  * Named class extension
  */
 class B extends goog.A {
+  b: any;
   constructor(a: number, b: boolean) {
     super(a);
     this.b = b;

--- a/src/test/java/com/google/javascript/gents/singleTests/static_methods.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/static_methods.ts
@@ -1,5 +1,6 @@
 let goog: any = {};
 goog.A = class {
+  a: any;
   constructor(a: number) {
     this.a = a;
   }


### PR DESCRIPTION
Even fields which don't have type information should be emitted as class fields.

Partially addresses #345

Migrating from phabricator