### PR TITLE
Make log comparison deteministic.

### DIFF
--- a/src/main/java/com/google/javascript/gents/ModuleRenameLogger.java
+++ b/src/main/java/com/google/javascript/gents/ModuleRenameLogger.java
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -23,7 +24,7 @@ import java.util.Set;
  * <p>Which generates the following log line: foo.bar,buz.ts,A
  */
 class ModuleRenameLogger {
-  private class LogItem {
+  public class LogItem {
     String originalName;
     String tsFile;
     String defaultRename;
@@ -32,6 +33,31 @@ class ModuleRenameLogger {
       this.originalName = originalName;
       this.tsFile = tsFile;
       this.defaultRename = defaultRename;
+    }
+
+    public boolean equals(Object obj) {
+      if (!(obj instanceof LogItem)) return false;
+      LogItem o = (LogItem) obj;
+      return this.originalName.equals(o.originalName)
+          && this.tsFile.equals(o.tsFile)
+          && this.defaultRename.equals(o.defaultRename);
+    }
+
+    public String toString() {
+      return "{originalName: "
+          + this.originalName
+          + ",\n"
+          + "{tsFile: "
+          + this.tsFile
+          + ",\n"
+          + "{defaultRename: "
+          + this.defaultRename
+          + "}";
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(this.originalName, this.tsFile, this.defaultRename);
     }
   }
 


### PR DESCRIPTION
Because closure compiler visits files in non-deterministic order
(observed differently on Ubuntu vs. Travis) the test might fail on some
platforms. Instead of string comparison we parse the log in both
golden and emit and compare them as sets.

Closes #454