### PR TITLE
Add option for supporting partial program input to clutz.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -71,6 +71,14 @@ public class Options {
   )
   List<String> entryPoints = new ArrayList<>();
 
+  @Option(
+    name = "--partialInput",
+    usage =
+        "allow input of incomplete programs. All unknown types will be treated as forward"
+            + "declared."
+  )
+  boolean partialInput;
+
   @Argument List<String> arguments = new ArrayList<>();
 
   Depgraph depgraph;
@@ -106,6 +114,10 @@ public class Options {
     options.setChecksOnly(true);
     options.setPreserveDetailedSourceInfo(true);
     options.setParseJsDocDocumentation(Config.JsDocParsing.INCLUDE_DESCRIPTIONS_NO_WHITESPACE);
+    if (partialInput) {
+      options.setAssumeForwardDeclaredForMissingTypes(true);
+      options.setWarningLevel(DiagnosticGroups.MISSING_SOURCES_WARNINGS, CheckLevel.OFF);
+    }
     return options;
   }
 

--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -75,7 +75,7 @@ public class Options {
     name = "--partialInput",
     usage =
         "allow input of incomplete programs. All unknown types will be treated as forward"
-            + "declared."
+            + " declared."
   )
   boolean partialInput;
 

--- a/src/test/java/com/google/javascript/clutz/DeclarationGeneratorTests.java
+++ b/src/test/java/com/google/javascript/clutz/DeclarationGeneratorTests.java
@@ -3,6 +3,7 @@ package com.google.javascript.clutz;
 import static com.google.javascript.clutz.ProgramSubject.assertThatProgram;
 
 import com.google.common.base.Charsets;
+import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import java.io.File;
 import java.io.FilenameFilter;
@@ -73,6 +74,9 @@ public class DeclarationGeneratorTests {
       if (input.getName().contains("_emit_platform_externs")) {
         subject.emitPlatformExterns = true;
       }
+      if (input.getParentFile().getName().equals("partial")) {
+        subject.partialInput = true;
+      }
       subject.extraExternFile = getExternFileNameOrNull(input.getName());
       suite.addTest(new DeclarationTest(input.getName(), goldenText, subject));
     }
@@ -91,7 +95,11 @@ public class DeclarationGeneratorTests {
 
   public static List<File> getTestInputFiles(FilenameFilter filter) {
     File[] testFiles = getPackagePath().toFile().listFiles(filter);
-    return Arrays.asList(testFiles);
+    // Partial files live in 'partial' dir and run implicitly with the --partialInput option on.
+    File[] testPartialFiles = getPackagePath().resolve("partial").toFile().listFiles(filter);
+    List<File> filesList = Lists.newArrayList(testFiles);
+    filesList.addAll(Arrays.asList(testPartialFiles));
+    return filesList;
   }
 
   static Path getTestInputFile(String fileName) {

--- a/src/test/java/com/google/javascript/clutz/ProgramSubject.java
+++ b/src/test/java/com/google/javascript/clutz/ProgramSubject.java
@@ -30,6 +30,7 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
       SourceFile.fromFile("src/test/java/com/google/javascript/clutz/base.js", UTF_8);
 
   public boolean withPlatform = false;
+  public boolean partialInput = false;
   public String extraExternFile = null;
   public boolean emitPlatformExterns;
 
@@ -77,6 +78,9 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
 
   private String[] parse() throws AssertionError {
     Options opts = new Options();
+    if (partialInput) {
+      opts.partialInput = true;
+    }
     opts.debug = true;
     opts.emitPlatformExterns = emitPlatformExterns;
     List<SourceFile> sourceFiles = new ArrayList<>();
@@ -105,7 +109,7 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
       roots.add("main.js");
     }
 
-    List<SourceFile> externFiles = new ArrayList<>();
+    List<SourceFile> externFiles;
     if (withPlatform) {
       externFiles = DeclarationGenerator.getDefaultExterns(opts);
     } else {

--- a/src/test/java/com/google/javascript/clutz/partial/missing_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_type.d.ts
@@ -1,0 +1,10 @@
+declare namespace ಠ_ಠ.clutz.module$exports$missing$type {
+  var x : any ;
+}
+declare namespace goog {
+  function require(name: 'module$exports$missing$type'): typeof ಠ_ಠ.clutz.module$exports$missing$type;
+}
+declare module 'goog:missing.type' {
+  import alias = ಠ_ಠ.clutz.module$exports$missing$type;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/missing_type.js
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_type.js
@@ -1,0 +1,6 @@
+goog.module('missing.type');
+
+/** @const {!Missing} */
+let x = missingFunctionCall();
+
+exports.x = x;


### PR DESCRIPTION
When the flag is set, clutz will use setAssumeForwardDeclaration for all
unknown types, and not error on incomplete inputs.

Adds /partial/ directory for tests that run with that option on.