### PR TITLE
fix: Don't add empty exports when assigning goog.require to a var.

### DIFF
--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_assignment.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_assignment.js
@@ -1,0 +1,3 @@
+goog.module("no.empty.export.with.import");
+
+const A = goog.require("default.A");

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_assignment.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_assignment.ts
@@ -1,0 +1,1 @@
+import {A} from './export_default';


### PR DESCRIPTION
Summary:
The current ‘no empty export’ detection mechanism doesn’t take into account cases where the goog.require is assigned to a value. (e.g. `const A = goog.require(‘A’);`)
