### PR TITLE
Files with the same basename don't clobber each other.

### DIFF
--- a/src/main/java/com/google/javascript/gents/PathUtil.java
+++ b/src/main/java/com/google/javascript/gents/PathUtil.java
@@ -18,8 +18,8 @@ public class PathUtil {
    * Returns the file name without its file extension or path. The result does not include the
    * '{@code .}'.
    */
-  String getFileNameWithoutExtension(String filepath) {
-    return removeExtension(new File(filepath).getName());
+  String getFilePathWithoutExtension(String filepath) {
+    return removeExtension(new File(filepath).getPath());
   }
 
   /**

--- a/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
+++ b/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
@@ -109,8 +109,8 @@ public class TypeScriptGenerator {
 
     for (String filename : filesToConvert) {
       String relativePath = pathUtil.getRelativePath(".", filename);
-      String basename = pathUtil.getFileNameWithoutExtension(relativePath);
-      String tsCode = result.get(basename);
+      String filepath = pathUtil.getFilePathWithoutExtension(relativePath);
+      String tsCode = result.get(filepath);
       if ("-".equals(opts.output)) {
         System.out.println("========================================");
         System.out.println("File: " + relativePath);
@@ -173,7 +173,7 @@ public class TypeScriptGenerator {
 
     // We only use the source root as the extern root is ignored for codegen
     for (Node file : srcRoot.children()) {
-      String basename = pathUtil.getFileNameWithoutExtension(file.getSourceFileName());
+      String filepath = pathUtil.getFilePathWithoutExtension(file.getSourceFileName());
       CodeGeneratorFactory factory = new CodeGeneratorFactory() {
         @Override
         public CodeGenerator getCodeGenerator(Format outputFormat, CodeConsumer cc) {
@@ -190,7 +190,7 @@ public class TypeScriptGenerator {
           .setOutputTypes(true)
           .build();
 
-      sourceFileMap.put(basename, tryClangFormat(tsCode));
+      sourceFileMap.put(filepath, tryClangFormat(tsCode));
     }
 
     errorManager.doGenerateReport();

--- a/src/test/java/com/google/javascript/gents/TypeScriptGeneratorMultiTests.java
+++ b/src/test/java/com/google/javascript/gents/TypeScriptGeneratorMultiTests.java
@@ -73,7 +73,7 @@ public class TypeScriptGeneratorMultiTests extends TypeScriptGeneratorTests {
           if (!filename.endsWith("_keep.js")) {
             sourceNames.add(sourceFile.getName());
 
-            String basename = gents.pathUtil.getFileNameWithoutExtension(sourceFile.getName());
+            String basename = gents.pathUtil.getFilePathWithoutExtension(sourceFile.getName());
             File goldenFile = DeclarationGeneratorTests.getGoldenFile(sourceFile, ".ts");
             String goldenText = getFileText(goldenFile);
             goldenFiles.put(basename, goldenText);

--- a/src/test/java/com/google/javascript/gents/TypeScriptGeneratorMultiTests.java
+++ b/src/test/java/com/google/javascript/gents/TypeScriptGeneratorMultiTests.java
@@ -2,9 +2,11 @@ package com.google.javascript.gents;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.io.Files;
 import com.google.javascript.clutz.DeclarationGeneratorTests;
 import com.google.javascript.jscomp.SourceFile;
 import java.io.File;
@@ -58,7 +60,7 @@ public class TypeScriptGeneratorMultiTests extends TypeScriptGeneratorTests {
       try {
         TypeScriptGenerator gents = new TypeScriptGenerator(new Options());
 
-        List<File> testFiles = getTestInputFiles(DeclarationGeneratorTests.JS,
+        List<File> testFiles = getTestInputFilesRecursive(DeclarationGeneratorTests.JS,
             multiTestPath, dirName);
 
         Set<String> sourceNames = Sets.newHashSet();
@@ -67,13 +69,13 @@ public class TypeScriptGeneratorMultiTests extends TypeScriptGeneratorTests {
 
         for (final File sourceFile : testFiles) {
           String sourceText = getFileText(sourceFile);
-          String filename = sourceFile.getName();
-          sourceFiles.add(SourceFile.fromCode(sourceFile.getName(), sourceText));
+          String filepath = sourceFile.getPath();
+          sourceFiles.add(SourceFile.fromCode(filepath, sourceText));
 
-          if (!filename.endsWith("_keep.js")) {
-            sourceNames.add(sourceFile.getName());
+          if (!filepath.endsWith("_keep.js")) {
+            sourceNames.add(filepath);
 
-            String basename = gents.pathUtil.getFilePathWithoutExtension(sourceFile.getName());
+            String basename = gents.pathUtil.getFilePathWithoutExtension(filepath);
             File goldenFile = DeclarationGeneratorTests.getGoldenFile(sourceFile, ".ts");
             String goldenText = getFileText(goldenFile);
             goldenFiles.put(basename, goldenText);
@@ -111,6 +113,19 @@ public class TypeScriptGeneratorMultiTests extends TypeScriptGeneratorTests {
     @Override
     public Description getDescription() {
       return Description.createTestDescription(TypeScriptGeneratorMultiTests.class, dirName);
+    }
+
+    private List<File> getTestInputFilesRecursive(FilenameFilter filter, String... dir) {
+      ImmutableList.Builder<File> filesBuilder = ImmutableList.builder();
+
+      for (File f : Files.fileTreeTraverser().preOrderTraversal(getTestDirPath(dir).toFile())) {
+        if (filter.accept(f.getParentFile(), f.getName())) {
+          filesBuilder.add(f);
+        }
+      }
+
+      return filesBuilder.build();
+
     }
   }
 }

--- a/src/test/java/com/google/javascript/gents/TypeScriptGeneratorTests.java
+++ b/src/test/java/com/google/javascript/gents/TypeScriptGeneratorTests.java
@@ -107,7 +107,7 @@ public class TypeScriptGeneratorTests {
       try {
         gents = new TypeScriptGenerator(this.testOptions);
 
-        String basename = gents.pathUtil.getFileNameWithoutExtension(sourceFile.getName());
+        String basename = gents.pathUtil.getFilePathWithoutExtension(sourceFile.getName());
         String sourceText = getFileText(sourceFile);
         String goldenText = getFileText(goldenFile);
 
@@ -175,7 +175,7 @@ public class TypeScriptGeneratorTests {
   @Test
   public void testFileNameTrimming() {
     String filepath = "/this/is/a/path/to/../foo.bar";
-    String filename = gents.pathUtil.getFileNameWithoutExtension(filepath);
+    String filename = gents.pathUtil.getFilePathWithoutExtension(filepath);
     assertThat(filename).isEqualTo("foo");
   }
 

--- a/src/test/java/com/google/javascript/gents/multiTests/basenames_dont_collide/a/file.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/basenames_dont_collide/a/file.js
@@ -1,0 +1,3 @@
+// content unique to a/file.js
+/** @type {string} */
+let a = 'a';

--- a/src/test/java/com/google/javascript/gents/multiTests/basenames_dont_collide/a/file.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/basenames_dont_collide/a/file.ts
@@ -1,0 +1,2 @@
+// content unique to a/file.js
+let a: string = 'a';

--- a/src/test/java/com/google/javascript/gents/multiTests/basenames_dont_collide/b/file.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/basenames_dont_collide/b/file.js
@@ -1,0 +1,3 @@
+// content unique to b/file.js
+/** @type {string} */
+let b = 'b';

--- a/src/test/java/com/google/javascript/gents/multiTests/basenames_dont_collide/b/file.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/basenames_dont_collide/b/file.ts
@@ -1,0 +1,2 @@
+// content unique to b/file.js
+let b: string = 'b';


### PR DESCRIPTION
Use the whole file path as a hash key, so that files in different
directories that have the same basename do not overwrite one another.

fixes #348