### PR TITLE
Upgrade clutz tests to TS2.4.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,81 +1,125 @@
 {
   "name": "clutz",
   "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "async": {
       "version": "1.5.2",
-      "from": "async@>=1.5.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
     },
     "balanced-match": {
       "version": "0.4.2",
-      "from": "balanced-match@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.6",
-      "from": "brace-expansion@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "0.4.2",
+        "concat-map": "0.0.1"
+      }
     },
     "clang-format": {
       "version": "1.0.48",
-      "from": "clang-format@>=1.0.48 <2.0.0",
-      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.48.tgz"
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.48.tgz",
+      "integrity": "sha1-RIhVJbhJO4ztfhxZtXOICNb/H3o=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "glob": "7.1.1",
+        "resolve": "1.2.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
-      "from": "concat-map@0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "from": "fs.realpath@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.1",
-      "from": "glob@>=7.0.0 <8.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.3",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "inflight": {
       "version": "1.0.6",
-      "from": "inflight@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.3",
-      "from": "minimatch@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.6"
+      }
     },
     "once": {
       "version": "1.4.0",
-      "from": "once@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "resolve": {
       "version": "1.2.0",
-      "from": "resolve@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz",
+      "integrity": "sha1-lYnD8vYUnRQXpAvswWY9tuxrwmw=",
+      "dev": true
     },
     "typescript": {
-      "version": "2.2.1",
-      "from": "typescript@>=2.1.6 <3.0.0",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.1.tgz"
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+      "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
-      "from": "wrappy@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "description": "Clutz is not on npm, and technically not a node package. \n This is needed only for testing Clutz's output against the TypeScript compiler, and to install some development dependencies from npm.",
   "devDependencies": {
     "clang-format": "^1.0.48",
-    "typescript": "^2.1.6"
+    "typescript": "^2.4.2"
   }
 }

--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -86,7 +86,6 @@ class DeclarationGenerator {
           "Headers",
           "RequestMode",
           "WorkerLocation",
-          "Promise",
           "RequestContext",
           "Response",
           "ReadableByteStream",

--- a/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
@@ -314,20 +314,6 @@ declare namespace ಠ_ಠ.clutz {
   }
 }
 declare namespace ಠ_ಠ.clutz {
-  class Promise < TYPE > extends Promise_Instance < TYPE > {
-    static all(promises : Promise < any > [] ) : Promise < any [] > ;
-    static race < T > (values : T [] ) : Promise < T > ;
-    static reject (opt_error ? : any ) : Promise < any > ;
-    static resolve < T >(value: Promise < T > | T): Promise < T >;
-  }
-  class Promise_Instance < TYPE > implements PromiseLike < TYPE > {
-    private noStructuralTyping_: any;
-    constructor (resolver : (a : (a ? : TYPE | PromiseLike < TYPE > | null | { then : any } ) => any , b : (a ? : any ) => any ) => any ) ;
-    catch < RESULT > (onRejected : (a : any ) => RESULT ) : Promise < RESULT > ;
-    then < RESULT > (opt_onFulfilled ? : ( (a : TYPE ) => Promise < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : Promise < RESULT > ;
-  }
-}
-declare namespace ಠ_ಠ.clutz {
   /**
    * The ReadableByteStreamController constructor cannot be used directly;
    * it only works on a ReadableStream that is in the middle of being constructed.

--- a/src/test/java/com/google/javascript/clutz/tte_promise_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/tte_promise_usage.ts
@@ -5,4 +5,4 @@ let y: Promise<string> = x.then(x => x).then(x => x + 'foo');
 let z: Promise<boolean> = x.then(x => new Promise<boolean>());
 let w: Promise<number> = x.then(x => 0);
 
-let all: Promise<[string, string, number]> = Promise.all([x, y, z, w]);
+let all: Promise<any[]> = Promise.all([x, y, z, w]);


### PR DESCRIPTION
Remove 'Promise' from the list of platform APIs for which we generate
types. This means that clutz will reuse the Promise definition from
lib.d.ts, instead of attempting to translate closure's definition.

Closure already uses TTE's for the types of Promise and we have to
resort to hard-coding the translation.

Also, fix a test that failed in the presence of properly covariant
promises.