### PR TITLE
Add readonly to const parameters properties in gents

### DIFF
--- a/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
+++ b/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
@@ -7,7 +7,6 @@ import com.google.javascript.jscomp.CompilerOptions;
 import com.google.javascript.rhino.JSDocInfo.Visibility;
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.Token;
-
 import java.util.Map;
 
 /**
@@ -109,6 +108,10 @@ public class GentsCodeGenerator extends CodeGenerator {
               default:
                 break;
             }
+          }
+
+          if (n.getBooleanProp(Node.IS_CONSTANT_NAME)) {
+            add("readonly ");
           }
         }
         return false;

--- a/src/test/java/com/google/javascript/gents/singleTests/parameter_prop.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/parameter_prop.js
@@ -18,8 +18,9 @@ function A(a, b, c) {
  * @param {number} b
  * @param {number} c
  * @param {number} d
+ * @param {number} e
  */
-function B(a, b, c, d) {
+function B(a, b, c, d, e) {
   /** @public @type {number} */
   this.a = a;
   /** @package @type {number} */
@@ -28,4 +29,6 @@ function B(a, b, c, d) {
   this.c = c;
   /** @private @type {number} */
   this.d = d;
+  /** @const {number} */
+  this.e = e;
 }

--- a/src/test/java/com/google/javascript/gents/singleTests/parameter_prop.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/parameter_prop.ts
@@ -10,5 +10,5 @@ class A {
 class B {
   constructor(
       public a: number, public b: number, protected c: number,
-      private d: number) {}
+      private d: number, public readonly e: number) {}
 }


### PR DESCRIPTION
This updates constructor parameter properties to be marked `readonly` if the parameter is annotated with `@const` 

Partially addresses #382