### PR TITLE
Emit inferred props on a goog.module object.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/infer_in_goog_module.d.ts
+++ b/src/test/java/com/google/javascript/clutz/infer_in_goog_module.d.ts
@@ -1,0 +1,8 @@
+declare namespace ಠ_ಠ.clutz.module$exports$infer {
+  var a : string ;
+  var b : string ;
+}
+declare module 'goog:infer' {
+  import alias = ಠ_ಠ.clutz.module$exports$infer;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/infer_in_goog_module.js
+++ b/src/test/java/com/google/javascript/clutz/infer_in_goog_module.js
@@ -1,0 +1,15 @@
+goog.module('infer');
+
+/**
+ * @param {string} str
+ * @return {string}
+ */
+var f = function(str) {
+  return str;
+};
+
+const fnCall = f('foo');
+const lit = 'foo';
+
+exports.a = fnCall;
+exports.b = lit;


### PR DESCRIPTION
Clutz walks all `compiler.getTopScope().getAllSymbols()`. It appears
that for module objects

```javascript
goog.module('a.b');
const c = 0;
exports.c = c;
```

Closure does not register a corresponding 'a.b.c' symbol, while

```javascript
goog.module('a.b');
/** @const */
const c = 0;
exports.c = c;
```

does produce the symbol in question. To fix the first situation,
we also traverse the unemitted props on the 'a.b' object.

Fixes #506