### PR TITLE
fix: UnsupportedOperationException in TypeConversionPass

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeConversionPass.java
@@ -151,7 +151,8 @@ public final class TypeConversionPass implements CompilerPass {
         }
 
         Node fnNode = NodeUtil.getEnclosingFunction(n);
-        String fnName = fnNode.getParent().getString();
+        Node fnParent = fnNode.getParent();
+        String fnName = (fnParent.isGetProp()) ? fnParent.getQualifiedName() : fnParent.getString();
 
         // TODO(gmoothart): in many cases we should be able to infer the type from the rhs if there
         // is no jsDoc

--- a/src/main/java/com/google/javascript/gents/TypeConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeConversionPass.java
@@ -152,7 +152,10 @@ public final class TypeConversionPass implements CompilerPass {
 
         Node fnNode = NodeUtil.getEnclosingFunction(n);
         Node fnParent = fnNode.getParent();
-        String fnName = (fnParent.isGetProp()) ? fnParent.getQualifiedName() : fnParent.getString();
+
+        // Use the QualifiedName if the function is on an object/namespace: `foo.moreFoo()`;
+        // otherwise, use the string on the node `function foo()` => `foo`.
+        String fnName = fnParent.isGetProp()? fnParent.getQualifiedName() : fnParent.getString();
 
         // TODO(gmoothart): in many cases we should be able to infer the type from the rhs if there
         // is no jsDoc


### PR DESCRIPTION
at com.google.javascript.rhino.Node.getString(Node.java:1116)
at com.google.javascript.gents.TypeConversionPass$FieldOnThisConverter.visit(TypeConversionPass.java:154)
Caused by: java.lang.UnsupportedOperationException: GETPROP 60 [length:
440] [source_file:path/to/file.js] is not a string node