### PR TITLE
fix(gents): Reference renaming for classes with inner typedefs (2/4)

### DIFF
--- a/src/main/java/com/google/javascript/gents/CollectModuleMetadata.java
+++ b/src/main/java/com/google/javascript/gents/CollectModuleMetadata.java
@@ -33,6 +33,12 @@ public final class CollectModuleMetadata extends AbstractTopLevelCallback implem
     return fileToModule;
   }
 
+  void addFileMap(String filename) {
+    if (!fileToModule.containsKey(filename)) {
+      fileToModule.put(filename, new FileModule(filename, false));
+    }
+  }
+
   Map<String, FileModule> getNamespaceMap() {
     return namespaceToModule;
   }

--- a/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
@@ -490,20 +490,21 @@ public final class TypeAnnotationPass implements CompilerPass {
       FileModule module = symbolToModule.get(importedNamespace);
       String symbol = module.importedNamespacesToSymbols.get(importedNamespace);
 
-      // Create new import statement
-      Node importSpec;
-      Node importFile;
-      if (module.shouldUseOldSyntax()) {
-        importSpec = Node.newString(Token.NAME, symbol);
-        importFile = Node.newString("goog:" + importedNamespace);
-      } else {
-        importSpec = new Node(Token.IMPORT_SPECS, new Node(Token.IMPORT_SPEC, IR.name(symbol)));
-        String referencedFile = pathUtil.getImportPath(sourceFile, module.file);
-        importFile = Node.newString(referencedFile);
+      // Create a new import statement if the symbol to import isn't from the same file.
+      if (!sourceFile.equals(symbolToModule.get(typeName).file)) {
+        Node importSpec;
+        Node importFile;
+        if (module.shouldUseOldSyntax()) {
+          importSpec = Node.newString(Token.NAME, symbol);
+          importFile = Node.newString("goog:" + importedNamespace);
+        } else {
+          importSpec = new Node(Token.IMPORT_SPECS, new Node(Token.IMPORT_SPEC, IR.name(symbol)));
+          String referencedFile = pathUtil.getImportPath(sourceFile, module.file);
+          importFile = Node.newString(referencedFile);
+        }
+        Node importNode = new Node(Token.IMPORT, IR.empty(), importSpec, importFile);
+        importsNeeded.put(sourceFile, importNode);
       }
-      Node importNode = new Node(Token.IMPORT, IR.empty(), importSpec, importFile);
-      importsNeeded.put(sourceFile, importNode);
-
       typeRewrite.put(sourceFile, importedNamespace, symbol);
       return nameUtil.replacePrefixInName(typeName, importedNamespace, symbol);
     }

--- a/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
+++ b/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
@@ -186,7 +186,7 @@ public class TypeScriptGenerator {
             opts.alreadyConvertedPrefix);
     modulePass.process(externRoot, srcRoot);
 
-    new TypeConversionPass(compiler, comments).process(externRoot, srcRoot);
+    new TypeConversionPass(compiler, modulePrePass, comments).process(externRoot, srcRoot);
 
     new TypeAnnotationPass(
             compiler,

--- a/src/test/java/com/google/javascript/gents/multiTests/goog_provide_rewrite/import.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/goog_provide_rewrite/import.js
@@ -1,0 +1,21 @@
+goog.require("lorem.ipsum.Foo");
+
+const Foo = lorem.ipsum.Foo;
+
+/** @type {Foo.InnerTypedef} */
+var a = {key: 1, value: "bar"};
+
+/**
+ * @param {Foo.InnerTypedef} arg
+ * @return {Foo.InnerTypedefWithAssignment}
+ */
+Foo.func = function(arg) { return {key: 3, value: "bar3"}; };
+
+const b = Foo.func(a);
+
+/**
+ * @typedef {{
+ *   t: Foo.InnerTypedefWithAssignment
+ * }}
+ */
+var PrivateTypedef_;

--- a/src/test/java/com/google/javascript/gents/multiTests/goog_provide_rewrite/import.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/goog_provide_rewrite/import.ts
@@ -1,0 +1,14 @@
+import * as FooExports from './goog_scope';
+import {InnerTypedef} from './goog_scope';
+import {InnerTypedefWithAssignment} from './goog_scope';
+import {Foo} from './goog_scope';
+
+const Foo = Foo;
+let a: InnerTypedef = {key: 1, value: 'bar'};
+Foo.func = function(arg: InnerTypedef): InnerTypedefWithAssignment {
+  return {key: 3, value: 'bar3'};
+};
+const b = Foo.func(a);
+type PrivateTypedef_ = {
+  t: InnerTypedefWithAssignment
+};


### PR DESCRIPTION
@dpurp @gmoothart @rkirov PTAL.
Closure annotated typedefs inside a class are converted into exported
top level interfaces in TypeScript. This PR supports renaming the use in
other files.
This only fixes goog.provide and is a no-op for goog.module