### PR TITLE
Support enums nested in typedefs that are defined in externs

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -632,9 +632,9 @@ class DeclarationGenerator {
     if (isPrivate(type.getJSDocInfo()) && !isConstructor(type.getJSDocInfo())) {
       return true;
     }
-    // Only var declarations have collisions, while class, interface, and functions can coexist with
-    // namespaces.
-    if (type.isInterface() || type.isConstructor() || type.isFunctionType()) {
+    // Only var declarations have collisions, while class, interface, function, and typedef can
+    // coexist with namespaces.
+    if (type.isInterface() || type.isConstructor() || type.isFunctionType() || isTypedef(type)) {
       return false;
     }
     return isDefaultExport(symbol);

--- a/src/test/java/com/google/javascript/clutz/nested_typedef_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/nested_typedef_enum.d.ts
@@ -1,0 +1,20 @@
+declare namespace ಠ_ಠ.clutz.nested_typedef_enum {
+  type Bar = { a : string } ;
+}
+declare module 'goog:nested_typedef_enum.Bar' {
+  import alias = ಠ_ಠ.clutz.nested_typedef_enum.Bar;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.nested_typedef_enum.Bar {
+  type Baz = number ;
+  var Baz : {
+    A : Baz ,
+  };
+}
+declare namespace goog {
+  function require(name: 'nested_typedef_enum.Bar.Baz'): typeof ಠ_ಠ.clutz.nested_typedef_enum.Bar.Baz;
+}
+declare module 'goog:nested_typedef_enum.Bar.Baz' {
+  import alias = ಠ_ಠ.clutz.nested_typedef_enum.Bar.Baz;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/nested_typedef_enum.externs.js
+++ b/src/test/java/com/google/javascript/clutz/nested_typedef_enum.externs.js
@@ -1,0 +1,5 @@
+/** @externs */
+
+/** @suppress {duplicate} */
+var nested_typedef_enum;
+nested_typedef_enum.Bar;

--- a/src/test/java/com/google/javascript/clutz/nested_typedef_enum.js
+++ b/src/test/java/com/google/javascript/clutz/nested_typedef_enum.js
@@ -1,0 +1,8 @@
+goog.provide('nested_typedef_enum.Bar');
+goog.provide('nested_typedef_enum.Bar.Baz');
+
+/** @typedef {{a: string}} */
+nested_typedef_enum.Bar;
+
+/** @enum {number} */
+nested_typedef_enum.Bar.Baz = {A: 1};

--- a/src/test/java/com/google/javascript/clutz/nested_typedef_enum_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/nested_typedef_enum_usage.ts
@@ -1,0 +1,5 @@
+import Bar from 'goog:nested_typedef_enum.Bar';
+import Baz from 'goog:nested_typedef_enum.Bar.Baz';
+
+const x: Bar = {a: 'a'};
+const y = Baz.A;


### PR DESCRIPTION
This surprising pattern is from an actual piece of code encountered in the wild.
It is an obscure corner case, and it is unclear whether the NoType check is
correct or might trigger in other programs. I will try this change out on a
larger code base and see if it breaks things.