### PR TITLE
Do not strip empty jsdoc lines used for spacing

### DIFF
--- a/src/test/java/com/google/javascript/gents/singleTests/comments.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/comments.js
@@ -17,6 +17,9 @@ var A = function() {};
 A.prototype.foo = function() {};
 
 /**
+ * This is a comment
+ *
+ * with empty line breaks that are preserved
  * @param {number} deleted
  * @param {Foo} $foo
  * @param {number} notdeleted because this has a description
@@ -25,13 +28,14 @@ A.prototype.foo = function() {};
 // This is just some extra stuff
 var foo = function(deleted, notdeleted) { return deleted + notdeleted; };
 
-// The following comment should be entirely deleted
+// The following comment should be mostly deleted
 /**
  * @constructor
  * @extends {A}
  * @type {number}
  * @private {number}
  * @protected {number}
+ * @param {number} foo description of foo
  * @public {number}
  * @package {number}
  * @const {number}

--- a/src/test/java/com/google/javascript/gents/singleTests/comments.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/comments.ts
@@ -17,6 +17,9 @@ class A {
 // Here too
 
 /**
+ * This is a comment
+ *
+ * with empty line breaks that are preserved
  * @param notdeleted because this has a description
  * @return this also has a description
  */
@@ -25,7 +28,10 @@ let foo = function(deleted: number, notdeleted: number): number {
   return deleted + notdeleted;
 };
 
-// The following comment should be entirely deleted
+// The following comment should be mostly deleted
+/**
+ * @param foo description of foo
+ */
 const x;
 
 /** @export */


### PR DESCRIPTION
Updates the comment regexes so that, instead of removing all blank lines
indiscriminately, we just remove matching lines if there is nothing in
the `keep` capture group.

fixes #385