### PR TITLE
Locking the node package dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 before_install:
-  - npm install clang-format
+  - npm install
 language: java
 sudo: false
 cache:

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,4 +1,4 @@
-# Hacking on Clutz
+# Hacking on Clutz and Gents
 
 ## Prerequisites
 
@@ -8,9 +8,9 @@
 
 ## NPM dependencies
 
-Clutz uses some tools that are installed using NPM (`clang-format` and
-`typescript`, specifically). Run `npm install` in your project folder to install
-them.
+Clutz and Gents use some tools that are installed using npm (`clang-format` and
+`typescript`, specifically). Run `npm install` in your project folder to
+install them.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ auto-complete) as if the imported code was written in TypeScript.
 
 We don't offer a binary distribution, so first you need to build:
 ```shell
-$ npm install clang-format
+$ npm install 
 $ gradle build installDist
 ...
 BUILD SUCCESSFUL
@@ -50,5 +50,6 @@ bug in Closure Compiler).
 ## Supported Version of TypeScript
 Clutz produces declaration files that are guaranteed to be accepted by a
 version of TypeScript
-[2.0.6](https://github.com/Microsoft/TypeScript/tree/v2.0.6). The current test
-suite runs against `typescript@next`, so that is always a good choice.
+[2.1.6](https://github.com/Microsoft/TypeScript/tree/v2.1.6). The current test
+suite runs against the version of `typescript` in `npm-shrinkwrap.json`, so that is
+always a good choice.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,81 @@
+{
+  "name": "clutz",
+  "version": "0.0.0",
+  "dependencies": {
+    "async": {
+      "version": "1.5.2",
+      "from": "async@>=1.5.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+    },
+    "balanced-match": {
+      "version": "0.4.2",
+      "from": "balanced-match@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+    },
+    "brace-expansion": {
+      "version": "1.1.6",
+      "from": "brace-expansion@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+    },
+    "clang-format": {
+      "version": "1.0.48",
+      "from": "clang-format@>=1.0.48 <2.0.0",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.48.tgz"
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "from": "concat-map@0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "from": "fs.realpath@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+    },
+    "glob": {
+      "version": "7.1.1",
+      "from": "glob@>=7.0.0 <8.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "from": "inflight@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "from": "inherits@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+    },
+    "minimatch": {
+      "version": "3.0.3",
+      "from": "minimatch@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+    },
+    "once": {
+      "version": "1.4.0",
+      "from": "once@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+    },
+    "resolve": {
+      "version": "1.2.0",
+      "from": "resolve@>=1.1.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz"
+    },
+    "typescript": {
+      "version": "2.2.1",
+      "from": "typescript@>=2.1.6 <3.0.0",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.1.tgz"
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "from": "wrappy@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/angular/clutz",
   "description": "Clutz is not on npm, and technically not a node package. \n This is needed only for testing Clutz's output against the TypeScript compiler, and to install some development dependencies from npm.",
   "devDependencies": {
-    "clang-format": "^1.0.46",
-    "typescript": "^2.0.0"
+    "clang-format": "^1.0.48",
+    "typescript": "^2.1.6"
   }
 }

--- a/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
+++ b/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
@@ -16,7 +16,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -66,14 +65,6 @@ public class DeclarationSyntaxTest {
           "es5,dom,es2015.iterable",
           "--noImplicitAny",
           "--strictNullChecks");
-
-  @BeforeClass
-  public static void setUpTsc() throws Exception {
-    if (!TSC.toFile().exists()) {
-      System.err.println("Installing typescript...");
-      runChecked("npm", "install", "typescript@next");
-    }
-  }
 
   @Test
   public void testDeclarationSyntax() throws Exception {

--- a/src/test/java/com/google/javascript/gents/singleTests/classes.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/classes.ts
@@ -63,16 +63,16 @@ class F {
 
 
   /**
-     * block comment
-     */
+   * block comment
+   */
   constructor() {}
 
   /** Do foo! */
   foo() {}
 
   /**
-     * Returns phone number.
-     */
+   * Returns phone number.
+   */
   bar(): string {
     return '';
   }
@@ -80,8 +80,8 @@ class F {
 
 class G {
   /**
-     * ES6 method short hand.
-     */
+   * ES6 method short hand.
+   */
   method() {}
 }
 


### PR DESCRIPTION
Removes on demand installation of `typescript@next` as
that can create version mismatch between different developers.

Fixes some formatting that changed with clang-format 1.0.48.