### PR TITLE
Added support for inline JsDoc types.

### DIFF
--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -274,8 +274,11 @@ public final class CommentLinkingPass implements CompilerPass {
       }
 
       if (getLastLineOfCurrentComment() == line) {
-        // Comment on same line as code
-        linkCommentBufferToNode(n);
+        // Comment on same line as code -- we have to make sure this is the node we should attach
+        // it to. It will be the first node after the comment.
+        if (getCurrentComment().getAbsolutePosition() < n.getSourceOffset()) {
+          linkCommentBufferToNode(n);
+        }
       } else if (getLastLineOfCurrentComment() == line - 1) {
         // Comment ends just before code
         linkCommentBufferToNode(n);

--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -166,7 +166,7 @@ public final class CommentLinkingPass implements CompilerPass {
 
       String comment = sb.toString();
       if (!comment.isEmpty()) {
-        nodeComments.putComment(n, comment);
+        nodeComments.addComment(n, comment);
       }
       commentBuffer.clear();
     }

--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -64,7 +64,7 @@ public final class CommentLinkingPass implements CompilerPass {
    */
   // TODO(bowenni): More nodes missing here?
   private static final ImmutableSet<Token> TOKENS_IGNORE_COMMENTS =
-      ImmutableSet.of(Token.LABEL_NAME, Token.NAME, Token.GENERIC_TYPE, Token.BLOCK);
+      ImmutableSet.of(Token.LABEL_NAME, Token.GENERIC_TYPE, Token.BLOCK);
 
   private final Compiler compiler;
   private final NodeComments nodeComments;
@@ -276,8 +276,10 @@ public final class CommentLinkingPass implements CompilerPass {
       if (getLastLineOfCurrentComment() == line) {
         // Comment on same line as code -- we have to make sure this is the node we should attach
         // it to. It will be the first node after the comment.
-        if (getCurrentComment().getAbsolutePosition() < n.getSourceOffset()) {
+        if (getCurrentComment().location.end.column < n.getCharno()) {
           linkCommentBufferToNode(n);
+        } else {
+          return true;
         }
       } else if (getLastLineOfCurrentComment() == line - 1) {
         // Comment ends just before code

--- a/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
@@ -101,7 +101,7 @@ public final class ModuleConversionPass implements CompilerPass {
             // export {};
             Node commentNode = new Node(Token.EMPTY);
             commentNode.useSourceInfoFrom(n);
-            nodeComments.putComment(
+            nodeComments.addComment(
                 commentNode,
                 "\n// gents: force this file to be an ES6 module (no imports or exports)");
 

--- a/src/main/java/com/google/javascript/gents/NodeComments.java
+++ b/src/main/java/com/google/javascript/gents/NodeComments.java
@@ -8,10 +8,14 @@ import java.util.Map;
 public class NodeComments {
   final Map<Node, String> nodeToComment = new HashMap<>();
 
-  void putComment(Node n, String comment) {
+  void addComment(Node n, String comment) {
     if (hasComment(n)) {
       comment = getComment(n) + comment;
     }
+    setComment(n, comment);
+  }
+
+  void setComment(Node n, String comment) {
     nodeToComment.put(n, comment);
   }
 
@@ -29,7 +33,7 @@ public class NodeComments {
 
   void moveComment(Node from, Node to) {
     if (getComment(from) != null) {
-      putComment(to, getComment(from));
+      addComment(to, getComment(from));
       clearComment(from);
     }
   }

--- a/src/test/java/com/google/javascript/gents/singleTests/inline_types.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/inline_types.js
@@ -8,3 +8,12 @@ const /** string */ x = 'fruit';
 function /** string */ f(/** number */ x, z, /** string */ y) {
   return x + y + ' apples';
 }
+
+/**
+ * This line says what the function does!
+ * @param {string} y
+ * @param {number} z
+ */
+function /** string */ g(/** number */ x, y, z) {
+  return x + y + ' apples' + z;
+}

--- a/src/test/java/com/google/javascript/gents/singleTests/inline_types.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/inline_types.js
@@ -5,6 +5,6 @@ var /** !Foo */ foo = {};
 
 const /** string */ x = 'fruit';
 
-// TODO(#352): Support inline typing for functions.
-// input: function /** string */ f(/** number */ x) {return x + ' apples'}
-// output: function f(x: number): string {return x + ' apples'}
+function /** string */ f(/** number */ x, z, /** string */ y) {
+  return x + y + ' apples';
+}

--- a/src/test/java/com/google/javascript/gents/singleTests/inline_types.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/inline_types.ts
@@ -1,11 +1,8 @@
 
 interface Foo {}
-/** !Foo */
 let foo: Foo = {};
-
-/** string */
 const x: string = 'fruit';
 
-// TODO(#352): Support inline typing for functions.
-// input: function /** string */ f(/** number */ x) {return x + ' apples'}
-// output: function f(x: number): string {return x + ' apples'}
+function f(x: number, z, y: string): string {
+  return x + y + ' apples';
+}

--- a/src/test/java/com/google/javascript/gents/singleTests/inline_types.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/inline_types.ts
@@ -6,3 +6,10 @@ const x: string = 'fruit';
 function f(x: number, z, y: string): string {
   return x + y + ' apples';
 }
+
+/**
+ * This line says what the function does!
+ */
+function g(x: number, y: string, z: number): string {
+  return x + y + ' apples' + z;
+}

--- a/src/test/java/com/google/javascript/gents/singleTests/interface.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/interface.ts
@@ -24,7 +24,6 @@ class Y implements Interface2, Interface3 {
 
 export interface StructuralInterface { bar(a: string): number; }
 const structInterfaceImpl: StructuralInterface = {
-  /** !ns.StructuralInterface */
   bar: function(a: string): number {
     return 1;
   }

--- a/src/test/java/com/google/javascript/gents/singleTests/interface.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/interface.ts
@@ -23,9 +23,8 @@ class Y implements Interface2, Interface3 {
 }
 
 export interface StructuralInterface { bar(a: string): number; }
-
-/** !ns.StructuralInterface */
 const structInterfaceImpl: StructuralInterface = {
+  /** !ns.StructuralInterface */
   bar: function(a: string): number {
     return 1;
   }


### PR DESCRIPTION
Fixes #352.

Reference:
https://github.com/google/closure-compiler/wiki/Annotating-Types#function-declarations

One unrelated test (interface.ts) had to be fixed for this change to pass.
It put a wrong comment before this change, now it puts it (still wrongly)
elsewhere.