### PR TITLE
Properly convert imports from already converted to TS files.

### DIFF
--- a/src/main/java/com/google/javascript/gents/Options.java
+++ b/src/main/java/com/google/javascript/gents/Options.java
@@ -54,6 +54,11 @@ public class Options {
       metaVar = "EXTERNSMAP")
   String externsMapFile = null;
 
+  @Option(name = "--alreadyConvertedPrefix",
+      usage = "Goog.modules starting with this prefix are assumed to be already in TypeScript",
+      metaVar = "ALREADY_CONVERTED_PREFIX")
+  String alreadyConvertedPrefix = "google3";
+
   @Argument
   List<String> arguments = new ArrayList<>();
 
@@ -92,7 +97,8 @@ public class Options {
 
   private Map<String, String> getExternsMap() throws IOException {
     if (this.externsMapFile != null) {
-      Type mapType = new TypeToken<Map<String, String>>() { /* empty */ }.getType();
+      Type mapType = new TypeToken<Map<String, String>>() { /* empty */
+      }.getType();
       try (JsonReader reader = new JsonReader(new FileReader(externsMapFile));) {
         return new Gson().fromJson(reader, mapType);
       }

--- a/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
+++ b/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
@@ -171,7 +171,8 @@ public class TypeScriptGenerator {
     final NodeComments comments = commentsPass.getComments();
 
     ModuleConversionPass modulePass = new ModuleConversionPass(compiler, pathUtil, nameUtil,
-        modulePrePass.getFileMap(), modulePrePass.getNamespaceMap(), comments);
+        modulePrePass.getFileMap(), modulePrePass.getNamespaceMap(), comments,
+        opts.alreadyConvertedPrefix);
     modulePass.process(externRoot, srcRoot);
 
     new TypeConversionPass(compiler, comments).process(externRoot, srcRoot);

--- a/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/already_converted_to_ts_keep.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/already_converted_to_ts_keep.js
@@ -1,0 +1,6 @@
+// This represents how a .ts file will look to gents, as a .js file output by
+// tsickle.
+goog.module('google3.already.ts.module');
+
+exports.foo = 0;
+exports.bar = 0;

--- a/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/converts_ts_module_require.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/converts_ts_module_require.js
@@ -1,0 +1,6 @@
+const {foo} = goog.require("google3.already.ts.module");
+const wholeModule = goog.require("google3.already.ts.module");
+goog.require("google3.already.ts.module");
+
+const wholeModuleClosure = goog.require("google3noperiod.module");
+

--- a/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/converts_ts_module_require.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/converts_ts_module_require.ts
@@ -1,0 +1,6 @@
+import './already_converted_to_ts_keep';
+
+import wholeModuleClosure from 'goog:google3noperiod.module';
+
+import * as wholeModule from './already_converted_to_ts_keep';
+import {foo} from './already_converted_to_ts_keep';

--- a/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/stays_in_closure_keep.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/stays_in_closure_keep.js
@@ -1,0 +1,4 @@
+// module starts with google3 to test that we match with trailing period.
+goog.module('google3noperiod.module');
+
+exports.foo = 0;


### PR DESCRIPTION
Identify already converted files based on the prefix of their
goog.modules. Adds a new option --alreadyConvertedPrefix.

If the file is already in TS, the goog.require call needs to be
changed to an ES6 import.

Closes #333