### PR TITLE
fix(gents): fix an edge case when a GETPROP node contains inline comments that are more than one line before the property name node.

### DIFF
--- a/src/test/java/com/google/javascript/gents/singleTests/comments.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/comments.js
@@ -44,3 +44,20 @@ var x;
 
 /** @export {number} */
 let m = 4;
+
+var a = function() {
+  return {
+    b: function() {}
+  }
+};
+var c = function() {};
+
+// comment before GETPROP
+a(
+// comment in GETPROP
+).
+b();
+
+// comment after GETPROP
+c();
+// comment in the end

--- a/src/test/java/com/google/javascript/gents/singleTests/comments.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/comments.ts
@@ -36,3 +36,17 @@ const x;
 
 /** @export */
 let m: number = 4;
+let a = function() {
+  return {b: function() {}};
+};
+let c = function() {};
+
+// comment before GETPROP
+
+// comment in GETPROP
+a().b();
+
+// comment after GETPROP
+c();
+
+// comment in the end


### PR DESCRIPTION
Problem:
```javascript
a(
// comment
)
.b();
```
adds an EMPTY node before `b` node and attaches the comment to that EMPTY node. This breaks [GEPROP's children count assertion in Closure CodeGenerator](https://github.com/google/closure-compiler/blob/120d1c7a8d96d9c81a92e6600e1c0e2c7cbdcb98/src/com/google/javascript/jscomp/CodeGenerator.java#L737-L738)


We want to map the comment to a node, either `a` or `b` in this example. 
I choose to map the comment to `a` because mapping the comment to `b` requires overriding [code generator for GETPROP nodes](https://github.com/google/closure-compiler/blob/120d1c7a8d96d9c81a92e6600e1c0e2c7cbdcb98/src/com/google/javascript/jscomp/CodeGenerator.java#L722-L757).

In general, this (adding a new EMPTY node) may break not only GETPROP nodes but any nodes that have children count assertions in code generator. ~~But the counter examples are probably too contrived to worry about?~~ *Too early to call. Here's another counter example:*
```javascript
if (a) {
  // comment
}
else {
}
```
produces 4 children with one EMPTY node:
```
IF 1 [length: 23]
    NAME a 1 [length: 1]
    BLOCK 1 [length: 7]
    EMPTY
    BLOCK 4 [length: 3]
```
and this [breaks closure code generator](https://github.com/google/closure-compiler/blob/120d1c7a8d96d9c81a92e6600e1c0e2c7cbdcb98/src/com/google/javascript/jscomp/CodeGenerator.java#L817)