### PR TITLE
fix(gents): An interface can only extend, but not implement interfaces.

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeConversionPass.java
@@ -351,7 +351,7 @@ public final class TypeConversionPass implements CompilerPass {
 
     Node typeNode;
     if (jsDoc.isInterface()) {
-      List<JSTypeExpression> interfaces = jsDoc.getImplementedInterfaces();
+      List<JSTypeExpression> interfaces = jsDoc.getExtendedInterfaces();
       if (!interfaces.isEmpty()) {
         Node superInterfaces = new Node(Token.INTERFACE_EXTENDS);
         for (JSTypeExpression type : interfaces) {

--- a/src/test/java/com/google/javascript/gents/singleTests/interface.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/interface.js
@@ -18,7 +18,7 @@ ns.Interface2 = function() {}
  */
 ns.Interface2.prototype.bar = function(a) {};
 
-/** @interface @implements {ns.Interface2} */
+/** @interface @extends {ns.Interface2} */
 ns.Interface3 = function() {}
 /**
  * @param {string} a


### PR DESCRIPTION
https://github.com/google/closure-compiler/blob/ab4617a86346e659253593b11d2570fa26300415/src/com/google/javascript/jscomp/newtypes/JSTypeCreatorFromJSDoc.java#L85