### PR TITLE
Validate the AST, print file name when codegen fails.

### DIFF
--- a/src/main/java/com/google/javascript/gents/NodeComments.java
+++ b/src/main/java/com/google/javascript/gents/NodeComments.java
@@ -34,6 +34,7 @@ public class NodeComments {
   }
 
   void replaceWithComment(Node oldNode, Node newNode) {
+    newNode.useSourceInfoFrom(newNode);
     oldNode.getParent().replaceChild(oldNode, newNode);
     moveComment(oldNode, newNode);
   }

--- a/src/main/java/com/google/javascript/gents/Options.java
+++ b/src/main/java/com/google/javascript/gents/Options.java
@@ -68,7 +68,7 @@ public class Options {
     // Report duplicate definitions, e.g. for accidentally duplicated externs.
     options.setWarningLevel(DiagnosticGroups.DUPLICATE_VARS, CheckLevel.ERROR);
 
-    options.setLanguage(CompilerOptions.LanguageMode.ECMASCRIPT6);
+    options.setLanguage(CompilerOptions.LanguageMode.ECMASCRIPT6_TYPED);
     options.setLanguageOut(CompilerOptions.LanguageMode.NO_TRANSPILE);
 
     // Do not transpile module declarations

--- a/src/main/java/com/google/javascript/gents/Options.java
+++ b/src/main/java/com/google/javascript/gents/Options.java
@@ -68,7 +68,7 @@ public class Options {
     // Report duplicate definitions, e.g. for accidentally duplicated externs.
     options.setWarningLevel(DiagnosticGroups.DUPLICATE_VARS, CheckLevel.ERROR);
 
-    options.setLanguage(CompilerOptions.LanguageMode.ECMASCRIPT6_TYPED);
+    options.setLanguage(CompilerOptions.LanguageMode.ECMASCRIPT6);
     options.setLanguageOut(CompilerOptions.LanguageMode.NO_TRANSPILE);
 
     // Do not transpile module declarations

--- a/src/main/java/com/google/javascript/gents/RemoveGoogScopePass.java
+++ b/src/main/java/com/google/javascript/gents/RemoveGoogScopePass.java
@@ -100,6 +100,7 @@ public final class RemoveGoogScopePass extends AbstractTopLevelCallback implemen
         break;
       case ASSIGN:
         maybeReasignAlias(node.getFirstChild());
+        break;
       default:
         break;
     }

--- a/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
@@ -118,6 +118,7 @@ public final class TypeAnnotationPass implements CompilerPass {
               for (JSTypeExpression type : interfaces) {
                 impls.addChildToBack(convertTypeNodeAST(type.getRoot()));
               }
+              impls.useSourceInfoFrom(n);
               n.putProp(Node.IMPLEMENTS, impls);
             }
           }

--- a/src/main/java/com/google/javascript/gents/TypeConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeConversionPass.java
@@ -270,6 +270,7 @@ public final class TypeConversionPass implements CompilerPass {
           .getFirstChild() // ignore the ! node as we always output non nullable types
           .getString();
       superClass = NodeUtil.newQName(compiler, superClassName);
+      superClass.useSourceInfoFrom(n);
     }
 
     Node typeNode;
@@ -283,6 +284,7 @@ public final class TypeConversionPass implements CompilerPass {
         superClass = superInterfaces;
       }
       typeNode = new Node(Token.INTERFACE, name, superClass, new Node(Token.INTERFACE_MEMBERS));
+      typeNode.useSourceInfoFromForTree(n);
       // Must be registered here, as JSCompiler cannot extract names from INTERFACE nodes.
       addTypeToScope(typeNode, typeName);
     } else {
@@ -291,6 +293,7 @@ public final class TypeConversionPass implements CompilerPass {
           "constructor",
           IR.function(IR.name(""), params, body)
       );
+      constructor.useSourceInfoFrom(n);
       // Sets jsdoc info to preserve type declarations on method
       constructor.setJSDocInfo(jsDoc);
       Node classMembers = new Node(Token.CLASS_MEMBERS, constructor);
@@ -315,6 +318,7 @@ public final class TypeConversionPass implements CompilerPass {
     }
 
     Node classMembers = new Node(Token.CLASS_MEMBERS);
+    classMembers.useSourceInfoFrom(n);
     for (Node child : n.getLastChild().children()) {
       if (child.isStringKey() || child.isMemberFunctionDef()) {
         // Handle static methods
@@ -332,6 +336,7 @@ public final class TypeConversionPass implements CompilerPass {
       }
     }
     Node classNode = new Node(Token.CLASS, IR.empty(), superClass, classMembers);
+    classNode.useSourceInfoFrom(n);
 
     nodeComments.replaceWithComment(n, classNode);
     compiler.reportCodeChange();

--- a/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
+++ b/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
@@ -188,18 +188,6 @@ public class TypeScriptGenerator {
 
     new StyleFixPass(compiler, comments).process(externRoot, srcRoot);
 
-    // Sadly this doesn't work. Gents produces an AST that doesn't validate for class fields that
-    // get initialized ("class X { y = 1; }"), which Closure Compiler rejects.
-    //new AstValidator(
-    //        compiler,
-    //        new AstValidator.ViolationHandler() {
-    //          @Override
-    //          public void handleViolation(String message, Node n) {
-    //            compiler.report(JSError.make(n, GENTS_MALFORMED_AST, message));
-    //          }
-    //        })
-    //    .process(externRoot, srcRoot);
-
     // We only use the source root as the extern root is ignored for codegen
     for (Node file : srcRoot.children()) {
       try {

--- a/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
+++ b/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
@@ -37,7 +37,7 @@ import org.kohsuke.args4j.CmdLineException;
  * TypeScript.
  */
 public class TypeScriptGenerator {
-  /** Diagnostic that indicates Clutz somehow produced an incorrect AST structure. */
+  /** Diagnostic that indicates Gents somehow produced an incorrect AST structure. */
   private static final DiagnosticType CLUTZ_MALFORMED_AST = DiagnosticType.error(
       "CLUTZ_INTERNAL_ERROR", "Clutz produced a malformed AST: {0}");
   /**
@@ -218,6 +218,7 @@ public class TypeScriptGenerator {
         sourceFileMap.put(filepath, tryClangFormat(tsCode));
       } catch (Throwable t) {
         System.err.println("Failed while converting " + file.getSourceFileName());
+        throw t;
       }
     }
 

--- a/src/test/java/com/google/javascript/gents/TypeScriptGeneratorMultiTests.java
+++ b/src/test/java/com/google/javascript/gents/TypeScriptGeneratorMultiTests.java
@@ -9,9 +9,12 @@ import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import com.google.javascript.clutz.DeclarationGeneratorTests;
 import com.google.javascript.jscomp.SourceFile;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -82,10 +85,17 @@ public class TypeScriptGeneratorMultiTests extends TypeScriptGeneratorTests {
           }
         }
 
+        ByteArrayOutputStream errStream = new ByteArrayOutputStream();
+        gents.setErrorStream(new PrintStream(errStream));
+
         Map<String, String> transpiledSource = gents.generateTypeScript(
             sourceNames,
             sourceFiles,
             Collections.<SourceFile>emptyList());
+
+        String errors = new String(errStream.toByteArray(),StandardCharsets.UTF_8 );
+        assertThat(errors).isEmpty();
+        assertThat(gents.hasErrors()).isFalse();
 
         assertThat(transpiledSource).hasSize(sourceNames.size());
         for (String basename : goldenFiles.keySet()) {

--- a/src/test/java/com/google/javascript/gents/TypeScriptGeneratorTests.java
+++ b/src/test/java/com/google/javascript/gents/TypeScriptGeneratorTests.java
@@ -9,9 +9,12 @@ import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import com.google.javascript.clutz.DeclarationGeneratorTests;
 import com.google.javascript.jscomp.SourceFile;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -111,10 +114,17 @@ public class TypeScriptGeneratorTests {
         String sourceText = getFileText(sourceFile);
         String goldenText = getFileText(goldenFile);
 
+        ByteArrayOutputStream errStream = new ByteArrayOutputStream();
+        gents.setErrorStream(new PrintStream(errStream));
+
         Map<String, String> transpiledSource = gents.generateTypeScript(
             Collections.singleton(sourceFile.getName()),
             Collections.singletonList(SourceFile.fromCode(sourceFile.getName(), sourceText)),
             Collections.<SourceFile>emptyList());
+
+        String errors = new String(errStream.toByteArray(),StandardCharsets.UTF_8 );
+        assertThat(errors).isEmpty();
+        assertThat(gents.hasErrors()).isFalse();
 
         assertThat(transpiledSource).hasSize(1);
         assertThat(transpiledSource).containsKey(basename);

--- a/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/imported_module.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/imported_module.ts
@@ -1,5 +1,5 @@
 
-export class foo {};
+export class foo {}
 
 export const typA = foo;
 

--- a/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/unimported_module.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/type_rewrite/unimported_module.ts
@@ -1,5 +1,5 @@
 
-export class foo {};
+export class foo {}
 
 export const typC = foo;
 

--- a/src/test/java/com/google/javascript/gents/singleTests/module_both.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_both.ts
@@ -11,7 +11,7 @@ export {B};
 
 export function C(): number {
   return num;
-};
+}
 
 /**
  * Note: `let` may be unsafe to export directly.

--- a/src/test/java/com/google/javascript/gents/singleTests/module_class.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_class.ts
@@ -7,4 +7,4 @@ export class Klass {
   foo(): boolean {
     return false;
   }
-};
+}

--- a/src/test/java/com/google/javascript/gents/singleTests/module_class2.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_class2.ts
@@ -19,4 +19,4 @@ export class Klass {
   static myStaticFunction(): string {
     return '';
   }
-};
+}

--- a/src/test/java/com/google/javascript/gents/singleTests/module_class3.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_class3.ts
@@ -17,4 +17,4 @@ export class Klass {
   static myStaticFunction(): string {
     return '';
   }
-};
+}


### PR DESCRIPTION
Gents already reports the failure location for the various code
visitors, but does not report a location when code generation fails. To
track down AST issues, also validate the AST before emit.