### PR TITLE
fix: Support for IArrayLike and IObject used as bare types.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/index_signature_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/index_signature_with_platform.d.ts
@@ -6,6 +6,13 @@ declare namespace ಠ_ಠ.clutz.index_signature {
     [ key: number ]: string ;
     length : number ;
   }
+  class ImplementsIArrayLikeBare extends ImplementsIArrayLikeBare_Instance {
+  }
+  class ImplementsIArrayLikeBare_Instance implements ArrayLike < any > {
+    private noStructuralTyping_: any;
+    [ key: number ]: any ;
+    length : number ;
+  }
   class ImplementsIArrayLikeWithGeneric < T > extends ImplementsIArrayLikeWithGeneric_Instance < T > {
   }
   class ImplementsIArrayLikeWithGeneric_Instance < T > implements ArrayLike < T > {
@@ -18,6 +25,12 @@ declare namespace ಠ_ಠ.clutz.index_signature {
   class ImplementsIObject_Instance implements IObject < string , number > {
     private noStructuralTyping_: any;
     [ key: string ]: number ;
+  }
+  class ImplementsIObjectLikeBare extends ImplementsIObjectLikeBare_Instance {
+  }
+  class ImplementsIObjectLikeBare_Instance implements IObject < any , any > {
+    private noStructuralTyping_: any;
+    [ /* warning: coerced from ? */ key: string ]: any ;
   }
   class ImplementsIObjectWithGeneric < T > extends ImplementsIObjectWithGeneric_Instance < T > {
   }

--- a/src/test/java/com/google/javascript/clutz/index_signature_with_platform.js
+++ b/src/test/java/com/google/javascript/clutz/index_signature_with_platform.js
@@ -57,3 +57,18 @@ index_signature.ShouldContainIndexSignature = function() {}
 
 /** @type {number} */
 index_signature.ShouldContainIndexSignature.prototype.length;
+
+/**
+ * @constructor
+ * @implements {IArrayLike}
+ */
+index_signature.ImplementsIArrayLikeBare = function() {};
+
+/** @type {number} */
+index_signature.ImplementsIArrayLikeBare.prototype.length;
+
+/**
+ * @constructor
+ * @implements {IObject}
+ */
+index_signature.ImplementsIObjectLikeBare = function() {};


### PR DESCRIPTION
Closure supports referring to templatized type without passing
type parameters, i.e. a type C<T>, can be use bare as C. This change
adds support for using IArrayLike and IObject in such way.