### PR TITLE
Inline deprecated options.setIdeMode call.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -5,6 +5,7 @@ import com.google.javascript.jscomp.CheckLevel;
 import com.google.javascript.jscomp.CompilerOptions;
 import com.google.javascript.jscomp.DependencyOptions;
 import com.google.javascript.jscomp.DiagnosticGroups;
+import com.google.javascript.jscomp.parsing.Config;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -100,13 +101,12 @@ public class Options {
     options.setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT5);
     options.setCheckTypes(true);
     options.setInferTypes(true);
-    setIdeMode(options);
+    // turns off optimizations.
+    options.setChecksOnly(true);
+    options.setContinueAfterErrors(true);
+    options.setPreserveDetailedSourceInfo(true);
+    options.setParseJsDocDocumentation(Config.JsDocParsing.INCLUDE_DESCRIPTIONS_NO_WHITESPACE);
     return options;
-  }
-
-  @SuppressWarnings("deprecation")
-  private void setIdeMode(final CompilerOptions options) {
-    options.setIdeMode(true); // So that we can query types after compilation.
   }
 
   Options(String[] args) throws CmdLineException {

--- a/src/main/java/com/google/javascript/gents/Options.java
+++ b/src/main/java/com/google/javascript/gents/Options.java
@@ -9,6 +9,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.javascript.jscomp.CheckLevel;
 import com.google.javascript.jscomp.CompilerOptions;
 import com.google.javascript.jscomp.DiagnosticGroups;
+import com.google.javascript.jscomp.parsing.Config;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.file.Files;
@@ -109,15 +110,13 @@ public class Options {
 
     // Compiler passes must be disabled to disable down-transpilation to ES5.
     options.skipAllCompilerPasses();
-    setIdeMode(options);
+    // turns off optimizations.
+    options.setChecksOnly(true);
+    options.setContinueAfterErrors(true);
+    options.setPreserveDetailedSourceInfo(true);
+    options.setParseJsDocDocumentation(Config.JsDocParsing.INCLUDE_DESCRIPTIONS_NO_WHITESPACE);
 
     return options;
-  }
-
-  @SuppressWarnings("deprecation")
-  private void setIdeMode(final CompilerOptions options) {
-    // So that we can query types after compilation.
-    options.setIdeMode(true);
   }
 
   private Map<String, String> getExternsMap() throws IOException {

--- a/src/test/java/com/google/javascript/clutz/goog_scope_templatized.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_scope_templatized.d.ts
@@ -13,8 +13,7 @@ declare module 'goog:aliasT.I2' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.aliasT {
-  //!! TODO(rado): investigate why this is not I<string>.
-  var iboom : ಠ_ಠ.clutz.$jscomp.scope.I < any > | null ;
+  var iboom : ಠ_ಠ.clutz.$jscomp.scope.I < string > | null ;
 }
 declare namespace goog {
   function require(name: 'aliasT.iboom'): typeof ಠ_ಠ.clutz.aliasT.iboom;


### PR DESCRIPTION
For now replace with exact contents of setIdeMode:
https://github.com/google/closure-compiler/blob/7580f657e1d513efb06eb1ff9821e872a8b743c6/src/com/google/javascript/jscomp/CompilerOptions.java#L2044
except setAllowHotswapReplaceScript since both clutz and gents do not
support hotswapping code.

Surprisingly removing setAllowHotswapReplaceScript changes type
inference (what looks like for the better).