### PR TITLE
Remove continueAfterError flag.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -391,9 +391,13 @@ class DeclarationGenerator {
       List<SourceFile> sourceFiles, List<SourceFile> externs, Depgraph depgraph)
       throws AssertionError {
     compiler.compile(externs, sourceFiles, opts.getCompilerOptions());
-    precomputeChildLists();
-    collectTypedefs();
-    String dts = produceDts(depgraph);
+    String dts = "";
+    // If there is an error top scope is null.
+    if (compiler.getTopScope() != null) {
+      precomputeChildLists();
+      collectTypedefs();
+      dts = produceDts(depgraph);
+    }
     errorManager.doGenerateReport();
     return dts;
   }

--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -103,7 +103,6 @@ public class Options {
     options.setInferTypes(true);
     // turns off optimizations.
     options.setChecksOnly(true);
-    options.setContinueAfterErrors(true);
     options.setPreserveDetailedSourceInfo(true);
     options.setParseJsDocDocumentation(Config.JsDocParsing.INCLUDE_DESCRIPTIONS_NO_WHITESPACE);
     return options;

--- a/src/main/java/com/google/javascript/gents/Options.java
+++ b/src/main/java/com/google/javascript/gents/Options.java
@@ -112,7 +112,6 @@ public class Options {
     options.skipAllCompilerPasses();
     // turns off optimizations.
     options.setChecksOnly(true);
-    options.setContinueAfterErrors(true);
     options.setPreserveDetailedSourceInfo(true);
     options.setParseJsDocDocumentation(Config.JsDocParsing.INCLUDE_DESCRIPTIONS_NO_WHITESPACE);
 

--- a/src/test/java/com/google/javascript/clutz/ClutzErrorManagerTest.java
+++ b/src/test/java/com/google/javascript/clutz/ClutzErrorManagerTest.java
@@ -19,7 +19,7 @@ public class ClutzErrorManagerTest {
     // Useful
     assertThatProgram("/** @type {number} */ var x = 1;", "/** @type {number} */ var x = 2;")
         .diagnosticStream()
-        .containsMatch("ERROR.*variable x redefined");
+        .containsMatch("ERROR.*Variable x first declared in");
   }
 
   @Test


### PR DESCRIPTION
Clutz and Gents are already pretty lenient about errors.

However, when a true error is encountered by closure, continuing after
it can result in an even more catastrophic internal compiler error.

For example, the following snippet uses ES7 proposed syntax
```
function f() {
    {...res}
    switch (0) {
        case undefined:
            return 0
        }
    }
```
without setContinueAfterErrors - a normal syntax error.
with setContinueAfterErrors - an internal compiler error.

/cc @MatrixFrog