### PR TITLE
externsMap allows a type alias for 'any' to be supplied

### DIFF
--- a/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
+++ b/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
@@ -108,7 +108,6 @@ public class GentsCodeGenerator extends CodeGenerator {
           add(anyTypeName);
           return true;
         }
-
         return false;
       default:
         return false;

--- a/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
+++ b/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
@@ -5,17 +5,20 @@ import com.google.javascript.jscomp.CodeGenerator;
 import com.google.javascript.jscomp.CompilerOptions;
 import com.google.javascript.rhino.JSDocInfo.Visibility;
 import com.google.javascript.rhino.Node;
+import java.util.Map;
 
 /**
  * Code generator for gents to add TypeScript specific code generation.
  */
 public class GentsCodeGenerator extends CodeGenerator {
   private final NodeComments nodeComments;
+  private final Map<String, String> externsMap;
 
   protected GentsCodeGenerator(CodeConsumer consumer, CompilerOptions options,
-      NodeComments nodeComments) {
+      NodeComments nodeComments, Map<String, String> externsMap) {
     super(consumer, options);
     this.nodeComments = nodeComments;
+    this.externsMap = externsMap;
   }
 
   @Override
@@ -97,6 +100,15 @@ public class GentsCodeGenerator extends CodeGenerator {
             }
           }
         }
+        return false;
+      case ANY_TYPE:
+        // Check the externsMap for an alias to use in place of "any"
+        String anyTypeName = externsMap.get("any");
+        if (anyTypeName != null) {
+          add(anyTypeName);
+          return true;
+        }
+
         return false;
       default:
         return false;

--- a/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
+++ b/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
@@ -177,7 +177,7 @@ public class TypeScriptGenerator {
       CodeGeneratorFactory factory = new CodeGeneratorFactory() {
         @Override
         public CodeGenerator getCodeGenerator(Format outputFormat, CodeConsumer cc) {
-          return new GentsCodeGenerator(cc, compilerOpts, comments);
+          return new GentsCodeGenerator(cc, compilerOpts, comments, opts.externsMap);
         }
       };
 

--- a/src/test/java/com/google/javascript/gents/singleTests/externs_map.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/externs_map.js
@@ -3,3 +3,6 @@ let d = function() {};
 
 /** @type {jQuery} */
 let j = $('#foo');
+
+/** @type {*} */
+let o = Object();

--- a/src/test/java/com/google/javascript/gents/singleTests/externs_map.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/externs_map.ts
@@ -1,2 +1,3 @@
 let d: ng.IDirective = function() {};
 let j: JQuery = $('#foo');
+let o: OldNoType = Object();

--- a/src/test/java/com/google/javascript/gents/test_externs_map.json
+++ b/src/test/java/com/google/javascript/gents/test_externs_map.json
@@ -1,4 +1,5 @@
 {
   "jQuery": "JQuery"
   , "angular.Directive": "ng.IDirective"
+  , "any": "OldNoType"
 }


### PR DESCRIPTION
This supports the case where you want to be able to audit your uses of "any" after conversion, by aliasing them to something like `OldNoType`.

Also adds an extension point in TypescriptGeneratorTests to allow certain tests to be run with a different set of options from the other tests.

fixes #328