### PR TITLE
Add $ to regex that matches on param names, so they get stripped.

### DIFF
--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -28,7 +28,7 @@ public final class CommentLinkingPass implements CompilerPass {
       Pattern.compile("@(extends|implements|type)[ \t]*(\\{.*\\})[ \t]*(?<keep>)"),
       Pattern.compile("@(private|protected|public|package|const)[ \t]*(\\{.*\\})?[ \t]*(?<keep>)"),
       // Removes @param and @return if there is no description
-      Pattern.compile("@param[ \t]*(\\{.*\\})[ \t]*\\w+[ \t]*(?<keep>\\*\\/|\n)"),
+      Pattern.compile("@param[ \t]*(\\{.*\\})[ \t]*[\\w\\$]+[ \t]*(?<keep>\\*\\/|\n)"),
       Pattern.compile("@returns?[ \t]*(\\{.*\\})[ \t]*(?<keep>\\*\\/|\n)"),
       Pattern.compile("(?<keep>@(param|returns?))[ \t]*(\\{.*\\})"),
       // Remove empty lines with only *

--- a/src/test/java/com/google/javascript/gents/singleTests/comments.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/comments.js
@@ -18,6 +18,7 @@ A.prototype.foo = function() {};
 
 /**
  * @param {number} deleted
+ * @param {Foo} $foo
  * @param {number} notdeleted because this has a description
  * @return {number} this also has a description
  */


### PR DESCRIPTION
Fixes #396