### PR TITLE
Fix local alias in goog.scope for goog.provide

### DIFF
--- a/src/test/java/com/google/javascript/gents/singleTests/goog_scope_local_alias.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/goog_scope_local_alias.js
@@ -1,0 +1,30 @@
+goog.provide('a.b.c.Base1');
+goog.provide('a.b.c.Base2');
+goog.provide('a.b.c.Base3');
+goog.provide('a.b.c.Base4');
+
+goog.scope(function() {
+var b = a.b;
+/** @constructor */
+b.c.Base1 = function() {}
+});
+
+goog.scope(function() {
+var c = a.b.c;
+/** @constructor */
+c.Base2 = function() {}
+});
+
+goog.scope(function() {
+/** @constructor */
+a.b.c.Base3 = function() {}
+});
+
+goog.scope(function() {
+var c = a.b.c;
+var localVarNotGoogProvided = 1;
+// localVarNotGoogProvided should not be exported
+localVarNotGoogProvided = localVarNotGoogProvided + 1;
+/** @constructor */
+c.Base4 = function() {}
+});

--- a/src/test/java/com/google/javascript/gents/singleTests/goog_scope_local_alias.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/goog_scope_local_alias.ts
@@ -1,0 +1,12 @@
+
+export class Base1 {}
+
+export class Base2 {}
+
+export class Base3 {}
+let localVarNotGoogProvided = 1;
+
+// localVarNotGoogProvided should not be exported
+localVarNotGoogProvided = localVarNotGoogProvided + 1;
+
+export class Base4 {}


### PR DESCRIPTION
*Duplicate of https://github.com/angular/clutz/pull/461. Travis is broken for https://github.com/angular/clutz/pull/461 and refuses to run any builds.

Attempt to fix https://github.com/angular/clutz/issues/453
Two fixes:
(1) The original assumption is that the node returned by `maybeRecordAndRemoveAlias()` is ought to be moved. This is not true. In some cases (for example `var foo = a.b.c;` where `a.b.c` comes from `goog.provide`), we detach this node and return the next node which has not been checked at all. We shouldn't simply move the next node in this case.
(2) Instead of checking if the alias matches goog.provide precisely, we could check if the alias matches goog.provide partially so that local partial alias works.