### PR TITLE
fix: Add support for constructor params with default values.

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeConversionPass.java
@@ -171,9 +171,11 @@ public final class TypeConversionPass implements CompilerPass {
           JSDocInfo constructorJsDoc = NodeUtil.getBestJSDocInfo(fnNode);
 
           for (Node param : params.children()) {
-            JSTypeExpression paramType = constructorJsDoc.getParameterType(param.getString());
+            String paramName =
+                param.isDefaultValue() ? param.getFirstChild().getString() : param.getString();
+            JSTypeExpression paramType = constructorJsDoc.getParameterType(paramName);
             // Names and types must be equal
-            if (declaration.memberName.equals(param.getString()) && declarationType.equals(paramType)) {
+            if (declaration.memberName.equals(paramName) && declarationType.equals(paramType)) {
               // Add visibility directly to param if possible
               moveAccessModifier(declaration, param);
               markAsConst(declaration, param);

--- a/src/test/java/com/google/javascript/gents/singleTests/functions.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/functions.js
@@ -12,6 +12,9 @@ var oneParam = function(n) {};
  */
 function twoParams(b, s) {}
 
+/** @param {!Array<?>=} list */
+function withDefaultValue(list = []) {}
+
 // Function returns
 /**
  * @return {*}

--- a/src/test/java/com/google/javascript/gents/singleTests/functions.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/functions.ts
@@ -5,6 +5,8 @@ let oneParam = function(n: number) {};
 
 function twoParams(b: boolean, s: string) {}
 
+function withDefaultValue(list = []) {}
+
 // Function returns
 let anyReturn = function(): any {
   return 'hello';

--- a/src/test/java/com/google/javascript/gents/singleTests/module_class3.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_class3.js
@@ -3,10 +3,15 @@ goog.module("A.B.Klass");
 /** Possibly outdated information about Klass. */
 class Klass {
 
-  /** @param {number} n */
-  constructor(n) {
+  /** 
+   * @param {number} n
+   * @param {Array<?>=} list
+   */
+  constructor(n, list = []) {
     this.n = n;
-
+    
+    /** @const {Array<?>} */
+    this.list = list;
     this.x = 4;
   }
 

--- a/src/test/java/com/google/javascript/gents/singleTests/module_class3.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_class3.ts
@@ -2,10 +2,12 @@
 /** Possibly outdated information about Klass. */
 export class Klass {
   n: any;
+  list: any[];
   x: any = 4;
 
-  constructor(n: number) {
+  constructor(n: number, list = []) {
     this.n = n;
+    this.list = list;
   }
 
   foo(): boolean {


### PR DESCRIPTION
Fixes:
```
DEFAULT_VALUE 12 [length: 13] [source_file: path/to/file.js] is not a string node
  Node(EXPR_RESULT): path/to/file.js:20:4
    this.children = children;
  Parent(BLOCK): path/to/file_with_default_value.js:12:48
  constructor(name, children = []) 
```