### PR TITLE
Only consider OwnProprertyNames when describing objects.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -831,7 +831,7 @@ class DeclarationGenerator {
       ObjectType objType = symbol.getType().toMaybeObjectType();
       // Can be null if the symbol is provided, but not defined.
       Set<String> propertyNames =
-          objType != null ? objType.getPropertyNames() : Collections.<String>emptySet();
+          objType != null ? objType.getOwnPropertyNames() : Collections.<String>emptySet();
       for (String property : propertyNames) {
         // When parsing externs namespaces are explicitly declared with a var of Object type
         // Do not emit the var declaration, as it will conflict with the namespace.

--- a/src/test/java/com/google/javascript/clutz/infer_in_goog_module_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/infer_in_goog_module_with_platform.d.ts
@@ -1,0 +1,10 @@
+declare namespace ಠ_ಠ.clutz.module$exports$inferWithPlatform {
+  var A : number ;
+}
+declare namespace goog {
+  function require(name: 'module$exports$inferWithPlatform'): typeof ಠ_ಠ.clutz.module$exports$inferWithPlatform;
+}
+declare module 'goog:inferWithPlatform' {
+  import alias = ಠ_ಠ.clutz.module$exports$inferWithPlatform;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/infer_in_goog_module_with_platform.js
+++ b/src/test/java/com/google/javascript/clutz/infer_in_goog_module_with_platform.js
@@ -1,0 +1,6 @@
+goog.module('inferWithPlatform');
+
+/** @const */
+const A = 0;
+
+exports.A = A;


### PR DESCRIPTION
After #508 we started emitting all properties on export objects.
However, every object has inherited properties from the prototype
Object - __defineGetter__ etc.

TypeScript already models those internally, so there is no need to
emit them for every module object.