### PR TITLE
fix: Destructured values in modules cause NPE.

### DIFF
--- a/src/main/java/com/google/javascript/gents/CollectModuleMetadata.java
+++ b/src/main/java/com/google/javascript/gents/CollectModuleMetadata.java
@@ -1,5 +1,6 @@
 package com.google.javascript.gents;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.javascript.jscomp.AbstractCompiler;
 import com.google.javascript.jscomp.CompilerPass;
 import com.google.javascript.jscomp.JSError;
@@ -7,6 +8,7 @@ import com.google.javascript.jscomp.NodeTraversal;
 import com.google.javascript.jscomp.NodeUtil;
 import com.google.javascript.rhino.JSDocInfo;
 import com.google.javascript.rhino.Node;
+
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -229,7 +231,13 @@ public final class CollectModuleMetadata extends AbstractTopLevelCallback implem
       } else if (exportsName.isGetProp() &&
           "exports".equals(exportsName.getFirstChild().getQualifiedName())) {
         String identifier = exportsName.getLastChild().getString();
-        addExport(exportsName.getQualifiedName(), fullname + "." + identifier, identifier);
+        String importName = fullname + "." + identifier;
+        addExport(exportsName.getQualifiedName(), importName, identifier);
+
+        if (importName != null && !namespaceToModule.containsKey(importName)) {
+          namespaceToModule.put(importName, this);
+          providesObjectChildren.put(importName, ImmutableSet.<String>of());
+        }
       }
     }
 

--- a/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
@@ -191,12 +191,12 @@ public final class ModuleConversionPass implements CompilerPass {
     @Override
     public void visit(NodeTraversal t, Node n, Node parent) {
       if (NodeUtil.isNameDeclaration(n)) {
-        // var x = goog.require(...);
         Node node = n.getFirstFirstChild();
         if (node == null) {
           return;
         }
 
+        // var x = goog.require(...);
         if (node.isCall() && "goog.require".equals(node.getFirstChild().getQualifiedName())) {
           Node callNode = node;
           String requiredNamespace = callNode.getLastChild().getString();
@@ -205,8 +205,12 @@ public final class ModuleConversionPass implements CompilerPass {
           return;
 
         }
+
+        // var {foo} = goog.require(...);
         if (node.isObjectPattern()
             && "goog.require".equals(node.getNext().getFirstChild().getQualifiedName())) {
+          // TODO(#392): Support multiple destructured import values here.
+          //     Currently, this only allows for a single destructured import value.
           String namedExport = node.getFirstChild().getString();
           String requiredNamespace = node.getNext().getFirstChild().getNext().getString();
           requiredNamespace += "." + namedExport;

--- a/src/test/java/com/google/javascript/gents/multiTests/import_rewrite/import.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/import_rewrite/import.ts
@@ -1,5 +1,9 @@
 import './export';
 
+import * as Z from './export';
+import * as FExports from './export';
+import * as EExports from './export';
+import * as DExports from './export';
 import * as C from './export';
 import {B} from './export';
 import {D} from './export';
@@ -10,11 +14,11 @@ import {Z as stuff} from './export';
 B();
 let num = C.x + C.y;
 D();
-D.foo();
+DExports.foo();
 E();
-E.bar();
+EExports.bar();
 F();
-let o = new F.G();
-F.G.baz();
+let o = new FExports.G();
+FExports.G.baz();
 stuff();
-stuff.fun();
+Z.fun();

--- a/src/test/java/com/google/javascript/gents/multiTests/import_rewrite/import.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/import_rewrite/import.ts
@@ -1,9 +1,5 @@
 import './export';
 
-import * as Z from './export';
-import * as FExports from './export';
-import * as EExports from './export';
-import * as DExports from './export';
 import * as C from './export';
 import {B} from './export';
 import {D} from './export';
@@ -14,11 +10,11 @@ import {Z as stuff} from './export';
 B();
 let num = C.x + C.y;
 D();
-DExports.foo();
+D.foo();
 E();
-EExports.bar();
+E.bar();
 F();
-let o = new FExports.G();
-FExports.G.baz();
+let o = new F.G();
+F.G.baz();
 stuff();
-Z.fun();
+stuff.fun();

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_both.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_both.js
@@ -1,5 +1,5 @@
 goog.module("both.A.B.C.D");
 
-exports = function() {};
+exports = class D {};
 exports.x = 4;
-exports.foo = function() {};
+exports.bar = function() {};

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_both.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_both.ts
@@ -1,5 +1,5 @@
-export function D() {}
+export class D {}
 
 export const x = 4;
 
-export function foo() {}
+export function bar() {}

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_named.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_named.js
@@ -1,0 +1,5 @@
+goog.module("named.A.B");
+
+exports.x = 4;
+exports.foo = function() {};
+exports.bar = function(n) {};

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_named.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_named.ts
@@ -1,0 +1,5 @@
+export const x = 4;
+
+export function foo() {}
+
+export function bar(n) {}

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.js
@@ -1,5 +1,24 @@
+goog.module("import.binding.barrel");
+
+goog.require("sideeffect.A.B.C");
 var A = goog.require("default.A");
 var X = goog.require("default.A");
-var B = goog.require("namespace.A.B");
-let C = goog.require("sideeffect.A.B.C");
+const {foo} = goog.require("named.A.B");
+var namespace = goog.require("namespace.A.B");
 const D = goog.require("both.A.B.C.D");
+const {bar} = goog.require("both.A.B.C.D");
+
+// Use imports from a namespace.
+namespace.foo();
+namespace.bar(namespace.x);
+
+// Use destructured import.
+foo();
+
+// Use import from a file that has both default and named exports.
+const D = new D();
+bar(D.x);
+
+// Use imports with default and local names.
+const aInstance = new A();
+const aInstanceAsX = new X();

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.ts
@@ -1,7 +1,27 @@
 import './export_sideeffect';
 
-import * as DExports from './export_both';
-import {D} from './export_both';
 import {A} from './export_default';
 import {A as X} from './export_default';
-import * as B from './export_namespace';
+import {foo} from './export_named';
+
+export {};
+
+import * as namespace from './export_namespace';
+import {D} from './export_both';
+import * as DExports from './export_both';
+import {bar} from './export_both';
+
+// Use imports from a namespace.
+namespace.foo();
+namespace.bar(namespace.x);
+
+// Use destructured import.
+foo();
+
+// Use import from a file that has both default and named exports.
+const D;
+bar(DExports.x);
+
+// Use imports with default and local names.
+const aInstance = new A();
+const aInstanceAsX = new X();

--- a/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/import.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/import.ts
@@ -3,7 +3,7 @@ import E from 'goog:keep.E';
 import * as A from './imported_module';
 import {A as X} from './imported_module';
 import * as B from './imported_provide';
-import {C} from './unimported_module';
+import {foo} from './unimported_module';
 import {typC} from './unimported_module';
 import {typD} from './unimported_provide';
 
@@ -14,4 +14,4 @@ let b: A.typA = A.valA;
 let c: X = A.valA;
 let d: A.typA = A.valA;
 let e: B.typB = B.valB;
-let foo = function(f: C, g: typC, h: typD, i: E) {};
+let foo = function(f: foo, g: typC, h: typD, i: E) {};


### PR DESCRIPTION
Fix for NPE when converting a goog.module with a destructured assignment.

Add support for importing a single destructured import value (#392).


Triggering code:
```javascript
goog.module('path.to.FooUser');

const {foo} = goog.require('path.to.foo');
```

Stack trace:
```
java.lang.RuntimeException: INTERNAL COMPILER ERROR.
Please report this problem.

null
  Node(CONST): path/to/file_test.js:6:0
const {ImportedValue} = goog.require('path.to.file');
  Parent(MODULE_BODY): path/to/file_test.js:1:0
goog.module('path.to.FileTest');

        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:779)
        at com.google.javascript.gents.ModuleConversionPass$ModuleExportConverter.collectMetdataForExports(ModuleConversionPass.java:178)
        at com.google.javascript.gents.ModuleConversionPass$ModuleExportConverter.visit(ModuleConversionPass.java:110)
```