### PR TITLE
fix: support transitive types shadowed by namespaces.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -51,9 +51,6 @@ import com.google.javascript.rhino.jstype.TemplateType;
 import com.google.javascript.rhino.jstype.TemplatizedType;
 import com.google.javascript.rhino.jstype.UnionType;
 import com.google.javascript.rhino.jstype.Visitor;
-
-import org.kohsuke.args4j.CmdLineException;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -69,8 +66,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
-
 import javax.annotation.Nullable;
+import org.kohsuke.args4j.CmdLineException;
 
 /**
  * A tool that generates {@code .d.ts} declarations from a Google Closure JavaScript program.
@@ -383,7 +380,7 @@ class DeclarationGenerator {
     // For the purposes of determining which provides have been emitted
     // combine original provides and rewritten ones.
     provides.addAll(rewrittenProvides);
-    processUnprovidedTypes(provides);
+    processUnprovidedTypes(provides, transitiveProvides);
 
     checkState(indent == 0, "indent must be zero after printing, but is %s", indent);
     return out.toString();
@@ -472,7 +469,7 @@ class DeclarationGenerator {
    * positions. However, our emit phases only emits goog.provided symbols and namespaces, so this
    * extra pass is required, in order to have valid output.
    */
-  private void processUnprovidedTypes(Set<String> provides) {
+  private void processUnprovidedTypes(Set<String> provides, Set<String> transitiveProvides) {
     /**
      * A new set of types can be discovered while visiting unprovided types.
      * To prevent an infinite loop in a pathological case, limit to a number of passes.
@@ -486,18 +483,24 @@ class DeclarationGenerator {
       // AFAICT, there is no api for going from type to symbol, so iterate all symbols first.
       for (TypedVar symbol : compiler.getTopScope().getAllSymbols()) {
         String name = symbol.getName();
-        // skip unused symbols, symbols already emitted or symbols whose namespace is emitted.
+        String namespace = getNamespace(name);
+        // skip unused symbols, symbols already emitted or symbols whose namespace is emitted
+        // (unless the symbols have their own provide).
         if (!typesUsed.contains(name) || typesEmitted.contains(name) ||
-            typesEmitted.contains(getNamespace(name))) {
+            (!transitiveProvides.contains(name) && typesEmitted.contains(namespace))) {
           continue;
         }
+
         // skip provided symbols (as default or in an namespace).
-        if (provides.contains(name) || provides.contains(getNamespace(name))) continue;
+        if (provides.contains(name)
+            || (!transitiveProvides.contains(name) && provides.contains(namespace))) {
+          continue;
+        }
 
         // skip extern symbols (they have a separate pass).
         CompilerInput symbolInput = this.compiler.getInput(new InputId(symbol.getInputName()));
         if (symbolInput != null && symbolInput.isExtern()) continue;
-        declareNamespace(getNamespace(name), symbol, name, /* isDefault */ true,
+        declareNamespace(namespace, symbol, name, /* isDefault */ true,
             Collections.<String>emptySet(), /* isExtern */ false);
         typesEmitted.add(name);
       }

--- a/src/test/java/com/google/javascript/clutz/MultiFileTest.java
+++ b/src/test/java/com/google/javascript/clutz/MultiFileTest.java
@@ -60,9 +60,13 @@ public class MultiFileTest {
   @Test
   public void depgraph() throws Exception {
     String expected = DeclarationGeneratorTests.getTestFileText(input("depgraph.d.ts"));
-    assertThatProgram(ImmutableList.of(input("root.js")),
-        ImmutableList.of(input("transitive.js"), input("transitive_unused.js")))
-            .generatesDeclarations(expected);
+    assertThatProgram(
+            ImmutableList.of(input("root.js")),
+            ImmutableList.of(
+                input("transitive.js"),
+                input("transitive_unused.js"),
+                input("transitive_namespace.js")))
+        .generatesDeclarations(expected);
   }
 
   private File input(String filename) {

--- a/src/test/java/com/google/javascript/clutz/depgraph/depgraph.d.ts
+++ b/src/test/java/com/google/javascript/clutz/depgraph/depgraph.d.ts
@@ -4,6 +4,7 @@ declare namespace ಠ_ಠ.clutz.root {
   class Z_Instance {
     private noStructuralTyping_: any;
     useTransitive ( ) : ಠ_ಠ.clutz.transitive.Y | null ;
+    useTransitiveNamespaced ( ) : ಠ_ಠ.clutz.transitive.ns.Z | null ;
   }
 }
 declare namespace goog {
@@ -17,6 +18,13 @@ declare namespace ಠ_ಠ.clutz.transitive {
   class Y extends Y_Instance {
   }
   class Y_Instance {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.transitive.ns {
+  class Z extends Z_Instance {
+  }
+  class Z_Instance {
     private noStructuralTyping_: any;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/depgraph/root.js
+++ b/src/test/java/com/google/javascript/clutz/depgraph/root.js
@@ -1,6 +1,8 @@
 goog.provide('root.Z');
 
 goog.require('transitive.Y');
+goog.require('transitive.ns');
+goog.require('transitive.ns.Z');
 goog.require('transitive_unused.X');
 
 /** @constructor */
@@ -9,5 +11,11 @@ root.Z = function() {};
 /** @return {?transitive.Y} */
 root.Z.prototype.useTransitive = function() {
   var unused = new transitive_unused.X();
+  return null;
+};
+
+/** @return {?transitive.ns.Z} */
+root.Z.prototype.useTransitiveNamespaced = function() {
+  var unused = transitive.ns.fooFunc();
   return null;
 };

--- a/src/test/java/com/google/javascript/clutz/depgraph/transitive_namespace.js
+++ b/src/test/java/com/google/javascript/clutz/depgraph/transitive_namespace.js
@@ -1,0 +1,12 @@
+/**
+ * @fileoverview 'transitive.ns' contains 'transitive.ns.Z', which used to
+ * cause it being ignored when producing transitively used types.
+ */
+goog.provide('transitive.ns');
+goog.provide('transitive.ns.Z');
+
+/** @return {string} */
+transitive.ns.fooFunc = function() { return 'x'; };
+
+/** @constructor */
+transitive.ns.Z = function() {};


### PR DESCRIPTION
Previously, Clutz would ignore types that are contained in a namespace,
assuming they were just fields on that namespace. Now, Clutz will still
generate them if they are their own provide (from the list of transitive
provides).