### PR TITLE
Fixes NPEs for constructors with destructuring.

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeConversionPass.java
@@ -213,8 +213,19 @@ public final class TypeConversionPass implements CompilerPass {
           @Nullable JSDocInfo constructorJsDoc = NodeUtil.getBestJSDocInfo(fnNode);
 
           for (Node param : params.children()) {
-            String paramName =
-                param.isDefaultValue() ? param.getFirstChild().getString() : param.getString();
+            Node nodeAfterDefault = param.isDefaultValue() ? param.getFirstChild() : param;
+            // If not a Name node, it is potentially a destructuring arg, for which we cannot
+            // use the public/private shorthand.
+            if (!nodeAfterDefault.isName()) {
+              continue;
+            }
+            // It appears that adding ACCESS_MODIFIERs to Default params do not come out though
+            // the CodeGenerator, thus not safe to remove the declaration.
+            // TODO(rado): fix in emitting code and remove this line.
+            if (param.isDefaultValue()) {
+              continue;
+            }
+            String paramName = nodeAfterDefault.getString();
             @Nullable
             JSTypeExpression paramType =
                 constructorJsDoc == null ? null : constructorJsDoc.getParameterType(paramName);

--- a/src/test/java/com/google/javascript/gents/singleTests/destr.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/destr.js
@@ -1,0 +1,21 @@
+class C {
+  /**
+   * @param {{a: number}} destrParam
+   * @param {{b: number}} destrParamWithDefault
+   * @param {number} c with default
+   * @param {number} d
+   */
+  constructor({a}, {b} = {}, c = 0, d) {
+    /** @private {number} */
+    this.a = a;
+
+    /** @private {number} */
+    this.b = b;
+
+    /** @private {number} */
+    this.c = c;
+
+    /** @private {number} */
+    this.d = d;
+  }
+}

--- a/src/test/java/com/google/javascript/gents/singleTests/destr.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/destr.ts
@@ -1,0 +1,18 @@
+
+class C {
+  private a: number;
+  private b: number;
+  private c: number;
+
+  /**
+   * @param c with default
+   */
+  constructor({a}, {b} = {}, c = 0, private d: number) {
+    this.a = a;
+    this.b = b;
+    //!! Due to a closure bug this one stays behind even though it is possible
+    //!! to write it in shorthand form.
+    //!! Note: Tslint fix pass will pick it up.
+    this.c = c;
+  }
+}


### PR DESCRIPTION
Constructors with destructuring cannot use the 'public' shorthand:

class C {
  a: string;
  constructor({a}: {a: string}) {
    this.a = a;
  }
}

Also fixes a bug where gents half-moved ctors with default args.  Since
CodeGenerator seems to avoid emitting 'public'/'private' keywords on
arguments with defaults. Back off and leave this transformation to
tslint.