### PR TITLE
Keep generic @extends comments to make post processing easier.

### DIFF
--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -33,8 +33,11 @@ public final class CommentLinkingPass implements CompilerPass {
    */
   private static final Pattern[] JSDOC_REPLACEMENTS = {
     Pattern.compile(
-        BEGIN_JSDOC_LINE + "@(extends|implements|type)[ \t]*(\\{[^@]*\\})[ \t]*(?<keep>)" + EOL,
+        BEGIN_JSDOC_LINE + "@(implements|type)[ \t]*(\\{[^@]*\\})[ \t]*(?<keep>)" + EOL,
         Pattern.DOTALL),
+    //keep generic extends for post processing
+    Pattern.compile(
+        BEGIN_JSDOC_LINE + "@extends[ \t]*(\\{[^@<>]*\\})[ \t]*(?<keep>)" + EOL, Pattern.DOTALL),
     Pattern.compile(BEGIN_JSDOC_LINE + "@(constructor|interface|record)[ \t]*(?<keep>)" + EOL),
     Pattern.compile(
         BEGIN_JSDOC_LINE


### PR DESCRIPTION
This may help with implementing https://github.com/angular/clutz/issues/483, and in the meantime it helps you identify places that need to be manually fixed.