### PR TITLE
Remove @type annotation for multiple lines annotations.

### DIFF
--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -33,7 +33,8 @@ public final class CommentLinkingPass implements CompilerPass {
    */
   private static final Pattern[] JSDOC_REPLACEMENTS = {
     Pattern.compile(
-        BEGIN_JSDOC_LINE + "@(extends|implements|type)[ \t]*(\\{.*\\})[ \t]*(?<keep>)" + EOL),
+        BEGIN_JSDOC_LINE + "@(extends|implements|type)[ \t]*(\\{[^@]*\\})[ \t]*(?<keep>)" + EOL,
+        Pattern.DOTALL),
     Pattern.compile(BEGIN_JSDOC_LINE + "@(constructor|interface|record)[ \t]*(?<keep>)" + EOL),
     Pattern.compile(
         BEGIN_JSDOC_LINE

--- a/src/test/java/com/google/javascript/gents/singleTests/comments.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/comments.js
@@ -50,6 +50,32 @@ var xConst = 1;
  */
 var X = function() {}
 
+class B {
+  constructor() {
+
+    /**
+     * @type {{param1: (string|undefined)
+     * }}
+     */
+    this.twoLines = {param1: "param1"};
+
+    /**
+     * @type {{
+     *   param2: (string|undefined)
+     * }}
+     */
+    this.multipleLines = {param2: "param2"};
+
+    /**
+     * @type {{
+     *   param3: (string|undefined),
+     *   param4: (string|undefined),
+     * }}
+     */
+    this.twoParams = {param3: "param3", param4: "param4"};
+  }
+}
+
 /** @export {number} */
 let m = 4;
 

--- a/src/test/java/com/google/javascript/gents/singleTests/comments.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/comments.ts
@@ -37,6 +37,13 @@ const xConst: number = 1;
 
 class X extends A {}
 
+class B {
+  twoLines: {param1: string | undefined} = {param1: 'param1'};
+  multipleLines: {param2: string | undefined} = {param2: 'param2'};
+  twoParams: {param3: string | undefined,
+              param4: string|undefined} = {param3: 'param3', param4: 'param4'};
+}
+
 /** @export */
 let m: number = 4;
 


### PR DESCRIPTION
`.` matches any character except a newline therefore multi-lines annotations wouldn't be removed.