### PR TITLE
fix: Fix issue wherein all comments appear at the top of the file

### DIFF
--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -202,6 +202,11 @@ public final class CommentLinkingPass implements CompilerPass {
       }
 
       while (hasRemainingComments() && !isCommentAdjacentToLine(line)) {
+        // Comment is AFTER this line
+        if (getLastLineOfCurrentComment() > line) {
+          return true;
+        }
+
         // If the new comment is separated from the current one by at least a line,
         // output the current group of comments.
         if (getFirstLineOfNextComment() - getLastLineOfCurrentComment() > 1) {

--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -66,6 +66,8 @@ public final class CommentLinkingPass implements CompilerPass {
   public void process(Node externs, Node root) {
     for (Node script : root.children()) {
       if (script.isScript()) {
+        // Note: this doesn't actually copy the list since the underlying list is already an
+        // immutable list.
         ImmutableList<Comment> comments =
             ImmutableList.copyOf(compiler.getComments(script.getSourceFileName()));
         NodeTraversal.traverseEs6(compiler, script, new LinkCommentsForOneFile(comments));
@@ -211,11 +213,9 @@ public final class CommentLinkingPass implements CompilerPass {
       if (getLastLineOfCurrentComment() == line) {
         // Comment on same line as code
         linkCommentGroupToNode(currentCommentGroup, n);
-
       } else if (getLastLineOfCurrentComment() == line - 1) {
         // Comment ends just before code
         linkCommentGroupToNode(currentCommentGroup, n);
-
       } else if (!hasRemainingComments()) {
         // Exhausted all comments, output floating comment before current node
         parent.addChildBefore(newFloatingComment(currentCommentGroup), n);

--- a/src/test/java/com/google/javascript/gents/multiTests/import_rewrite/export.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/import_rewrite/export.js
@@ -1,3 +1,8 @@
+/**
+ * @fileoverview test comment about this file to ensure comments are 
+ * appropriately placed
+ */
+
 goog.provide("sideeffect.A");
 goog.provide("value.B");
 goog.provide("obj.C");
@@ -6,8 +11,10 @@ goog.provide("nested.E");
 goog.provide("nested.E.F");
 goog.provide("nested.E.F.Z");
 
+/** test comment about value to ensure that comments are appropriately placed */ 
 value.B = function() {};
 
+/** test comment about value to ensure that comments are appropriately placed */ 
 obj.C.x = 4;
 obj.C.y = 8;
 

--- a/src/test/java/com/google/javascript/gents/multiTests/import_rewrite/export.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/import_rewrite/export.ts
@@ -1,6 +1,13 @@
 
+/**
+ * @fileoverview test comment about this file to ensure comments are
+ * appropriately placed
+ */
+
+/** test comment about value to ensure that comments are appropriately placed */
 export function B() {}
 
+/** test comment about value to ensure that comments are appropriately placed */
 export const x = 4;
 
 export const y = 8;


### PR DESCRIPTION
 - Fix issue wherein all comments appear at the top of the file (before all code)
 - Refactors CommentLinkingPass to improve readability.


More details:
When there is a newline between the @fileoverview and the goog.provide, then the comments strangely go out of sync.

== Works ====
```java
/** 
 * @fileoverview the quick brown fox jumps over the lazy dog 
 */
goog.provide('foo.bar')
```

== Broken ====
```java
/** 
 * @fileoverview the quick brown fox jumps over the lazy dog 
 * notice that there is a blank line after this
 */

goog.provide('foo.bar')
```

