### PR TITLE
Emit a prefix for absolute module paths.

### DIFF
--- a/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
@@ -306,25 +306,25 @@ public final class ModuleConversionPass implements CompilerPass {
     String moduleSuffix = nameUtil.lastStepOfName(requiredNamespace);
     // Avoid name collisions
     String backupName = moduleSuffix.equals(localName) ? moduleSuffix + "Exports" : moduleSuffix;
-    String referencedFile = pathUtil.getImportPath(n.getSourceFileName(), module.file);
 
     if (alreadyConverted) {
-      // we cannot user referencedFile here, because usually it points to the ES5 js file that is
+      // we cannot use referencedFile here, because usually it points to the ES5 js file that is
       // the output of TS, and not the original source TS file.
       // However, we can reverse map the goog.module name to a file name.
       // TODO(rado): sync this better with the mapping done in tsickle.
-      referencedFile =
-          pathUtil.getImportPath(
-              n.getSourceFileName(),
-              requiredNamespace.replace(alreadyConvertedPrefix + ".", "").replace(".", "/"));
+      String originalPath =
+          requiredNamespace.replace(alreadyConvertedPrefix + ".", "").replace(".", "/");
       // requiredNamespace is not always precisely the string inside "goog.require(...)", we
       // have to strip suffixes added earlier.
       if (moduleSuffix.equals(localName) && !fullLocalName.equals(requiredNamespace)) {
-        referencedFile = referencedFile.replaceAll("/" + localName + "$", "");
+        originalPath = originalPath.replaceAll("/" + localName + "$", "");
       }
-      convertRequireForAlreadyConverted(n, fullLocalName, referencedFile);
+      convertRequireForAlreadyConverted(
+          n, fullLocalName, pathUtil.getImportPath(n.getSourceFileName(), originalPath));
       return;
     }
+
+    String referencedFile = pathUtil.getImportPath(n.getSourceFileName(), module.file);
 
     // Uses default import syntax as this is a javascript namespace
     if (module.shouldUseOldSyntax()) {

--- a/src/main/java/com/google/javascript/gents/Options.java
+++ b/src/main/java/com/google/javascript/gents/Options.java
@@ -34,7 +34,7 @@ public class Options {
   String output = "-";
 
   @Option(name = "--root", usage = "root directory of imports", metaVar = "ROOT")
-  String root = null;
+  String root = ".";
 
   @Option(name = "--debug", usage = "run in debug mode (prints compiler warnings)")
   boolean debug = false;
@@ -77,6 +77,13 @@ public class Options {
     metaVar = "ALREADY_CONVERTED_PREFIX"
   )
   String alreadyConvertedPrefix = "google3";
+
+  @Option(
+    name = "--absolutePathPrefix",
+    usage = "Prefix for emitting absolute module references in import statements.",
+    metaVar = "ABSOLUTE_PATH_PREFIX"
+  )
+  String absolutePathPrefix = "google3";
 
   @Argument List<String> arguments = new ArrayList<>();
 

--- a/src/main/java/com/google/javascript/gents/PathUtil.java
+++ b/src/main/java/com/google/javascript/gents/PathUtil.java
@@ -6,10 +6,12 @@ import java.nio.file.Paths;
 
 /** Utility methods for file path resolution. */
 public class PathUtil {
-  private String rootpath = null;
+  private final String rootpath;
+  private final String absolutePrefix;
 
-  public PathUtil(String root) {
+  public PathUtil(String root, String absolutePrefix) {
     this.rootpath = root;
+    this.absolutePrefix = absolutePrefix;
   }
 
   /**
@@ -29,12 +31,15 @@ public class PathUtil {
   /**
    * Returns the proper import path for a referenced file. Defaults to an absolute path if the
    * referenced file is more than 2 directories above the current source file.
+   *
+   * <p>NOTE: the string returned from this is not really a root-based path on disk. It only makes
+   * sense as an input to a 'from '...'' clause.
    */
   String getImportPath(String sourceFile, String referencedFile) {
     referencedFile = removeExtension(referencedFile);
     String relativePath = getRelativePath(sourceFile + "/..", referencedFile);
-    if (rootpath != null && relativePath.startsWith("../..")) {
-      return getRelativePath(rootpath, referencedFile);
+    if (relativePath.startsWith("../..")) {
+      return absolutePrefix + "/" + getRelativePath(rootpath, referencedFile);
     } else {
       return relativePath.startsWith(".") ? relativePath : "./" + relativePath;
     }

--- a/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
@@ -499,8 +499,7 @@ public final class TypeAnnotationPass implements CompilerPass {
           importFile = Node.newString("goog:" + importedNamespace);
         } else {
           importSpec = new Node(Token.IMPORT_SPECS, new Node(Token.IMPORT_SPEC, IR.name(symbol)));
-          String referencedFile = pathUtil.getImportPath(sourceFile, module.file);
-          importFile = Node.newString(referencedFile);
+          importFile = Node.newString(pathUtil.getImportPath(sourceFile, module.file));
         }
         Node importNode = new Node(Token.IMPORT, IR.empty(), importSpec, importFile);
         importsNeeded.put(sourceFile, importNode);

--- a/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
+++ b/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
@@ -97,7 +97,7 @@ public class TypeScriptGenerator {
     compiler.disableThreads();
     setErrorStream(System.err);
 
-    this.pathUtil = new PathUtil(opts.root);
+    this.pathUtil = new PathUtil(opts.root, opts.absolutePathPrefix);
     this.nameUtil = new NameUtil(compiler);
   }
 

--- a/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/a/b/c/deep_keep.es5.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/a/b/c/deep_keep.es5.js
@@ -1,0 +1,4 @@
+// This represents how a .ts file will look to gents.
+goog.module('google3.src.test.java.com.google.javascript.gents.multiTests.converts_ts_module_require.a.b.c.deep_keep');
+
+exports.foo = 0;

--- a/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/converts_ts_module_require.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/converts_ts_module_require.js
@@ -3,4 +3,3 @@ const wholeModule = goog.require("google3.src.test.java.com.google.javascript.ge
 goog.require("google3.src.test.java.com.google.javascript.gents.multiTests.converts_ts_module_require.already_converted_to_ts_keep");
 
 const wholeModuleClosure = goog.require("google3noperiod.module");
-

--- a/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/x/y/z/convert.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/x/y/z/convert.js
@@ -1,0 +1,1 @@
+const wholeModule = goog.require("google3.src.test.java.com.google.javascript.gents.multiTests.converts_ts_module_require.a.b.c.deep_keep");

--- a/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/x/y/z/convert.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/x/y/z/convert.ts
@@ -1,0 +1,1 @@
+import * as wholeModule from 'google3/src/test/java/com/google/javascript/gents/multiTests/converts_ts_module_require/a/b/c/deep_keep';


### PR DESCRIPTION
Set the default root to be '.' (which is the one used by internal uses)
for parity between tests and users.