### PR TITLE
Always move field declarations into classes as static methods, even if there is no type information

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeConversionPass.java
@@ -208,8 +208,10 @@ public final class TypeConversionPass implements CompilerPass {
           if (declaration.rhs != null && declaration.rhs.isFunction()) {
             moveMethodsIntoClasses(declaration);
           } else {
-            // Ignore field declarations without a type annotation
-            if (declaration.jsDoc != null && declaration.jsDoc.getType() != null) {
+            // Ignore field declarations that are enums or classes
+            String comment = nodeComments.getComment(n);
+            if (!(declaration.rhs != null && declaration.rhs.isClass())
+                && (comment == null || comment.indexOf("@enum") < 0)) {
               moveFieldsIntoClasses(declaration);
             }
           }

--- a/src/test/java/com/google/javascript/gents/singleTests/static_methods.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/static_methods.ts
@@ -1,5 +1,6 @@
 let goog: any = {};
 goog.A = class {
+  static B: any = {};
   a: any;
 
   constructor(a: number) {
@@ -20,7 +21,6 @@ goog.A = class {
     return n > 0;
   }
 };
-goog.A.B = {};
 
 /**
  * Unconverted method


### PR DESCRIPTION
This fixes https://github.com/angular/clutz/issues/485

This makes the check for adding static members more specific. Any field that is not annotated with `@enum` and that is not a class will be added as a static member.