### PR TITLE
feat: Add better newline insertion.

### DIFF
--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -126,7 +126,7 @@ public final class CommentLinkingPass implements CompilerPass {
     /** Links a comment to the corresponding node */
     private void linkCommentToNode(Node n) {
       StringBuilder sb = new StringBuilder();
-      String sep = "";
+      String sep = "\n";
       for (Comment c : group) {
         String comment = filterCommentContent(c.type, c.value);
         if (!comment.isEmpty()) {

--- a/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
+++ b/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
@@ -1,5 +1,6 @@
 package com.google.javascript.gents;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.javascript.jscomp.CodeConsumer;
 import com.google.javascript.jscomp.CodeGenerator;
 import com.google.javascript.jscomp.CompilerOptions;
@@ -59,17 +60,16 @@ public class GentsCodeGenerator extends CodeGenerator {
     addNewlines(n);
   }
 
+  private static final ImmutableSet<Token> TOKENS_TO_ADD_NEWLINES_BEFORE =
+      ImmutableSet.of(
+          Token.CLASS, Token.EXPORT, Token.FUNCTION, Token.INTERFACE, Token.MEMBER_FUNCTION_DEF);
+
   /** Add newlines to the generated source */
   private void addNewlines(Node n) {
     Node nextNode = n.getNext();
     if (nextNode != null) {
-      int lineSpacing = nextNode.getLineno() - n.getLineno();
-
-      // Add an empty line if:
-      //   - the next node is further away than the next line
-      //   - the next node is a class function (but the current node is not a comment)
-      if (lineSpacing > 1 ||
-          (nextNode.getToken() == Token.MEMBER_FUNCTION_DEF && n.getToken() != Token.EMPTY)) {
+      if (nodeComments.getComment(nextNode) == null // Comments already prepend a newline.
+          && TOKENS_TO_ADD_NEWLINES_BEFORE.contains(nextNode.getToken())) {
         add("\n");
       }
     }

--- a/src/test/java/com/google/javascript/gents/multiTests/basenames_dont_collide/a/file.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/basenames_dont_collide/a/file.ts
@@ -1,2 +1,3 @@
+
 // content unique to a/file.js
 let a: string = 'a';

--- a/src/test/java/com/google/javascript/gents/multiTests/basenames_dont_collide/b/file.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/basenames_dont_collide/b/file.ts
@@ -1,2 +1,3 @@
+
 // content unique to b/file.js
 let b: string = 'b';

--- a/src/test/java/com/google/javascript/gents/multiTests/import_rewrite/export.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/import_rewrite/export.ts
@@ -1,13 +1,17 @@
 export function B() {}
 
 export const x = 4;
+
 export const y = 8;
 
 export function D() {}
+
 export function foo() {}
 
 export function E() {}
+
 export function bar() {}
+
 export function F() {}
 
 export class G {
@@ -15,4 +19,5 @@ export class G {
 }
 
 export function Z() {}
+
 export function fun() {}

--- a/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/export.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/export.ts
@@ -1,2 +1,3 @@
 export function A() {}
+
 export function foo() {}

--- a/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/import.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/import.ts
@@ -8,7 +8,6 @@ export {};
 
 A();
 AExports.foo();
-
 B();
 let n = B.num + B.num;
 X();

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_both.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_both.ts
@@ -1,3 +1,5 @@
 export function D() {}
+
 export const x = 4;
+
 export function foo() {}

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_namespace.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_namespace.ts
@@ -1,3 +1,5 @@
 export const x = 4;
+
 export function foo() {}
+
 export function bar(n) {}

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_sideeffect.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_sideeffect.ts
@@ -1,3 +1,2 @@
 export {};
-
 console.log('hello');

--- a/src/test/java/com/google/javascript/gents/multiTests/provide_imports/export.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/provide_imports/export.ts
@@ -1,12 +1,15 @@
 export function B() {}
 
 export const x = 4;
+
 export const y = 8;
 
 export function D() {}
+
 export function foo() {}
 
 export function E() {}
+
 export function bar() {}
 
 export class G {

--- a/src/test/java/com/google/javascript/gents/multiTests/provide_imports/export_module.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/provide_imports/export_module.ts
@@ -1,2 +1,3 @@
 export function Z() {}
+
 export function foo() {}

--- a/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/imported_module.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/imported_module.ts
@@ -1,4 +1,5 @@
 export class foo {};
 
 export const typA = foo;
+
 export const valA = new foo();

--- a/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/imported_provide.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/imported_provide.ts
@@ -1,4 +1,5 @@
 class foo {}
 
 export const typB = foo;
+
 export const valB = new foo();

--- a/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/unimported_module.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/unimported_module.ts
@@ -1,4 +1,5 @@
 export class foo {};
 
 export const typC = foo;
+
 export const valC = new foo();

--- a/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/unimported_provide.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/unimported_provide.ts
@@ -1,4 +1,5 @@
 class foo {}
 
 export const typD = foo;
+
 export const valD = new foo();

--- a/src/test/java/com/google/javascript/gents/singleTests/access_modifiers.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/access_modifiers.ts
@@ -2,12 +2,14 @@ class A {
   // Static field access
   protected static sa: number;
   private static sb: number;
+
   // Field access
   a: number;
   b: number;
   c: number;
   protected d: number;
   private e: number;
+
   // Method access
   foo() {}
 

--- a/src/test/java/com/google/javascript/gents/singleTests/classes.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/classes.ts
@@ -1,3 +1,4 @@
+
 /**
  * Anonymous class
  */
@@ -50,24 +51,24 @@ class E extends C {
     super(a, b);
   }
 }
-
 let nested = {};
 nested.klass = class {};
 
 class F {
   // inline comment
 
+
   /**
-   * block comment
-   */
+     * block comment
+     */
   constructor() {}
 
   /** Do foo! */
   foo() {}
 
   /**
-   * Returns phone number.
-   */
+     * Returns phone number.
+     */
   bar(): string {
     return '';
   }
@@ -75,7 +76,7 @@ class F {
 
 class G {
   /**
-   * ES6 method short hand.
-   */
+     * ES6 method short hand.
+     */
   method() {}
 }

--- a/src/test/java/com/google/javascript/gents/singleTests/comments.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/comments.ts
@@ -1,3 +1,4 @@
+
 /**
  * This comment describes a class
  */
@@ -6,6 +7,7 @@ class A {
   /* This one too (same comment block) */
   foo() {}
 }
+
 /**
  * This is a floating comment block
  * It stays together with anything not separated by an empty line
@@ -22,7 +24,9 @@ class A {
 let foo = function(deleted: number, notdeleted: number): number {
   return deleted + notdeleted;
 };
+
 // The following comment should be entirely deleted
 const x;
+
 /** @export */
 let m: number = 4;

--- a/src/test/java/com/google/javascript/gents/singleTests/compound_types.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/compound_types.ts
@@ -1,14 +1,17 @@
+
 // Non-nullable types
 // We ignore the non-nullability as we transpile to TS with --strictNullChecks
 let n: number = 5;
 let foo = function(s: string): boolean {
   return true;
 };
+
 // Nullable types
 let niln: null|number = null;
 let bar = function(s: null|string): null | boolean {
   return null;
 };
+
 // Union types
 let sn: string|number = 9;
 let snb: string|null|number|boolean = false;

--- a/src/test/java/com/google/javascript/gents/singleTests/empty.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/empty.ts
@@ -1,1 +1,2 @@
+
 // this file is intentionally empty.

--- a/src/test/java/com/google/javascript/gents/singleTests/export_rewrite.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/export_rewrite.ts
@@ -1,7 +1,6 @@
 export function B() {}
 
 export class Klass { static NUM: number = 4; }
-
 B();
 let x = Klass();
 let y = Klass.NUM;

--- a/src/test/java/com/google/javascript/gents/singleTests/fields.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/fields.ts
@@ -9,25 +9,21 @@ class A {
   n: any = 12;
   c: number;
   d: string;
+
   // These are undeclared fields
   u: any;
   x: any;
   constructor(public a: number) {
     let y = 1;
     this.z = y + 1;
-
     this.w.bar = 'bar';
-
     baz.v = 1;
-
     this.n = 13;
   }
 
   foo() {
     this.c = 4;
-
     this.n = 14;
-
     this.x = this.a;
   }
 }

--- a/src/test/java/com/google/javascript/gents/singleTests/fn_params.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/fn_params.ts
@@ -1,5 +1,7 @@
+
 // Optional Parameters
 let optParams = function(n: number, s?: string, b?: boolean) {};
+
 // Variadic parameters
 let restParams = function(n: number, ...r: any[]) {};
 let restParamsTyped = function(n: number, ...br: boolean[]) {};

--- a/src/test/java/com/google/javascript/gents/singleTests/fn_types.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/fn_types.ts
@@ -1,18 +1,23 @@
+
 // 'Function' type
 let nop: Function = function() {};
 let foo: Function = function(a, b, c) {
   return a + b + c;
 };
+
 // Infers return type as 'any' by default
 let inferRetAny: () => any = function() {};
 let typedRetVoid: () => void = function() {};
+
 // Normal Parameters
 let basicParams: (p1: number, p2: string) => number = function(n, s) {
   return n;
 };
+
 // Optional Parameters
 let optParams: (p1: number, p2?: string, p3?: boolean) =>
     any = function(n, s, b) {};
+
 // Variadic parameters
 let restParams: (p1: number, ...p2) => any = function(n, r) {};
 let restParamsTyped: (p1: number, ...p2: boolean[]) => any = function(n, br) {};

--- a/src/test/java/com/google/javascript/gents/singleTests/functions.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/functions.ts
@@ -1,4 +1,5 @@
 let nop = function() {};
+
 // Function params
 let oneParam = function(n: number) {};
 function twoParams(b: boolean, s: string) {}
@@ -10,19 +11,19 @@ let anyReturn = function(): any {
 function typedReturn(): number {
   return 4;
 }
-
 let partiallyTyped = function(n: number, u1, b: boolean, u2) {};
+
 // Both params and returns
 let complex = function(b: boolean, s: string, x: any): string {
   if (b) {
     return s;
   }
 };
+
 // Undefined params
-
 let paramUndef = function(u: undefined, v: undefined) {};
-// Void returns
 
+// Void returns
 let retVoid = function(): void {};
 let retUndef = function(): void {};
 function arrow(a: number): number {

--- a/src/test/java/com/google/javascript/gents/singleTests/goog_scope.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/goog_scope.ts
@@ -12,7 +12,6 @@ export class Foo {
         'since it is goog.provided';
   }
 }
-
 const Foo = Foo;
 Foo.Bar = class {
   static bar(): boolean {

--- a/src/test/java/com/google/javascript/gents/singleTests/inline_types.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/inline_types.ts
@@ -1,8 +1,10 @@
 interface Foo {}
 /** !Foo */
 let foo: Foo = {};
+
 /** string */
 const x: string = 'fruit';
+
 // TODO(#352): Support inline typing for functions.
 // input: function /** string */ f(/** number */ x) {return x + ' apples'}
 // output: function f(x: number): string {return x + ' apples'}

--- a/src/test/java/com/google/javascript/gents/singleTests/module_both.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_both.ts
@@ -1,4 +1,5 @@
 let num = 4;
+
 /**
  * Note: `var` and `let` may be unsafe to export directly.
  */
@@ -21,7 +22,6 @@ export {L};
 export {num};
 
 export class foo { static z: number; }
-
 foo.z = num * 2;
 
 class ClassThatShouldNotBeExported {}

--- a/src/test/java/com/google/javascript/gents/singleTests/module_class2.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_class2.ts
@@ -1,3 +1,4 @@
+
 /** Possibly outdated information about Klass. */
 export class Klass {
   n: any;

--- a/src/test/java/com/google/javascript/gents/singleTests/module_class3.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_class3.ts
@@ -1,3 +1,4 @@
+
 /** Possibly outdated information about Klass. */
 export class Klass {
   n: any;

--- a/src/test/java/com/google/javascript/gents/singleTests/module_namespace.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_namespace.ts
@@ -6,5 +6,6 @@ export const x: number = 4;
 export function foo(): number {
   return 4;
 }
+
 export const baz = bar;
 baz.z = 8;

--- a/src/test/java/com/google/javascript/gents/singleTests/parameter_prop.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/parameter_prop.ts
@@ -3,7 +3,6 @@ class A {
   c: number;
   constructor(public a: number, b: number, c) {
     this.b = b;
-
     this.c = c;
   }
 }

--- a/src/test/java/com/google/javascript/gents/singleTests/primitives.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/primitives.ts
@@ -8,6 +8,7 @@ let b: boolean = true;
 let s: string = 'hello';
 let l: number = 6;
 const c: number = 8;
+
 /**
  * Escape characters
  */

--- a/src/test/java/com/google/javascript/gents/singleTests/proto_methods.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/proto_methods.ts
@@ -1,4 +1,5 @@
 let goog: any = {};
+
 /**
  * Nested anonymous class in ES6 syntax
  */
@@ -9,8 +10,8 @@ goog.A = class {
   }
 
   /**
- * Untyped method
- */
+   * Untyped method
+   */
   foo(n) {
     return n;
   }
@@ -27,15 +28,15 @@ class B extends goog.A {
   }
 
   /**
- * Typed method
- */
+   * Typed method
+   */
   bar(n: number): boolean {
     return super.foo(n) > 0;
   }
 
   /**
- * Another typed method
- */
+   * Another typed method
+   */
   baz(n: number): boolean {
     return super.foo(n) > 0;
   }

--- a/src/test/java/com/google/javascript/gents/singleTests/static_methods.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/static_methods.ts
@@ -6,20 +6,19 @@ goog.A = class {
   }
 
   /**
- * Untyped method
- */
+   * Untyped method
+   */
   static foo(n) {
     return n;
   }
 
   /**
- * Typed method
- */
+   * Typed method
+   */
   static bar(n: number): boolean {
     return n > 0;
   }
 };
-
 goog.A.B = {};
 
 /**

--- a/src/test/java/com/google/javascript/gents/singleTests/typedef_export.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/typedef_export.ts
@@ -2,5 +2,4 @@ type NamespacedTypedef = {
   x: string
 };
 export {NamespacedTypedef};
-
 let y: NamespacedTypedef = 'x';


### PR DESCRIPTION
Summary:
Changes the newline insertion heuristic to always add a newline before comments and specific tokens.

This removes the previous heuristic of using line numbering for inserting newlines when nodes differed by more than one line number, which broke with multi-line statements.

Supports #376