### PR TITLE
Update travis independently from java8 changes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ cache:
   - $HOME/.gradle
 jdk:
   - oraclejdk8
-  - oraclejdk7


### PR DESCRIPTION
Removing jdk7 doesn't seem to be taking effect in my Java8 PR, possibly
because I added it too late.  Attempting to update independently, so
that the Java 8 changes can be merged.