### PR TITLE
perf: Single quotes + free up completed compiler passes

### DIFF
--- a/src/main/java/com/google/javascript/gents/Options.java
+++ b/src/main/java/com/google/javascript/gents/Options.java
@@ -75,6 +75,7 @@ public class Options {
     options.setWrapGoogModulesForWhitespaceOnly(false);
     // Stop escaping the characters "=&<>"
     options.setTrustedStrings(true);
+    options.setPreferSingleQuotes(true);
 
     // Compiler passes must be disabled to disable down-transpilation to ES5.
     options.skipAllCompilerPasses();


### PR DESCRIPTION
- Don't store completed compiler passes in locals unless they are used
later.
- Add visibility & static modifiers where appropriate.
- Output single quotes instead of double quotes to reduce the work
needed by clang-format.