### PR TITLE
fix: Only add empty export blocks when necessary

### DIFF
--- a/src/main/java/com/google/javascript/gents/CollectModuleMetadata.java
+++ b/src/main/java/com/google/javascript/gents/CollectModuleMetadata.java
@@ -88,6 +88,12 @@ public final class CollectModuleMetadata extends AbstractTopLevelCallback implem
           case "goog.provide":
             registerProvidesModule(child, filename, child.getLastChild().getString());
             break;
+          case "goog.require":
+            FileModule module = fileToModule.get(filename);
+            if (module != null) {
+              module.reportImport();
+            }
+            break;
           default:
             break;
         }
@@ -148,6 +154,9 @@ public final class CollectModuleMetadata extends AbstractTopLevelCallback implem
     /** Declared with goog.module rather than goog.provide */
     private final boolean isGoogModule;
 
+    /** {@code True}, if the module has any imports (e.g.{@code goog.require}). */
+    private boolean hasImports = false;
+
     /**
      * Map from each provided namespace to all exported subproperties. Note that only namespaces
      * declared with 'goog.module' or 'goog.provide' are considered provided. Their subproperties
@@ -199,6 +208,16 @@ public final class CollectModuleMetadata extends AbstractTopLevelCallback implem
     /** Returns if the file actually exports any symbols. */
     boolean hasExports() {
       return !exportedNamespacesToSymbols.isEmpty();
+    }
+
+    /** Records that the module has at least one import. */
+    void reportImport() {
+      this.hasImports = true;
+    }
+
+    /** Returns {@code true} if the module has at least one import. */
+    boolean hasImports() {
+      return this.hasImports;
     }
 
     /**

--- a/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
@@ -88,11 +88,16 @@ public final class ModuleConversionPass implements CompilerPass {
       if (n.isScript()) {
         if (fileToModule.containsKey(fileName)) {
           // Module is declared purely for side effects
-          if (!fileToModule.get(fileName).hasExports()) {
+          FileModule module = fileToModule.get(fileName);
+          if (!module.hasImports() && !module.hasExports()) {
             // export {};
-            // TODO(renez): Add comment to explain that this statement is used to change file
-            // into a module.
-            Node exportNode = new Node(Token.EXPORT, new Node(Token.EXPORT_SPECS));
+            Node commentNode = new Node(Token.EMPTY);
+            nodeComments.putComment(
+                commentNode,
+                "\n//  Empty export added to coerce the file to be a module, since it does not have"
+                + " any imports or exports.");
+
+            Node exportNode = new Node(Token.EXPORT, new Node(Token.EXPORT_SPECS, commentNode));
 
             if (n.hasChildren() && n.getFirstChild().isModuleBody()) {
               n.getFirstChild().addChildToFront(exportNode);

--- a/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/import.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/import.ts
@@ -4,8 +4,6 @@ import X from 'goog:lib.C';
 import * as AExports from './export';
 import {A} from './export';
 
-export {};
-
 A();
 AExports.foo();
 B();

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_sideeffect.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_sideeffect.ts
@@ -1,2 +1,5 @@
-export {};
+export {
+  //  Empty export added to coerce the file to be a module, since it does not
+  //  have any imports or exports.
+};
 console.log('hello');

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.ts
@@ -1,11 +1,7 @@
 import './export_sideeffect';
-
 import {A} from './export_default';
 import {A as X} from './export_default';
 import {foo} from './export_named';
-
-export {};
-
 import * as namespace from './export_namespace';
 import {D} from './export_both';
 import * as DExports from './export_both';

--- a/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/import.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/import.ts
@@ -7,8 +7,6 @@ import {foo} from './unimported_module';
 import {typC} from './unimported_module';
 import {typD} from './unimported_provide';
 
-export {};
-
 let a: X = A.valA;
 let b: A.typA = A.valA;
 let c: X = A.valA;


### PR DESCRIPTION
Summary:
The current implementation adds empty export blocks to the file, if the file does not have an exports; however, empty export blocks are only needed to coerce a file to a module if has neither imports nor exports. 

To fix this, we augment the `FileModule` to record whether the module has any `goog.require`s, and then only add the empty block to the files without either.   When we do add the empty export block, also add a comment explaining its purpose. 