### PR TITLE
fix: Support defaultExports in import rewriting

### DIFF
--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/import.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/import.ts
@@ -1,6 +1,6 @@
 import './export_sideeffect';
 
 import * as DExports from './export_both';
-import {D} from './export_both';
-import {A} from './export_default';
+import D from './export_both';
+import A from './export_default';
 import * as B from './export_namespace';

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.ts
@@ -1,7 +1,7 @@
 import './export_sideeffect';
 
 import * as DExports from './export_both';
-import {D} from './export_both';
-import {A} from './export_default';
-import {A as X} from './export_default';
+import D from './export_both';
+import A from './export_default';
+import X from './export_default';
 import * as B from './export_namespace';

--- a/src/test/java/com/google/javascript/gents/multiTests/provide_imports/import.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/provide_imports/import.ts
@@ -8,4 +8,4 @@ import {B} from './export';
 import {D} from './export';
 import {E} from './export';
 import * as ZExports from './export_module';
-import {Z} from './export_module';
+import Z from './export_module';

--- a/src/test/java/com/google/javascript/gents/multiTests/provide_imports/import_binding.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/provide_imports/import_binding.ts
@@ -8,4 +8,4 @@ import {B} from './export';
 import {D as X} from './export';
 import {E} from './export';
 import * as ZExports from './export_module';
-import {Z} from './export_module';
+import Z from './export_module';

--- a/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/import.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/import.ts
@@ -1,9 +1,9 @@
 import E from 'goog:keep.E';
 
 import * as A from './imported_module';
-import {A as X} from './imported_module';
+import X from './imported_module';
 import * as B from './imported_provide';
-import {C} from './unimported_module';
+import C from './unimported_module';
 import {typC} from './unimported_module';
 import {typD} from './unimported_provide';
 


### PR DESCRIPTION
The import rewriter is not aware of default exports, which results in all exports being imported as a named export.

Supports #329 