### PR TITLE
Add a test case for function type interface member in typedefs.

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
@@ -198,7 +198,6 @@ public final class TypeAnnotationPass implements CompilerPass {
           // INTERFACE_MEMBERS's jsdoc. We are extracting the properties from the jsdoc and
           // creating each MEMBER_VARIABLE_DEFs so code generator works.
           if (bestJSDocInfo != null && bestJSDocInfo.hasTypedefType()) {
-            // TODO(bowenni): Also extract MEMBER_FUNCTION_DEFs from the jsdoc
             Node typedefTypeRoot = bestJSDocInfo.getTypedefType().getRoot();
             //LC
             //    LB

--- a/src/test/java/com/google/javascript/gents/singleTests/inner_types.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/inner_types.js
@@ -40,6 +40,7 @@ MyClass.InnerTypedef;
  * @typedef {{
  *     a: {b: {c: number}},
  *     d: string,
+ *     e: function(string, number): number,
  * }}
  */
 MyClass.InnerTypedefWithNestedTypes;

--- a/src/test/java/com/google/javascript/gents/singleTests/inner_types.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/inner_types.ts
@@ -29,6 +29,7 @@ export interface InnerTypedef { a: number; }
 export interface InnerTypedefWithNestedTypes {
   a: {b: {c: number}};
   d: string;
+  e: (p1: string, p2: number) => number;
 }
 type Typedef = {
   a: {b: {c: number}}


### PR DESCRIPTION
Function type interface members are still just interface members. They are no different from other members. This is already handled correctly by creating a `MEMBER_VARIABLE_DEF` .