### PR TITLE
Emit 'void' for all function return types.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -1662,7 +1662,15 @@ class DeclarationGenerator {
               JSType returnType = type.getReturnType();
               if (returnType != null) {
                 emit("=>");
-                visitType(returnType);
+                // Closure conflates 'undefined' and 'void', and in general visitType always emits `undefined`
+                // for that type.
+                // In idiomatic TypeScript, `void` is used for function return types, and the "void",
+                // "undefined" types are not the same.
+                if (returnType.isVoidType()) {
+                  emit("void");
+                } else {
+                  visitType(returnType);
+                }
               }
               return null;
             }
@@ -2211,8 +2219,8 @@ class DeclarationGenerator {
       emit(":");
       // Closure conflates 'undefined' and 'void', and in general visitType always emits `undefined`
       // for that type.
-      // In ideomatic TypeScript, `void` is used for function return types, and the types
-      // are not strictly the same.
+      // In idiomatic TypeScript, `void` is used for function return types, and the "void",
+      // "undefined" types are not the same.
       if (type.isVoidType()) {
         emit("void");
       } else if (typeOfThis != null && typeOfThis.isTemplateType() && typeOfThis.equals(type)) {

--- a/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
@@ -29,10 +29,10 @@ declare namespace ಠ_ಠ.clutz {
   }
   class ChromeBooleanEvent_Instance {
     private noStructuralTyping_: any;
-    addListener (callback : (a : boolean ) => undefined ) : void ;
-    hasListener (callback : (a : boolean ) => undefined ) : boolean ;
+    addListener (callback : (a : boolean ) => void ) : void ;
+    hasListener (callback : (a : boolean ) => void ) : boolean ;
     hasListeners ( ) : boolean ;
-    removeListener (callback : (a : boolean ) => undefined ) : void ;
+    removeListener (callback : (a : boolean ) => void ) : void ;
   }
 }
 declare namespace ಠ_ಠ.clutz {
@@ -54,10 +54,10 @@ declare namespace ಠ_ಠ.clutz {
   }
   class ChromeObjectEvent_Instance {
     private noStructuralTyping_: any;
-    addListener (callback : (a : Object ) => undefined ) : void ;
-    hasListener (callback : (a : Object ) => undefined ) : boolean ;
+    addListener (callback : (a : Object ) => void ) : void ;
+    hasListener (callback : (a : Object ) => void ) : boolean ;
     hasListeners ( ) : boolean ;
-    removeListener (callback : (a : Object ) => undefined ) : void ;
+    removeListener (callback : (a : Object ) => void ) : void ;
   }
 }
 declare namespace ಠ_ಠ.clutz {
@@ -68,10 +68,10 @@ declare namespace ಠ_ಠ.clutz {
   }
   class ChromeStringArrayEvent_Instance {
     private noStructuralTyping_: any;
-    addListener (callback : (a : string [] ) => undefined ) : void ;
-    hasListener (callback : (a : string [] ) => undefined ) : boolean ;
+    addListener (callback : (a : string [] ) => void ) : void ;
+    hasListener (callback : (a : string [] ) => void ) : boolean ;
     hasListeners ( ) : boolean ;
-    removeListener (callback : (a : string [] ) => undefined ) : void ;
+    removeListener (callback : (a : string [] ) => void ) : void ;
   }
 }
 declare namespace ಠ_ಠ.clutz {
@@ -82,10 +82,10 @@ declare namespace ಠ_ಠ.clutz {
   }
   class ChromeStringEvent_Instance {
     private noStructuralTyping_: any;
-    addListener (callback : (a : string ) => undefined ) : void ;
-    hasListener (callback : (a : string ) => undefined ) : boolean ;
+    addListener (callback : (a : string ) => void ) : void ;
+    hasListener (callback : (a : string ) => void ) : boolean ;
     hasListeners ( ) : boolean ;
-    removeListener (callback : (a : string ) => undefined ) : void ;
+    removeListener (callback : (a : string ) => void ) : void ;
   }
 }
 declare namespace ಠ_ಠ.clutz {
@@ -96,10 +96,10 @@ declare namespace ಠ_ಠ.clutz {
   }
   class ChromeStringStringEvent_Instance {
     private noStructuralTyping_: any;
-    addListener (callback : (a : string , b : string ) => undefined ) : void ;
-    hasListener (callback : (a : string , b : string ) => undefined ) : boolean ;
+    addListener (callback : (a : string , b : string ) => void ) : void ;
+    hasListener (callback : (a : string , b : string ) => void ) : boolean ;
     hasListeners ( ) : boolean ;
-    removeListener (callback : (a : string , b : string ) => undefined ) : void ;
+    removeListener (callback : (a : string , b : string ) => void ) : void ;
   }
 }
 declare namespace ಠ_ಠ.clutz {

--- a/src/test/java/com/google/javascript/clutz/undefined_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/undefined_type.d.ts
@@ -1,4 +1,12 @@
 declare namespace ಠ_ಠ.clutz.undefinedns {
+  class C extends C_Instance {
+  }
+  class C_Instance {
+    private noStructuralTyping_: any;
+    //!! Intentionally keeping string | undefined, as more stylistically correct than
+    //!! string | void.
+    constructor (f : ( ) => void , g : ( ) => string | undefined ) ;
+  }
   var a : undefined ;
   type alias = { foo ? : boolean } ;
   var b : undefined ;

--- a/src/test/java/com/google/javascript/clutz/undefined_type.js
+++ b/src/test/java/com/google/javascript/clutz/undefined_type.js
@@ -42,3 +42,11 @@ undefinedns.i = function() {};
  * @typedef {{foo: (boolean | undefined)}}
  */
 undefinedns.alias;
+
+
+/**
+ * @param {function(): void} f
+ * @param {function(): (string|void)} g
+ * @constructor
+ */
+undefinedns.C = function(f, g) {};


### PR DESCRIPTION
In closure 'void' and 'undefined' are synonims, in TypeScript there
are important distinctions.

In TypeScript the 'void' and 'undefined' types are not mutually
assignable.

Also 'function f(callback:() => undefined); f(() => {})' is
invalid, the compiler forces you to explicitly add 'return undefined'.
However, with `f(callback: () => void)` the empty callback `() =>
{}` works.

With this change for both 'void'/'undefined' in closure, clutz emits
TS 'void' when alone in a function return position - '(...) => void'.
Otherwise, it will emit TS 'undefined'.

Fixes #296