### PR TITLE
feat: interfaces

### DIFF
--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -24,8 +24,8 @@ public final class CommentLinkingPass implements CompilerPass {
    * Some regexes contain an empty capture group for uniform handling.
    */
   private static final Pattern[] COMMENT_REPLACEMENTS = {
-      Pattern.compile("@constructor[ \t]*(?<keep>)"),
-      Pattern.compile("@(extends|type)[ \t]*(\\{.*\\})[ \t]*(?<keep>)"),
+      Pattern.compile("@(constructor|interface|record)[ \t]*(?<keep>)"),
+      Pattern.compile("@(extends|implements|type)[ \t]*(\\{.*\\})[ \t]*(?<keep>)"),
       Pattern.compile("@(private|protected|public|package|const)[ \t]*(\\{.*\\})?[ \t]*(?<keep>)"),
       // Removes @param and @return if there is no description
       Pattern.compile("@param[ \t]*(\\{.*\\})[ \t]*\\w+[ \t]*(?<keep>\\*\\/|\n)"),

--- a/src/main/java/com/google/javascript/gents/Options.java
+++ b/src/main/java/com/google/javascript/gents/Options.java
@@ -91,7 +91,7 @@ public class Options {
 
   private Map<String, String> getExternsMap() throws FileNotFoundException {
     if (this.externsMapFile != null) {
-      Type mapType = new TypeToken<Map<String, String>>(){}.getType();
+      Type mapType = new TypeToken<Map<String, String>>() { /* empty */ }.getType();
       JsonReader reader = new JsonReader(new FileReader(externsMapFile));
       return new Gson().fromJson(reader, mapType);
     } else {

--- a/src/main/java/com/google/javascript/gents/StyleFixPass.java
+++ b/src/main/java/com/google/javascript/gents/StyleFixPass.java
@@ -43,7 +43,7 @@ public final class StyleFixPass extends AbstractPostOrderCallback implements Com
         if (hasGrandchildren(n)) {
           Node rhs = n.getFirstFirstChild();
           // ONLY convert classes (not functions) for var and let
-          if (rhs.isClass()) {
+          if (isTypeDefinition(rhs)) {
             liftClassOrFunctionDefinition(n);
           }
         }
@@ -51,7 +51,7 @@ public final class StyleFixPass extends AbstractPostOrderCallback implements Com
       case CONST:
         if (hasGrandchildren(n)) {
           Node rhs = n.getFirstFirstChild();
-          if (rhs.isClass()) {
+          if (isTypeDefinition(rhs)) {
             liftClassOrFunctionDefinition(n);
           } else if (rhs.isFunction()) {
             rhs.setIsArrowFunction(false);
@@ -113,6 +113,10 @@ public final class StyleFixPass extends AbstractPostOrderCallback implements Com
       default:
         break;
     }
+  }
+
+  private boolean isTypeDefinition(Node rhs) {
+    return rhs.isClass() || rhs.getType() == Token.INTERFACE;
   }
 
   /** Returns if a node has grandchildren */

--- a/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
@@ -108,6 +108,27 @@ public final class TypeAnnotationPass implements CompilerPass {
             setTypeExpression(n, bestJSDocInfo.getReturnType(), true);
           }
           break;
+        case CLASS:
+          if (bestJSDocInfo != null) {
+            List<JSTypeExpression> interfaces = bestJSDocInfo.getImplementedInterfaces();
+            if (!interfaces.isEmpty()) {
+              // Convert the @implements {...} JSDoc comments to TypeNodeASTs, and add them into the
+              // implements part of the class definition.
+              Node impls = new Node(Token.IMPLEMENTS);
+              for (JSTypeExpression type : interfaces) {
+                impls.addChildToBack(convertTypeNodeAST(type.getRoot()));
+              }
+              n.putProp(Node.IMPLEMENTS, impls);
+            }
+          }
+          break;
+        case INTERFACE_EXTENDS:
+          Node newExtends = n.cloneNode();
+          for (Node c : n.children()) {
+            newExtends.addChildToBack(convertTypeNodeAST(c));
+          }
+          parent.replaceChild(n, newExtends);
+          break;
         // Names and properties are annotated with their types
         case NAME:
         case GETPROP:

--- a/src/test/java/com/google/javascript/gents/singleTests/interface.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/interface.js
@@ -1,0 +1,36 @@
+goog.provide('ns.Interface2');
+goog.provide('ns.Interface3');
+
+/** @interface */
+function Interface() {}
+/**
+ * @param {string} a
+ * @return {number}
+ */
+Interface.prototype.bar = function(a) {};
+
+/** @interface */
+ns.Interface2 = function() {}
+/**
+ * @param {string} a
+ * @return {number}
+ */
+ns.Interface2.prototype.bar = function(a) {};
+
+/** @interface @implements {ns.Interface2} */
+ns.Interface3 = function() {}
+/**
+ * @param {string} a
+ * @return {number}
+ */
+ns.Interface3.prototype.baz = function(a) {};
+
+/** @implements {ns.Interface2} */
+class X {}
+
+/**
+ * @constructor
+ * @implements {ns.Interface2}
+ * @implements {ns.Interface3}
+ */
+function Y() {}

--- a/src/test/java/com/google/javascript/gents/singleTests/interface.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/interface.ts
@@ -1,0 +1,10 @@
+interface Interface {
+  bar(a: string): number;
+}
+export interface Interface2 { bar(a: string): number; }
+
+export interface Interface3 extends Interface2 { baz(a: string): number; }
+
+class X implements Interface2 {}
+
+class Y implements Interface2, Interface3 {}


### PR DESCRIPTION
This change adds support for converting interface definitions
from ES5 style to proper TypeScript interfaces. It also adds
support for `@implements` on classes and interfaces.

This change was brought to you by LH927 from LCY --> FRA.