### PR TITLE
Remove support for `export default`.

### DIFF
--- a/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
@@ -321,22 +321,14 @@ public final class ModuleConversionPass implements CompilerPass {
       rhs.detachFromParent();
       Node exportSpecNode;
       if (rhs.isName() && exportedSymbol.equals(rhs.getString())) {
-        exportSpecNode = exportedNamespace.equals(EXPORTS)
-            ? new Node(Token.EXPORT_SPEC, rhs)
-            : new Node(Token.EXPORT_SPECS, new Node(Token.EXPORT_SPEC, rhs));
+        exportSpecNode = new Node(Token.EXPORT_SPECS, new Node(Token.EXPORT_SPEC, rhs));
       } else {
-        exportSpecNode =
-            (exportedNamespace.equals(EXPORTS) && rhs.getQualifiedName() != null)
-                ? rhs
-                : IR.constNode(IR.name(exportedSymbol), rhs);
+        exportSpecNode = IR.constNode(IR.name(exportedSymbol), rhs);
       }
       exportSpecNode.setJSDocInfo(jsDoc);
       Node exportNode = new Node(Token.EXPORT, exportSpecNode);
       nodeComments.replaceWithComment(exprNode, exportNode);
 
-      if (exportedNamespace.equals(EXPORTS)) {
-        exportNode.putBooleanProp(Node.EXPORT_DEFAULT, true);
-      }
     } else {
       // Assume prefix has already been exported and just trim the prefix
       nameUtil.replacePrefixInName(lhs, exportedNamespace, exportedSymbol);

--- a/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
@@ -320,7 +320,8 @@ public final class ModuleConversionPass implements CompilerPass {
       // Generate new export statement
       rhs.detachFromParent();
       Node exportSpecNode;
-      if (rhs.isName() && exportedSymbol.equals(rhs.getString())) {
+      if (rhs.isName()
+          && (exportedSymbol.equals(rhs.getString()) || exportedNamespace.equals(EXPORTS))) {
         exportSpecNode = new Node(Token.EXPORT_SPECS, new Node(Token.EXPORT_SPEC, rhs));
       } else {
         exportSpecNode = IR.constNode(IR.name(exportedSymbol), rhs);

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_both.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_both.ts
@@ -1,3 +1,3 @@
-export default function D() {}
+export function D() {}
 export const x = 4;
 export function foo() {}

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_default.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_default.ts
@@ -1,3 +1,3 @@
-export default class A {
+export class A {
   constructor(public n: number) {}
 }

--- a/src/test/java/com/google/javascript/gents/multiTests/provide_imports/export_module.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/provide_imports/export_module.ts
@@ -1,2 +1,2 @@
-export default function Z() {}
+export function Z() {}
 export function foo() {}

--- a/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/imported_module.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/imported_module.ts
@@ -1,5 +1,5 @@
 class foo {}
 
-export default foo;
+export {foo};
 export const typA = foo;
 export const valA = new foo();

--- a/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/unimported_module.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/unimported_module.ts
@@ -1,5 +1,5 @@
 class foo {}
 
-export default foo;
+export {foo};
 export const typC = foo;
 export const valC = new foo();

--- a/src/test/java/com/google/javascript/gents/singleTests/module_both.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_both.ts
@@ -2,7 +2,7 @@ let num = 4;
 let B = function(): number {
   return num;
 };
-export default B;
+export {B};
 export {num};
 
 export class foo { static z: number; }

--- a/src/test/java/com/google/javascript/gents/singleTests/module_class.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_class.ts
@@ -7,4 +7,4 @@ class Klass {
   }
 }
 
-export default Klass;
+export {Klass};

--- a/src/test/java/com/google/javascript/gents/singleTests/module_class2.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_class2.ts
@@ -15,4 +15,4 @@ class Klass {
   }
 }
 
-export default Klass;
+export {Klass};

--- a/src/test/java/com/google/javascript/gents/singleTests/module_default.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_default.ts
@@ -1,3 +1,3 @@
-export default function B(): number {
+export function B(): number {
   return 4;
 }


### PR DESCRIPTION
After discussions we have decided that we would like this to be a forcing function to encourage people to conform with the TypeScript style guide.