### PR TITLE
fixes rewriteGoogProvide when alias is last

### DIFF
--- a/src/test/java/com/google/javascript/gents/singleTests/class_alias.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/class_alias.js
@@ -1,0 +1,14 @@
+goog.provide('classalias.C');
+
+goog.scope(function() {
+  /** @constructor */
+  classalias.C = goog.defineClass(null, {
+    f: function () {
+      return C.x;
+    },
+    statics: {
+      x: ''
+    }
+  });
+  var C = classalias.C;
+});

--- a/src/test/java/com/google/javascript/gents/singleTests/class_alias.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/class_alias.ts
@@ -1,0 +1,8 @@
+
+export class C {
+  static x: any = '';
+
+  f() {
+    return C.x;
+  }
+}


### PR DESCRIPTION
Introduces a RewriteStatus inner class to track 'stillAttached'
state, separate from a null Node, which could mean nothing more to
process.