### PR TITLE
Special case `@enum {number}` enums.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -1453,7 +1453,7 @@ class DeclarationGenerator {
       emit("=");
       visitType(registryType, true, false);
       // emit a brand to prevent accidental compatibility of values with an enum.
-      if (emitNeverBrand) emit("&{brand: never}");
+      if (emitNeverBrand) emit("&{clutzEnumBrand: never}");
       emit(";");
       emitBreak();
     }

--- a/src/test/java/com/google/javascript/clutz/aliased_enums.d.ts
+++ b/src/test/java/com/google/javascript/clutz/aliased_enums.d.ts
@@ -1,18 +1,15 @@
 declare namespace ಠ_ಠ.clutz.nested.bar {
-  type HahaEnum = number ;
-  var HahaEnum : {
-    A : HahaEnum ,
-  };
+  type HahaEnum = nested.baz.Enum ;
+  const HahaEnum : typeof nested.baz.Enum ;
 }
 declare module 'goog:nested.bar.HahaEnum' {
   import alias = ಠ_ಠ.clutz.nested.bar.HahaEnum;
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.nested.baz {
-  type Enum = number ;
-  var Enum : {
-    A : Enum ,
-  };
+  enum Enum {
+    A ,
+  }
 }
 declare module 'goog:nested.baz.Enum' {
   import alias = ಠ_ಠ.clutz.nested.baz.Enum;

--- a/src/test/java/com/google/javascript/clutz/enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/enum.d.ts
@@ -1,5 +1,5 @@
 declare namespace ಠ_ಠ.clutz.some {
-  type ObjectValuedEnum = X &{brand: never} ;
+  type ObjectValuedEnum = X &{clutzEnumBrand: never} ;
   var ObjectValuedEnum : {
     A : ObjectValuedEnum ,
     B : ObjectValuedEnum ,

--- a/src/test/java/com/google/javascript/clutz/enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/enum.d.ts
@@ -1,11 +1,28 @@
 declare namespace ಠ_ಠ.clutz.some {
-  type SomeEnum = number ;
-  var SomeEnum : {
-    A : SomeEnum ,
-    B : SomeEnum ,
+  type ObjectValuedEnum = X &{brand: never} ;
+  var ObjectValuedEnum : {
+    A : ObjectValuedEnum ,
+    B : ObjectValuedEnum ,
   };
+}
+declare module 'goog:some.ObjectValuedEnum' {
+  import alias = ಠ_ಠ.clutz.some.ObjectValuedEnum;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.some {
+  enum SomeEnum {
+    A ,
+    B ,
+  }
 }
 declare module 'goog:some.SomeEnum' {
   import alias = ಠ_ಠ.clutz.some.SomeEnum;
   export default alias;
+}
+declare namespace ಠ_ಠ.clutz {
+  class X extends X_Instance {
+  }
+  class X_Instance {
+    private noStructuralTyping_: any;
+  }
 }

--- a/src/test/java/com/google/javascript/clutz/enum.js
+++ b/src/test/java/com/google/javascript/clutz/enum.js
@@ -1,7 +1,17 @@
 goog.provide('some.SomeEnum');
+goog.provide('some.ObjectValuedEnum');
 
 /** @enum {number} */
 some.SomeEnum = {
   A: 1,
   B: 2
+};
+
+/** @constructor */
+function X() {}
+
+/** @enum {X} */
+some.ObjectValuedEnum = {
+  A: new X(),
+  B: new X()
 };

--- a/src/test/java/com/google/javascript/clutz/enum_unprovided.d.ts
+++ b/src/test/java/com/google/javascript/clutz/enum_unprovided.d.ts
@@ -11,7 +11,7 @@ declare module 'goog:somenamespace.Foo' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.somenamespace {
-  type MyEnum = string &{brand: never} ;
+  type MyEnum = string &{clutzEnumBrand: never} ;
   var MyEnum : {
   };
 }

--- a/src/test/java/com/google/javascript/clutz/enum_unprovided.d.ts
+++ b/src/test/java/com/google/javascript/clutz/enum_unprovided.d.ts
@@ -11,7 +11,7 @@ declare module 'goog:somenamespace.Foo' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.somenamespace {
-  type MyEnum = string ;
+  type MyEnum = string &{brand: never} ;
   var MyEnum : {
   };
 }

--- a/src/test/java/com/google/javascript/clutz/enum_with_method.d.ts
+++ b/src/test/java/com/google/javascript/clutz/enum_with_method.d.ts
@@ -4,9 +4,6 @@ declare namespace ಠ_ಠ.clutz.enums {
     BANANA ,
   }
 }
-declare namespace goog {
-  function require(name: 'enums.EnumWithMethod'): typeof ಠ_ಠ.clutz.enums.EnumWithMethod;
-}
 declare module 'goog:enums.EnumWithMethod' {
   import alias = ಠ_ಠ.clutz.enums.EnumWithMethod;
   export default alias;

--- a/src/test/java/com/google/javascript/clutz/enum_with_method.d.ts
+++ b/src/test/java/com/google/javascript/clutz/enum_with_method.d.ts
@@ -1,0 +1,13 @@
+declare namespace ಠ_ಠ.clutz.enums {
+  enum EnumWithMethod {
+    APPLE ,
+    BANANA ,
+  }
+}
+declare namespace goog {
+  function require(name: 'enums.EnumWithMethod'): typeof ಠ_ಠ.clutz.enums.EnumWithMethod;
+}
+declare module 'goog:enums.EnumWithMethod' {
+  import alias = ಠ_ಠ.clutz.enums.EnumWithMethod;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/enum_with_method.js
+++ b/src/test/java/com/google/javascript/clutz/enum_with_method.js
@@ -1,0 +1,10 @@
+goog.provide('enums.EnumWithMethod');
+
+/** @enum {number} */
+enums.EnumWithMethod = {
+  APPLE: 1,
+  BANANA: 2
+};
+
+//!! Known issue: does not get emitted.
+enums.EnumWithMethod.getColor = function() { return 'RED' /* all fruit are */; }

--- a/src/test/java/com/google/javascript/clutz/extern_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/extern_enum.d.ts
@@ -1,6 +1,5 @@
 declare namespace ಠ_ಠ.clutz.ns {
-  type Enum = number ;
-  var Enum : {
-    A : Enum ,
-  };
+  enum Enum {
+    A ,
+  }
 }

--- a/src/test/java/com/google/javascript/clutz/fn_inner_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/fn_inner_enum.d.ts
@@ -2,9 +2,8 @@ declare namespace ಠ_ಠ.clutz.ns {
   function foo ( ) : boolean ;
 }
 declare namespace ಠ_ಠ.clutz.ns.foo {
-  type Enum = number ;
-  var Enum : {
-  };
+  enum Enum {
+  }
 }
 declare module 'goog:ns.foo' {
   import alias = ಠ_ಠ.clutz.ns.foo;

--- a/src/test/java/com/google/javascript/clutz/inner_extern_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/inner_extern_enum.d.ts
@@ -4,7 +4,7 @@ declare namespace ಠ_ಠ.clutz.innerEnumNs {
   }
 }
 declare namespace ಠ_ಠ.clutz.innerEnumNs.Foo {
-  type Bar = string ;
+  type Bar = string &{brand: never} ;
   var Bar : {
     BAZ : Bar ,
   };

--- a/src/test/java/com/google/javascript/clutz/inner_extern_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/inner_extern_enum.d.ts
@@ -4,7 +4,7 @@ declare namespace ಠ_ಠ.clutz.innerEnumNs {
   }
 }
 declare namespace ಠ_ಠ.clutz.innerEnumNs.Foo {
-  type Bar = string &{brand: never} ;
+  type Bar = string &{clutzEnumBrand: never} ;
   var Bar : {
     BAZ : Bar ,
   };

--- a/src/test/java/com/google/javascript/clutz/interface.d.ts
+++ b/src/test/java/com/google/javascript/clutz/interface.d.ts
@@ -17,11 +17,10 @@ declare module 'goog:interface_exp' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.interface_exp {
-  type SomeEnum = number ;
-  var SomeEnum : {
-    A : SomeEnum ,
-    B : SomeEnum ,
-  };
+  enum SomeEnum {
+    A ,
+    B ,
+  }
 }
 declare module 'goog:interface_exp.SomeEnum' {
   import alias = ಠ_ಠ.clutz.interface_exp.SomeEnum;

--- a/src/test/java/com/google/javascript/clutz/nested_namespaces.d.ts
+++ b/src/test/java/com/google/javascript/clutz/nested_namespaces.d.ts
@@ -1,16 +1,14 @@
 declare namespace ಠ_ಠ.clutz.nested {
-  type NotNested = number ;
-  var NotNested : {
-  };
+  enum NotNested {
+  }
 }
 declare module 'goog:nested.NotNested' {
   import alias = ಠ_ಠ.clutz.nested.NotNested;
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.nested {
-  type NotNestedEither = number ;
-  var NotNestedEither : {
-  };
+  enum NotNestedEither {
+  }
 }
 declare module 'goog:nested.NotNestedEither' {
   import alias = ಠ_ಠ.clutz.nested.NotNestedEither;
@@ -28,9 +26,8 @@ declare module 'goog:nested.PrivateC' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.nested.PrivateC {
-  type Enum = number ;
-  var Enum : {
-  };
+  enum Enum {
+  }
 }
 declare module 'goog:nested.PrivateC.Enum' {
   import alias = ಠ_ಠ.clutz.nested.PrivateC.Enum;

--- a/src/test/java/com/google/javascript/clutz/nested_typedef_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/nested_typedef_enum.d.ts
@@ -6,10 +6,9 @@ declare module 'goog:nested_typedef_enum.Bar' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.nested_typedef_enum.Bar {
-  type Baz = number ;
-  var Baz : {
-    A : Baz ,
-  };
+  enum Baz {
+    A ,
+  }
 }
 declare module 'goog:nested_typedef_enum.Bar.Baz' {
   import alias = ಠ_ಠ.clutz.nested_typedef_enum.Bar.Baz;

--- a/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
@@ -17,11 +17,10 @@ declare namespace ಠ_ಠ.clutz.foo.bar.Baz {
   class NestedClass_Instance {
     private noStructuralTyping_: any;
   }
-  type NestedEnum = number ;
-  var NestedEnum : {
-    A : NestedEnum ,
-    B : NestedEnum ,
-  };
+  enum NestedEnum {
+    A ,
+    B ,
+  }
 }
 declare module 'goog:foo.bar.Baz' {
   import alias = ಠ_ಠ.clutz.foo.bar.Baz;

--- a/src/test/java/com/google/javascript/clutz/static_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_enum.d.ts
@@ -7,7 +7,7 @@ declare namespace ಠ_ಠ.clutz {
   }
 }
 declare namespace ಠ_ಠ.clutz.module$exports$foo$C {
-  type Enum = string &{brand: never} ;
+  type Enum = string &{clutzEnumBrand: never} ;
   var Enum : {
     A : Enum ,
   };

--- a/src/test/java/com/google/javascript/clutz/static_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_enum.d.ts
@@ -7,7 +7,7 @@ declare namespace ಠ_ಠ.clutz {
   }
 }
 declare namespace ಠ_ಠ.clutz.module$exports$foo$C {
-  type Enum = string ;
+  type Enum = string &{brand: never} ;
   var Enum : {
     A : Enum ,
   };

--- a/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch_nested_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch_nested_type.d.ts
@@ -30,7 +30,7 @@ declare namespace ಠ_ಠ.clutz.sim_nested {
   }
 }
 declare namespace ಠ_ಠ.clutz.sim_nested.Parent {
-  type Nested = string &{brand: never} ;
+  type Nested = string &{clutzEnumBrand: never} ;
   var Nested : {
     A : Nested ,
   };
@@ -40,7 +40,7 @@ declare module 'goog:sim_nested.Parent' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.sim_nested.Parent {
-  type NestedAndProvided = string &{brand: never} ;
+  type NestedAndProvided = string &{clutzEnumBrand: never} ;
   var NestedAndProvided : {
     A : NestedAndProvided ,
   };

--- a/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch_nested_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch_nested_type.d.ts
@@ -5,20 +5,18 @@ declare namespace ಠ_ಠ.clutz.sim_nested {
   }
 }
 declare namespace ಠ_ಠ.clutz.sim_nested.Child {
-  type Nested = number ;
-  var Nested : {
-    B : Nested ,
-  };
+  enum Nested {
+    B ,
+  }
 }
 declare module 'goog:sim_nested.Child' {
   import alias = ಠ_ಠ.clutz.sim_nested.Child;
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.sim_nested.Child {
-  type NestedAndProvided = number ;
-  var NestedAndProvided : {
-    B : NestedAndProvided ,
-  };
+  enum NestedAndProvided {
+    B ,
+  }
 }
 declare module 'goog:sim_nested.Child.NestedAndProvided' {
   import alias = ಠ_ಠ.clutz.sim_nested.Child.NestedAndProvided;
@@ -32,7 +30,7 @@ declare namespace ಠ_ಠ.clutz.sim_nested {
   }
 }
 declare namespace ಠ_ಠ.clutz.sim_nested.Parent {
-  type Nested = string ;
+  type Nested = string &{brand: never} ;
   var Nested : {
     A : Nested ,
   };
@@ -42,7 +40,7 @@ declare module 'goog:sim_nested.Parent' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.sim_nested.Parent {
-  type NestedAndProvided = string ;
+  type NestedAndProvided = string &{brand: never} ;
   var NestedAndProvided : {
     A : NestedAndProvided ,
   };

--- a/src/test/java/com/google/javascript/clutz/static_provided.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_provided.d.ts
@@ -10,11 +10,10 @@ declare module 'goog:a.b.StaticHolder' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.a.b.StaticHolder {
-  type AnEnum = number ;
-  var AnEnum : {
-    X : AnEnum ,
-    Y : AnEnum ,
-  };
+  enum AnEnum {
+    X ,
+    Y ,
+  }
 }
 declare module 'goog:a.b.StaticHolder.AnEnum' {
   import alias = ಠ_ಠ.clutz.a.b.StaticHolder.AnEnum;

--- a/src/test/java/com/google/javascript/clutz/typedef_inner_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/typedef_inner_enum.d.ts
@@ -2,7 +2,7 @@ declare namespace ಠ_ಠ.clutz.ns {
   type typedef = { foo : ಠ_ಠ.clutz.ns.typedef.E } ;
 }
 declare namespace ಠ_ಠ.clutz.ns.typedef {
-  type E = string ;
+  type E = string &{brand: never} ;
   var E : {
     Foo : E ,
   };

--- a/src/test/java/com/google/javascript/clutz/typedef_inner_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/typedef_inner_enum.d.ts
@@ -2,7 +2,7 @@ declare namespace ಠ_ಠ.clutz.ns {
   type typedef = { foo : ಠ_ಠ.clutz.ns.typedef.E } ;
 }
 declare namespace ಠ_ಠ.clutz.ns.typedef {
-  type E = string &{brand: never} ;
+  type E = string &{clutzEnumBrand: never} ;
   var E : {
     Foo : E ,
   };


### PR DESCRIPTION
Emitting proper TypeScript enums allows the TypeScript compiler to make
additional inferences about the code, e.g. to support tagged unions,
type narrowing, exhaustive switches etc.

This also adds an `&{brand: never}` token to all other enums, to prevent
accidental assignment compatibility of values.

Because enums with the same members are not assignment compatible in TS
(enums are essentially nominally typed), this also has to update the
aliased enum emit.

Fixes #546.