### PR TITLE
Convert to Java 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ cache:
   - $HOME/.gradle
 jdk:
   - oraclejdk8
-  - oraclejdk7

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ def createScript(project, mainClass, name) {
 startScripts.enabled = false
 run.enabled = false
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 version = '1.0'
 
 createScript(project, 'com.google.javascript.clutz.DeclarationGenerator', 'clutz')
@@ -40,14 +40,20 @@ repositories {
 }
 
 dependencies {
+  
+  // Verify all versions match closure-compiler's deps to avoid version conflicts.
+  // https://github.com/google/closure-compiler/blob/master/pom-main.xml
   runtime 'args4j:args4j:2.0.26'
-  runtime 'com.google.code.gson:gson:2.8.0'
-
+  runtime 'com.google.code.gson:gson:2.7.0'
+  
   compile 'com.google.javascript:closure-compiler:v20170124'
-  compile 'com.google.guava:guava:20.0'
-
+  
+  
+  compile 'com.google.code.findbugs:jsr305:3.0.1'
+  compile 'com.google.guava:guava:20.0' 
+  
   testCompile 'junit:junit:4.11'
-  testCompile 'com.google.truth:truth:0.31'
+  testCompile 'com.google.truth:truth:0.30'
 }
 
 tasks.withType(Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
   // Verify all versions match closure-compiler's deps to avoid version conflicts.
   // https://github.com/google/closure-compiler/blob/master/pom-main.xml
   runtime 'args4j:args4j:2.0.26'
-  runtime 'com.google.code.gson:gson:2.7.0'
+  runtime 'com.google.code.gson:gson:2.7'
   
   compile 'com.google.javascript:closure-compiler:v20170124'
   

--- a/src/main/java/com/google/javascript/clutz/Constants.java
+++ b/src/main/java/com/google/javascript/clutz/Constants.java
@@ -1,7 +1,7 @@
 package com.google.javascript.clutz;
 
 /** Shared constants for Clutz. */
-public class Constants {
+public interface Constants {
   /**
    * The namespace prefix. Admittedly this only exists here so that Eclipse's font rendering is not
    * disturbed by the extended Unicode character.

--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
@@ -798,7 +799,7 @@ class DeclarationGenerator {
       // JSCompiler treats "foo.x" as one variable name, so collect all provides that start with
       // $provide + "." but are not sub-properties.
       Set<String> desiredSymbols = new TreeSet<>();
-      List<TypedVar> allSymbols = new ArrayList<>(compiler.getTopScope().getAllSymbols());
+      List<TypedVar> allSymbols = Lists.newArrayList(compiler.getTopScope().getAllSymbols());
       sortSymbols(allSymbols);
 
       ObjectType objType = symbol.getType().toMaybeObjectType();

--- a/src/test/java/com/google/javascript/gents/TypeScriptGeneratorMultiTests.java
+++ b/src/test/java/com/google/javascript/gents/TypeScriptGeneratorMultiTests.java
@@ -3,9 +3,6 @@ package com.google.javascript.gents;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import com.google.javascript.clutz.DeclarationGeneratorTests;
 import com.google.javascript.jscomp.SourceFile;
@@ -15,7 +12,10 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -66,9 +66,9 @@ public class TypeScriptGeneratorMultiTests extends TypeScriptGeneratorTests {
         List<File> testFiles = getTestInputFilesRecursive(DeclarationGeneratorTests.JS,
             multiTestPath, dirName);
 
-        Set<String> sourceNames = Sets.newHashSet();
-        List<SourceFile> sourceFiles = Lists.newArrayList();
-        Map<String, String> goldenFiles = Maps.newHashMap();
+        Set<String> sourceNames = new HashSet<>();
+        List<SourceFile> sourceFiles = new ArrayList<>();
+        Map<String, String> goldenFiles = new HashMap<>();
 
         for (final File sourceFile : testFiles) {
           String sourceText = getFileText(sourceFile);


### PR DESCRIPTION
Change clutz/gents to use Java8 and run Refaster over the codebase.

Note: closure-compiler is pinned at Guava v20, so not all Guava Java 8
goodness is available yet (v21) adds new convenience methods (namely,
FluentIterable -> Streams; ImmutableList.toImmutableList (collector))