### PR TITLE
Revert bazel's output file mapping when going over already converted TS.

### DIFF
--- a/src/test/java/com/google/javascript/gents/TypeScriptGeneratorMultiTests.java
+++ b/src/test/java/com/google/javascript/gents/TypeScriptGeneratorMultiTests.java
@@ -80,7 +80,7 @@ public class TypeScriptGeneratorMultiTests extends TypeScriptGeneratorTests {
           String filepath = sourceFile.getPath();
           sourceFiles.add(SourceFile.fromCode(filepath, sourceText));
 
-          if (!filepath.endsWith("_keep.js")) {
+          if (!filepath.endsWith("_keep.js") && !filepath.endsWith("_keep.es5.js")) {
             sourceNames.add(filepath);
 
             String basename = gents.pathUtil.getFilePathWithoutExtension(filepath);

--- a/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/already_converted_to_ts_keep.es5.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/already_converted_to_ts_keep.es5.js
@@ -1,0 +1,6 @@
+// This represents how a .ts file will look to gents, as a .js file output by
+// tsickle.
+goog.module('google3.src.test.java.com.google.javascript.gents.multiTests.converts_ts_module_require.already_converted_to_ts_keep');
+
+exports.foo = 0;
+exports.bar = 0;

--- a/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/already_converted_to_ts_keep.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/already_converted_to_ts_keep.js
@@ -1,6 +1,0 @@
-// This represents how a .ts file will look to gents, as a .js file output by
-// tsickle.
-goog.module('google3.already.ts.module');
-
-exports.foo = 0;
-exports.bar = 0;

--- a/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/converts_ts_module_require.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/converts_ts_module_require.js
@@ -1,6 +1,6 @@
-const {foo} = goog.require("google3.already.ts.module");
-const wholeModule = goog.require("google3.already.ts.module");
-goog.require("google3.already.ts.module");
+const {foo} = goog.require("google3.src.test.java.com.google.javascript.gents.multiTests.converts_ts_module_require.already_converted_to_ts_keep");
+const wholeModule = goog.require("google3.src.test.java.com.google.javascript.gents.multiTests.converts_ts_module_require.already_converted_to_ts_keep");
+goog.require("google3.src.test.java.com.google.javascript.gents.multiTests.converts_ts_module_require.already_converted_to_ts_keep");
 
 const wholeModuleClosure = goog.require("google3noperiod.module");
 


### PR DESCRIPTION
When gents encounters 'require('google3.foo.bar')' it can map it back
to a tscikle emitted blaze-bin/foo/bar.es5.js. An extra back mapping
is required to map to foo/bar.ts, which is what the final import should
emit.