### PR TITLE
Adds a gents module rewrite log.

### DIFF
--- a/src/main/java/com/google/javascript/gents/ModuleRenameLogger.java
+++ b/src/main/java/com/google/javascript/gents/ModuleRenameLogger.java
@@ -1,0 +1,51 @@
+package com.google.javascript.gents;
+
+import com.google.gson.Gson;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Generates a log that maps how goog.modules/goog.provides where mapped to TS modules.
+ *
+ * <p>The log contains: - the original goog.module/goog.provide name. - the name of the TypeScript
+ * file that contains the converted Closure module/namespace. - Gents never uses TS default exports.
+ * This means if the original goog.module had a default export we generated a named export with a
+ * specific name. The field 'defaultRename' contains that name. If there was no default export, the
+ * field contains the empty string.
+ *
+ * <p>Ex: (in file buz.js) goog.module(foo.bar) class A { ... } exports = A;
+ *
+ * <p>is translated to buz.ts: export class A { ... }
+ *
+ * <p>Which generates the following log line: foo.bar,buz.ts,A
+ */
+class ModuleRenameLogger {
+  private class LogItem {
+    String originalName;
+    String tsFile;
+    String defaultRename;
+
+    LogItem(String originalName, String tsFile, String defaultRename) {
+      this.originalName = originalName;
+      this.tsFile = tsFile;
+      this.defaultRename = defaultRename;
+    }
+  }
+
+  private Gson gson = new Gson();
+
+  String generateModuleRewriteLog(
+      Set<String> filesToConvert, Map<String, CollectModuleMetadata.FileModule> namespaceMap) {
+    StringBuilder builder = new StringBuilder();
+    for (Map.Entry<String, CollectModuleMetadata.FileModule> entry : namespaceMap.entrySet()) {
+      String file = entry.getValue().file;
+      String defaultRename =
+          entry.getValue().exportedNamespacesToSymbols.getOrDefault("exports", "");
+      if (filesToConvert.contains(file)) {
+        builder.append(gson.toJson(new LogItem(entry.getKey(), file, defaultRename)));
+        builder.append("\n");
+      }
+    }
+    return builder.toString();
+  }
+}

--- a/src/main/java/com/google/javascript/gents/Options.java
+++ b/src/main/java/com/google/javascript/gents/Options.java
@@ -37,6 +37,13 @@ public class Options {
   boolean debug = false;
 
   @Option(
+    name = "--log",
+    usage = "output a log of module rewriting to this location",
+    metaVar = "MODULE_REWRITE_LOG"
+  )
+  String moduleRewriteLog = null;
+
+  @Option(
     name = "--convert",
     usage =
         "list of all files to be converted to TypeScript\n"

--- a/src/test/java/com/google/javascript/gents/TypeScriptGeneratorMultiTests.java
+++ b/src/test/java/com/google/javascript/gents/TypeScriptGeneratorMultiTests.java
@@ -5,6 +5,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import com.google.javascript.clutz.DeclarationGeneratorTests;
+import com.google.javascript.gents.TypeScriptGenerator.GentsResult;
 import com.google.javascript.jscomp.SourceFile;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -89,8 +90,9 @@ public class TypeScriptGeneratorMultiTests extends TypeScriptGeneratorTests {
         ByteArrayOutputStream errStream = new ByteArrayOutputStream();
         gents.setErrorStream(new PrintStream(errStream));
 
-        Map<String, String> transpiledSource =
+        GentsResult gentsResult =
             gents.generateTypeScript(sourceNames, sourceFiles, Collections.<SourceFile>emptyList());
+        Map<String, String> transpiledSource = gentsResult.sourceFileMap;
 
         String errors = new String(errStream.toByteArray(), StandardCharsets.UTF_8);
         assertThat(errors).isEmpty();
@@ -101,6 +103,11 @@ public class TypeScriptGeneratorMultiTests extends TypeScriptGeneratorTests {
           String goldenText = goldenFiles.get(basename);
           assertThat(transpiledSource).containsKey(basename);
           assertThat(transpiledSource.get(basename)).isEqualTo(goldenText);
+        }
+        File logFile = getTestDirPath(multiTestPath).resolve(dirName).resolve("log").toFile();
+        if (logFile.exists()) {
+          String goldenLog = getFileText(logFile);
+          assertThat(gentsResult.moduleRewriteLog).isEqualTo(goldenLog);
         }
       } catch (Throwable t) {
         result.addError(this, t);

--- a/src/test/java/com/google/javascript/gents/multiTests/import_rewrite/log
+++ b/src/test/java/com/google/javascript/gents/multiTests/import_rewrite/log
@@ -1,0 +1,7 @@
+{"originalName":"sideeffect.A","tsFile":"src/test/java/com/google/javascript/gents/multiTests/import_rewrite/export.js","defaultRename":""}
+{"originalName":"value.B","tsFile":"src/test/java/com/google/javascript/gents/multiTests/import_rewrite/export.js","defaultRename":""}
+{"originalName":"obj.C","tsFile":"src/test/java/com/google/javascript/gents/multiTests/import_rewrite/export.js","defaultRename":""}
+{"originalName":"both.D","tsFile":"src/test/java/com/google/javascript/gents/multiTests/import_rewrite/export.js","defaultRename":""}
+{"originalName":"nested.E","tsFile":"src/test/java/com/google/javascript/gents/multiTests/import_rewrite/export.js","defaultRename":""}
+{"originalName":"nested.E.F","tsFile":"src/test/java/com/google/javascript/gents/multiTests/import_rewrite/export.js","defaultRename":""}
+{"originalName":"nested.E.F.Z","tsFile":"src/test/java/com/google/javascript/gents/multiTests/import_rewrite/export.js","defaultRename":""}

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/log
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/log
@@ -1,0 +1,18 @@
+{"originalName":"both.A.B.C.D","tsFile":"src/test/java/com/google/javascript/gents/multiTests/module_imports/export_both.js","defaultRename":"D"}
+{"originalName":"both.A.B.C.D.x","tsFile":"src/test/java/com/google/javascript/gents/multiTests/module_imports/export_both.js","defaultRename":"D"}
+{"originalName":"both.A.B.C.D.bar","tsFile":"src/test/java/com/google/javascript/gents/multiTests/module_imports/export_both.js","defaultRename":"D"}
+{"originalName":"default.A","tsFile":"src/test/java/com/google/javascript/gents/multiTests/module_imports/export_default.js","defaultRename":"A"}
+{"originalName":"named.A.B","tsFile":"src/test/java/com/google/javascript/gents/multiTests/module_imports/export_named.js","defaultRename":""}
+{"originalName":"named.A.B.x","tsFile":"src/test/java/com/google/javascript/gents/multiTests/module_imports/export_named.js","defaultRename":""}
+{"originalName":"named.A.B.foo","tsFile":"src/test/java/com/google/javascript/gents/multiTests/module_imports/export_named.js","defaultRename":""}
+{"originalName":"named.A.B.bar","tsFile":"src/test/java/com/google/javascript/gents/multiTests/module_imports/export_named.js","defaultRename":""}
+{"originalName":"namespace.A.B","tsFile":"src/test/java/com/google/javascript/gents/multiTests/module_imports/export_namespace.js","defaultRename":""}
+//!! It appears that gents considers the inner goog.module symbols as "namespaces"
+//!! This is harmless, because closure does not allow goog.require-ing inner symbols like
+//!! namespace.A.B.x, so these fake modules will not match any real goog.requires.
+{"originalName":"namespace.A.B.x","tsFile":"src/test/java/com/google/javascript/gents/multiTests/module_imports/export_namespace.js","defaultRename":""}
+{"originalName":"namespace.A.B.foo","tsFile":"src/test/java/com/google/javascript/gents/multiTests/module_imports/export_namespace.js","defaultRename":""}
+{"originalName":"namespace.A.B.bar","tsFile":"src/test/java/com/google/javascript/gents/multiTests/module_imports/export_namespace.js","defaultRename":""}
+{"originalName":"sideeffect.A.B.C","tsFile":"src/test/java/com/google/javascript/gents/multiTests/module_imports/export_sideeffect.js","defaultRename":""}
+{"originalName":"no.empty.export.with.import","tsFile":"src/test/java/com/google/javascript/gents/multiTests/module_imports/import_assignment.js","defaultRename":""}
+{"originalName":"import.binding.barrel","tsFile":"src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.js","defaultRename":""}


### PR DESCRIPTION
When configured with the option --log, gents will write the module
conversion into a log. This log will be used by tools downsteam to
modify files outside the scope of gents.

Each line of the log contains three comma separated strings - (OriginalName,
TSFile, DefaultExportName).

OriginalName is the original goog.module/goog.provide name.
TSFile - the name of the TypeScript file that contains the converted Closure module/namespace.
DefaultExportName - Gents never uses TS default exports. This means if the
  original goog.module had a default export we generated a named export with a
  specific name. This field contains that name. If there was no default export,
  the field contains the empty string.