### PR TITLE
fix(gents): converts classes with inner typedefs to interfaces (1/4)

### DIFF
--- a/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
+++ b/src/main/java/com/google/javascript/gents/GentsCodeGenerator.java
@@ -146,6 +146,18 @@ public class GentsCodeGenerator extends CodeGenerator {
           return true;
         }
         return false;
+      case EXPORT:
+        // When a type alias is exported, closure code generator will add two semi-colons, one for type alias and one for export
+        // For example: export type T = {key: string};;
+        if (n.getChildCount() != 1) {
+          return false;
+        }
+        if (n.getFirstChild().getToken() == Token.TYPE_ALIAS) {
+          add("export");
+          add(n.getFirstChild());
+          return true;
+        }
+        return false;
       default:
         return false;
     }

--- a/src/test/java/com/google/javascript/gents/multiTests/goog_provide_rewrite/goog_scope.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/goog_provide_rewrite/goog_scope.js
@@ -82,6 +82,8 @@ lorem.ipsum.baz = function() { return false; };
 /** @typedef {{key: number, value: string}} */
 Foo.InnerTypedef;
 
+/** @typedef {{key: number, value: string}} */
+Foo.InnerTypedefWithAssignment = {};
 
 /**
  * @typedef {{

--- a/src/test/java/com/google/javascript/gents/multiTests/goog_provide_rewrite/goog_scope.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/goog_provide_rewrite/goog_scope.ts
@@ -47,10 +47,16 @@ exportedValue.setA(1).setB(2);
 export function baz(): boolean {
   return false;
 }
-type InnerTypedef = {
-  key: number,
-  value: string
-};
+
+export interface InnerTypedef {
+  key: number;
+  value: string;
+}
+
+export interface InnerTypedefWithAssignment {
+  key: number;
+  value: string;
+}
 type PrivateTypedef_ = {
   myFunction: (p1: any) => PrivateTypedef_
 };

--- a/src/test/java/com/google/javascript/gents/singleTests/inner_types.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/inner_types.js
@@ -1,0 +1,54 @@
+goog.module("foo.MyClass");
+
+class MyClass {
+  /**
+   * Constructor for MyClass
+   * @param {{type: !MyClass.InnerTypedefWithAssignment}} data
+   */
+  constructor(data) {
+    /** @export {!MyClass.InnerTypedefWithAssignment} type property*/
+    this.type = data.type;
+  }
+
+  /**
+   * equal function
+   * @param {!MyClass} otherData
+   * @return {boolean}
+   * @export
+   */
+  equals(otherData) {
+    return this.type.a === otherData.type.a;
+  }
+}
+
+/**
+ * @typedef {{
+ *     a: number,
+ *     b: number,
+ * }}
+ */
+MyClass.InnerTypedefWithAssignment = {};
+
+/**
+ * @typedef {{
+ *     a: number,
+ * }}
+ */
+MyClass.InnerTypedef;
+
+/**
+ * @typedef {{
+ *     a: {b: {c: number}},
+ *     d: string,
+ * }}
+ */
+MyClass.InnerTypedefWithNestedTypes;
+
+/**
+ * @typedef {{
+ *     a: {b: {c: number}},
+ * }}
+ */
+var Typedef;
+
+exports = MyClass;

--- a/src/test/java/com/google/javascript/gents/singleTests/inner_types.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/inner_types.ts
@@ -1,0 +1,35 @@
+
+export class MyClass {
+  /** @export type property*/
+  type: InnerTypedefWithAssignment;
+
+  /**
+   * Constructor for MyClass
+   */
+  constructor(data: {type: InnerTypedefWithAssignment}) {
+    this.type = data.type;
+  }
+
+  /**
+   * equal function
+   * @export
+   */
+  equals(otherData: MyClass): boolean {
+    return this.type.a === otherData.type.a;
+  }
+}
+
+export interface InnerTypedefWithAssignment {
+  a: number;
+  b: number;
+}
+
+export interface InnerTypedef { a: number; }
+
+export interface InnerTypedefWithNestedTypes {
+  a: {b: {c: number}};
+  d: string;
+}
+type Typedef = {
+  a: {b: {c: number}}
+};


### PR DESCRIPTION
@rkirov @dpurp PTAL
Fixes https://github.com/angular/clutz/issues/451
Gents doesn't know how to handle classes with inner typedefs.
PR 1/4: TypeScript doesn't have the closure equivalent of nested type alias inside classes. So we convert them into top level interfaces and rename its use in the file.