### PR TITLE
fix(gents): ignore @constructor annotations if inside goog.defineClass

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeConversionPass.java
@@ -77,7 +77,8 @@ public final class TypeConversionPass implements CompilerPass {
         case FUNCTION:
           bestJSDocInfo = NodeUtil.getBestJSDocInfo(n);
           if (bestJSDocInfo != null
-              && (bestJSDocInfo.isConstructor() || bestJSDocInfo.isInterface())) {
+              && bestJSDocInfo.isConstructorOrInterface()
+              && !isConstructorInGoogDefineClass(n)) {
             convertConstructorToClass(n, bestJSDocInfo);
           }
           break;
@@ -429,6 +430,39 @@ public final class TypeConversionPass implements CompilerPass {
     compiler.reportCodeChange();
   }
 
+  /** return if node n is a @constructor annotated function inside goog.defineClass */
+  boolean isConstructorInGoogDefineClass(Node n) {
+    // CALL
+    //     GETPROP
+    //         NAME goog
+    //         STRING defineClass
+    //     NULL|super class node
+    //     OBJECTLIT
+    //         STRING_KEY constructor
+    //             FUNCTION <- n
+    if (n == null) {
+      return false;
+    }
+
+    @Nullable Node stringKey = n.getParent();
+    if (stringKey == null
+        || !stringKey.isStringKey()
+        || !"constructor".equals(stringKey.getString())) {
+      return false;
+    }
+
+    @Nullable Node objectlit = stringKey.getParent();
+    if (objectlit == null) {
+      return false;
+    }
+
+    @Nullable Node call = objectlit.getParent();
+    if (call == null || !"goog.defineClass".equals(call.getFirstChild().getQualifiedName())) {
+      return false;
+    }
+
+    return true;
+  }
   /**
    * Converts functions and variables declared in object literals into member method and field
    * definitions

--- a/src/test/java/com/google/javascript/gents/singleTests/classes.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/classes.js
@@ -75,6 +75,39 @@ const F = goog.defineClass(null, {
   }
 });
 
+/**
+ * goog.defineClass with @constructor annotation
+ */
+var GoogDefinedClassWithConstructorAnnotation = goog.defineClass(null, {
+  /**
+   * @constructor
+   */
+  constructor: function() {
+  },
+});
+
+/**
+ * goog.defineClass with deeply nested @constructor annotation
+ */
+var GoogDefinedClassWithDeeplyNestedConstructorAnnotation = goog.defineClass(null, {
+  constructor: function() {},
+  foo: function() {
+    return new (/** @constructor */ function Klass() {})();
+  },
+});
+
+/**
+ * goog.defineClass with @constructor annotation and parameters
+ */
+var GoogDefinedClassWithConstructorAnnotationAndParameters = goog.defineClass(null, {
+  /**
+   * @param {number} a
+   * @constructor
+   */
+  constructor: function(a) {
+  },
+});
+
 const G = goog.defineClass(null, {
   /**
    * ES6 method short hand.

--- a/src/test/java/com/google/javascript/gents/singleTests/classes.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/classes.ts
@@ -78,6 +78,28 @@ class F {
   }
 }
 
+/**
+ * goog.defineClass with annotation
+ */
+class GoogDefinedClassWithConstructorAnnotation {}
+
+/**
+ * goog.defineClass with deeply nested annotation
+ */
+class GoogDefinedClassWithDeeplyNestedConstructorAnnotation {
+  foo() {
+    return new class Klass {}
+    ();
+  }
+}
+
+/**
+ * goog.defineClass with annotation and parameters
+ */
+class GoogDefinedClassWithConstructorAnnotationAndParameters {
+  constructor(a: number) {}
+}
+
 class G {
   /**
    * ES6 method short hand.


### PR DESCRIPTION
Previously we get a nested class:
```javascript
class A {
  constructor: any = class {  };
}
```