### PR TITLE
Add EventTarget to the list of globals that need aliasing.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -231,7 +231,7 @@ class DeclarationGenerator {
    * by replacing the second Error with GlobalError.
    */
   private static final ImmutableSet<String> GLOBAL_SYMBOL_ALIASES =
-      ImmutableSet.of("Error", "Event");
+      ImmutableSet.of("Error", "Event", "EventTarget");
 
   private final JSType UNKNOWN_TYPE;
   private final JSType NUMBER_TYPE;

--- a/src/resources/closure.lib.d.ts
+++ b/src/resources/closure.lib.d.ts
@@ -6,6 +6,8 @@ declare namespace ಠ_ಠ.clutz {
   var GlobalError: ErrorConstructor;
   type GlobalEvent = Event;
   var GlobalEvent: typeof Event;
+  type GlobalEventTarget = EventTarget;
+  var GlobalEventTarget: typeof EventTarget;
   /** Represents the type returned when goog.require-ing an unknown symbol */
   type ClosureSymbolNotGoogProvided = void;
   /** Represents a Closure type that is private, represented by an empty interface. */

--- a/src/test/java/com/google/javascript/clutz/shadowed_global_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/shadowed_global_with_platform.d.ts
@@ -1,0 +1,24 @@
+declare namespace ಠ_ಠ.clutz.goog.ns {
+  function fn (a : GlobalEventTarget ) : void ;
+}
+declare namespace goog {
+  function require(name: 'goog.ns'): typeof ಠ_ಠ.clutz.goog.ns;
+}
+declare module 'goog:goog.ns' {
+  import alias = ಠ_ಠ.clutz.goog.ns;
+  export = alias;
+}
+declare namespace ಠ_ಠ.clutz.goog.ns {
+  class EventTarget extends EventTarget_Instance {
+  }
+  class EventTarget_Instance {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace goog {
+  function require(name: 'goog.ns.EventTarget'): typeof ಠ_ಠ.clutz.goog.ns.EventTarget;
+}
+declare module 'goog:goog.ns.EventTarget' {
+  import alias = ಠ_ಠ.clutz.goog.ns.EventTarget;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/shadowed_global_with_platform.js
+++ b/src/test/java/com/google/javascript/clutz/shadowed_global_with_platform.js
@@ -1,0 +1,10 @@
+goog.provide('goog.ns');
+goog.provide('goog.ns.EventTarget');
+
+
+/** @constructor */
+goog.ns.EventTarget = function() {};
+
+//!! Expect the global EventTarget instead of the one defined above.
+/** @param {!EventTarget} a */
+goog.ns.fn = function(a) {};

--- a/src/test/java/com/google/javascript/clutz/shadowed_global_with_platform.usage.ts
+++ b/src/test/java/com/google/javascript/clutz/shadowed_global_with_platform.usage.ts
@@ -1,0 +1,3 @@
+import * as ns from 'goog:goog.ns';
+
+ns.fn({} as EventTarget);


### PR DESCRIPTION
Adds example of how this is needed for goog.events.EventTarget.

Fixes #472