### PR TITLE
Remove duplicate fields

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeConversionPass.java
@@ -136,7 +136,9 @@ public final class TypeConversionPass implements CompilerPass {
    * Converts fields declared internally inside a class using the "this" keyword.
    */
   private class FieldOnThisConverter extends AbstractPostOrderCallback {
-    // Map from class node to its field names
+    /**
+     * Map from class node to its field names.
+     */
     private Multimap<Node, String> classFieldMap = HashMultimap.create();
 
     @Override
@@ -154,7 +156,7 @@ public final class TypeConversionPass implements CompilerPass {
         // TODO(gmoothart): in many cases we should be able to infer the type from the rhs if there
         // is no jsDoc
 
-        // Handle parameter properties when we are in the constructor and have a
+        // Convert fields to parameter properties when we are in the constructor and have a
         // declaration of the form this.name = name;
         if ("constructor".equals(fnName) &&
             declaration.jsDoc != null &&

--- a/src/test/java/com/google/javascript/gents/singleTests/fields.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/fields.js
@@ -16,6 +16,8 @@ var A = function(a) {
   this.w.bar = 'bar';
 
   baz.v = 1;
+  this.n = 12;
+  this.n = 13;
 };
 
 A.prototype.foo = function() {
@@ -24,9 +26,9 @@ A.prototype.foo = function() {
   /** @type {string} */
   this.d;
 
+  this.n = 14;
   // These are undeclared fields
   this.u;
-  this.n = 12;
   this.x = this.a;
 };
 

--- a/src/test/java/com/google/javascript/gents/singleTests/fields.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/fields.ts
@@ -6,11 +6,11 @@ class A {
   b: boolean;
   z: number;
   w: any;
-  c: number = 4;
+  n: any = 12;
+  c: number;
   d: string;
   // These are undeclared fields
   u: any;
-  n: any = 12;
   x: any;
   constructor(public a: number) {
     let y = 1;
@@ -19,9 +19,15 @@ class A {
     this.w.bar = 'bar';
 
     baz.v = 1;
+
+    this.n = 13;
   }
 
   foo() {
+    this.c = 4;
+
+    this.n = 14;
+
     this.x = this.a;
   }
 }


### PR DESCRIPTION
This fixes a bug that would cause gents to generate duplicate fields and promote some assignments to field initializers inappropriately.

It changes behavior to only look in the constructor for fields. With some care to remove duplicates and leave the assignments in-place it would be possible to promote fields in other methods too.

fixes #358