### PR TITLE
fix: Make newline insertion more consistent.

### DIFF
--- a/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
+++ b/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
@@ -64,20 +64,23 @@ public class GentsCodeGenerator extends CodeGenerator {
 
   /** Add newlines to the generated source. */
   private void maybeAddNewline(Node n) {
-    Node previousNode = n.getPrevious();
     boolean hasComment =
         nodeComments.hasComment(n)
             || nodeComments.hasComment(n.getParent())
-            || isEmptyAndHasComment(previousNode)
-            || (n.getParent() != null && isEmptyAndHasComment(n.getParent().getPrevious()));
+            || isPreviousEmptyAndHasComment(n)
+            || (n.getParent() != null && isPreviousEmptyAndHasComment(n.getParent()));
 
     if (!hasComment && TOKENS_TO_ADD_NEWLINES_BEFORE.contains(n.getToken())) {
       add("\n");
     }
   }
 
-  private boolean isEmptyAndHasComment(Node n) {
-    return n != null && n.getToken() == Token.EMPTY && nodeComments.hasComment(n);
+  private boolean isPreviousEmptyAndHasComment(Node n) {
+    if (n == null || n.getParent() == null) {
+      return false;
+    }
+    Node prev = n.getPrevious();
+    return prev != null && prev.getToken() == Token.EMPTY && nodeComments.hasComment(prev);
   }
 
   /**

--- a/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
+++ b/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
@@ -25,10 +25,11 @@ public class GentsCodeGenerator extends CodeGenerator {
 
   @Override
   protected void add(Node n, Context ctx) {
+    maybeAddNewline(n);
+
     String comment = nodeComments.getComment(n);
     if (comment != null) {
       add(comment);
-      // temporary new line
       add("\n");
     }
 
@@ -55,23 +56,28 @@ public class GentsCodeGenerator extends CodeGenerator {
       default:
         break;
     }
-
-    addNewlines(n);
   }
 
   private static final ImmutableSet<Token> TOKENS_TO_ADD_NEWLINES_BEFORE =
       ImmutableSet.of(
           Token.CLASS, Token.EXPORT, Token.FUNCTION, Token.INTERFACE, Token.MEMBER_FUNCTION_DEF);
 
-  /** Add newlines to the generated source */
-  private void addNewlines(Node n) {
-    Node nextNode = n.getNext();
-    if (nextNode != null) {
-      if (nodeComments.getComment(nextNode) == null // Comments already prepend a newline.
-          && TOKENS_TO_ADD_NEWLINES_BEFORE.contains(nextNode.getToken())) {
-        add("\n");
-      }
+  /** Add newlines to the generated source. */
+  private void maybeAddNewline(Node n) {
+    Node previousNode = n.getPrevious();
+    boolean hasComment = nodeComments.hasComment(n) || nodeComments.hasComment(n.getParent());
+    if (isEmptyAndHasComment(previousNode)
+        || (n.getParent() != null && isEmptyAndHasComment(n.getParent().getPrevious()))) {
+      hasComment = true;
     }
+
+    if (!hasComment && TOKENS_TO_ADD_NEWLINES_BEFORE.contains(n.getToken())) {
+      add("\n");
+    }
+  }
+
+  private boolean isEmptyAndHasComment(Node n) {
+    return n != null && n.getToken() == Token.EMPTY && nodeComments.hasComment(n);
   }
 
   /**
@@ -121,14 +127,6 @@ public class GentsCodeGenerator extends CodeGenerator {
         if (anyTypeName != null) {
           add(anyTypeName);
           return true;
-        }
-        return false;
-      case MEMBER_FUNCTION_DEF:
-        // Add special newline insertion handling for constructors, since adding a newline after
-        // a node doesn't work between properties and the constructor due to semi-colon insertion.
-        if ("constructor".equals(n.getString())
-            && nodeComments.getComment(n) == null) {
-          add("\n");
         }
         return false;
       default:

--- a/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
+++ b/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
@@ -65,11 +65,11 @@ public class GentsCodeGenerator extends CodeGenerator {
   /** Add newlines to the generated source. */
   private void maybeAddNewline(Node n) {
     Node previousNode = n.getPrevious();
-    boolean hasComment = nodeComments.hasComment(n) || nodeComments.hasComment(n.getParent());
-    if (isEmptyAndHasComment(previousNode)
-        || (n.getParent() != null && isEmptyAndHasComment(n.getParent().getPrevious()))) {
-      hasComment = true;
-    }
+    boolean hasComment =
+        nodeComments.hasComment(n)
+            || nodeComments.hasComment(n.getParent())
+            || isEmptyAndHasComment(previousNode)
+            || (n.getParent() != null && isEmptyAndHasComment(n.getParent().getPrevious()));
 
     if (!hasComment && TOKENS_TO_ADD_NEWLINES_BEFORE.contains(n.getToken())) {
       add("\n");

--- a/src/test/java/com/google/javascript/gents/multiTests/goog_provide_rewrite/export.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/goog_provide_rewrite/export.ts
@@ -1,3 +1,4 @@
+
 export function aFunction() {}
 
 export class ImportedClass {}

--- a/src/test/java/com/google/javascript/gents/multiTests/goog_provide_rewrite/goog_scope.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/goog_provide_rewrite/goog_scope.ts
@@ -6,6 +6,7 @@ import {ProvidedSubclass} from './export';
 let instanceOfAlias = new ImportedClass();
 let instanceofProvidedAlias = new ImportedClass.ProvidedSubclass();
 let instanceofNotProvidedAlias = new ImportedClass.NotProvidedSubclass();
+
 export class Foo {
   static num: number = 8;
 

--- a/src/test/java/com/google/javascript/gents/multiTests/import_rewrite/export.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/import_rewrite/export.ts
@@ -1,3 +1,4 @@
+
 export function B() {}
 
 export const x = 4;

--- a/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/export.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/export.ts
@@ -1,3 +1,4 @@
+
 export function A() {}
 
 export function foo() {}

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_both.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_both.ts
@@ -1,3 +1,4 @@
+
 export class D {}
 
 export const x = 4;

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_default.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_default.ts
@@ -1,3 +1,4 @@
+
 export class A {
   constructor(public n: number) {}
 }

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_named.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_named.ts
@@ -1,3 +1,4 @@
+
 export const x = 4;
 
 export function foo() {}

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_namespace.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_namespace.ts
@@ -1,3 +1,4 @@
+
 export const x = 4;
 
 export function foo() {}

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_sideeffect.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/export_sideeffect.ts
@@ -1,3 +1,4 @@
+
 export {
   // gents: force this file to be an ES6 module (no imports or exports)
 };

--- a/src/test/java/com/google/javascript/gents/multiTests/provide_imports/export.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/provide_imports/export.ts
@@ -1,3 +1,4 @@
+
 export function B() {}
 
 export const x = 4;

--- a/src/test/java/com/google/javascript/gents/multiTests/provide_imports/export_module.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/provide_imports/export_module.ts
@@ -1,3 +1,4 @@
+
 export function Z() {}
 
 export function foo() {}

--- a/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/imported_module.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/imported_module.ts
@@ -1,3 +1,4 @@
+
 export class foo {};
 
 export const typA = foo;

--- a/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/imported_provide.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/imported_provide.ts
@@ -1,3 +1,4 @@
+
 class foo {}
 
 export const typB = foo;

--- a/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/unimported_module.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/unimported_module.ts
@@ -1,3 +1,4 @@
+
 export class foo {};
 
 export const typC = foo;

--- a/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/unimported_provide.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/unimported_provide.ts
@@ -1,3 +1,4 @@
+
 class foo {}
 
 export const typD = foo;

--- a/src/test/java/com/google/javascript/gents/singleTests/access_modifiers.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/access_modifiers.ts
@@ -1,3 +1,4 @@
+
 class A {
   // Static field access
   protected static sa: number;

--- a/src/test/java/com/google/javascript/gents/singleTests/const.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/const.ts
@@ -1,6 +1,7 @@
 const a = 1;
 const b: number = 2;
 const c = 3;
+
 function foo() {}
 
 function bar(n: number): number {

--- a/src/test/java/com/google/javascript/gents/singleTests/export_rewrite.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/export_rewrite.ts
@@ -1,3 +1,4 @@
+
 export function B() {}
 
 export class Klass { static NUM: number = 4; }

--- a/src/test/java/com/google/javascript/gents/singleTests/fields.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/fields.ts
@@ -1,3 +1,4 @@
+
 class A {
   e: number = 8;
   f: any;

--- a/src/test/java/com/google/javascript/gents/singleTests/fn_types.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/fn_types.ts
@@ -21,6 +21,7 @@ let optParams: (p1: number, p2?: string, p3?: boolean) =>
 // Variadic parameters
 let restParams: (p1: number, ...p2) => any = function(n, r) {};
 let restParamsTyped: (p1: number, ...p2: boolean[]) => any = function(n, br) {};
+
 function complex(n: number, o?: boolean, ...r: any[]): number {
   return n;
 }

--- a/src/test/java/com/google/javascript/gents/singleTests/functions.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/functions.ts
@@ -2,12 +2,14 @@ let nop = function() {};
 
 // Function params
 let oneParam = function(n: number) {};
+
 function twoParams(b: boolean, s: string) {}
 
 // Function returns
 let anyReturn = function(): any {
   return 'hello';
 };
+
 function typedReturn(): number {
   return 4;
 }

--- a/src/test/java/com/google/javascript/gents/singleTests/goog_provide.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/goog_provide.ts
@@ -5,6 +5,7 @@
 
 // This is used to test muli-level calls.
 let path = {to: {someUtilFunction: function() {}}};
+
 export class B {
   static num: number = 8;
 

--- a/src/test/java/com/google/javascript/gents/singleTests/inline_types.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/inline_types.ts
@@ -1,3 +1,4 @@
+
 interface Foo {}
 /** !Foo */
 let foo: Foo = {};

--- a/src/test/java/com/google/javascript/gents/singleTests/interface.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/interface.ts
@@ -1,3 +1,4 @@
+
 interface Interface {
   bar(a: string): number;
 }

--- a/src/test/java/com/google/javascript/gents/singleTests/module_both.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_both.ts
@@ -6,7 +6,9 @@ let num = 4;
 let B = function(): number {
   return num;
 };
+
 export {B};
+
 export function C(): number {
   return num;
 };
@@ -17,6 +19,7 @@ export function C(): number {
 let L = function(): number {
   return num;
 };
+
 export {L};
 
 export {num};

--- a/src/test/java/com/google/javascript/gents/singleTests/module_class.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_class.ts
@@ -1,3 +1,4 @@
+
 export class Klass {
   static x: number = 4;
 

--- a/src/test/java/com/google/javascript/gents/singleTests/module_class2.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_class2.js
@@ -3,6 +3,7 @@
  */
 goog.module("A.B.Klass");
 
+
 /** Possibly outdated information about Klass. */
 const Klass = goog.defineClass(null, {
 

--- a/src/test/java/com/google/javascript/gents/singleTests/module_default.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_default.ts
@@ -1,3 +1,4 @@
+
 export function B(): number {
   return 4;
 }

--- a/src/test/java/com/google/javascript/gents/singleTests/module_namespace.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_namespace.ts
@@ -1,6 +1,7 @@
 let bar = function(): boolean {
   return true;
 };
+
 export const x: number = 4;
 
 export function foo(): number {

--- a/src/test/java/com/google/javascript/gents/singleTests/parameter_prop.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/parameter_prop.ts
@@ -1,3 +1,4 @@
+
 class A {
   b: any;
   c: number;

--- a/src/test/java/com/google/javascript/gents/singleTests/static_methods.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/static_methods.ts
@@ -53,6 +53,7 @@ class A {
 
   static anon() {
     // Anonymous function call
+
     (function() {})();
   }
 }

--- a/src/test/java/com/google/javascript/gents/singleTests/untyped.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/untyped.ts
@@ -5,6 +5,7 @@ let s = 'hello';
 let foo = function(v) {
   return v;
 };
+
 function bar(b) {
   return !b;
 }


### PR DESCRIPTION
Summary:
Currently newline insertion breaks when the previous node ends with a semi-colon, due to Closure Compiler's automatic semi-colon insertion. This PR changes the insertion logic to insert a newline before the node is written, so that it does not fall victim to semi-colon insertion.

That is, currently Gents outputs:

``` typescript
const foo = 4
;
export class Bar {}
```

which gets formatted by clang-format to:

``` typescript
const foo = 4;
export class Bar {}
```

With this PR, Gents will output:

``` typescript
const foo = 4;

export class Bar {}
```
