### PR TITLE
Support custom [Symbol.iterator] implementations.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -2194,7 +2194,9 @@ class DeclarationGenerator {
 
     /**
      * Closure Compiler does not support tuple types, and thus cannot express the proper type for
-     * "Map<K, V>.entries()", which is an IterableIterator of a [K, V] tuple.
+     * "Map<K, V>.entries()", which is an IterableIterator of a [K, V] tuple. The tighter tuple type
+     * [K, V] allows destructuring loops "for (const [x, y] of ...)" with the tuple values getting
+     * the right types assigned.
      *
      * <p>Given that maps are very common, as are for loops over them, this special cases methods
      * called "entries" that have the right return type.

--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -2073,8 +2073,7 @@ class DeclarationGenerator {
       } else {
         return;
       }
-      emit("// Symbol.iterator inserted by Clutz for Iterable subtype");
-      emitBreak();
+      emitComment("Symbol.iterator inserted by Clutz for Iterable subtype");
       emit("[Symbol.iterator](): ");
       // The actual implementation of iterator could be an arbitrary subtype of Iterable. Emit
       // the type of the interface as the next best thing.

--- a/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
+++ b/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
@@ -61,6 +61,7 @@ public class DeclarationSyntaxTest {
       ImmutableList.of(
           "--noEmit",
           "--skipDefaultLibCheck",
+          "--downlevelIteration",
           "--lib",
           "es5,dom,es2015.iterable",
           "--noImplicitAny",
@@ -126,7 +127,7 @@ public class DeclarationSyntaxTest {
     if (tsc.exitValue() != 0) {
       InputStreamReader isr = new InputStreamReader(tsc.getInputStream(), Charsets.UTF_8);
       String consoleOut = CharStreams.toString(isr);
-      fail(command + ": exited abnormally with code " + tsc.exitValue() + "\n" + consoleOut);
+      fail("tsc exited abnormally with code " + tsc.exitValue() + "\n" + consoleOut);
     }
   }
 }

--- a/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
@@ -237,7 +237,6 @@ declare namespace ಠ_ಠ.clutz {
   class Headers_Instance implements Iterable < string [] > {
     private noStructuralTyping_: any;
     constructor (opt_headersInit ? : Headers | string [] [] | IObject < string , string > ) ;
-    // Symbol.iterator inserted by Clutz for Iterable subtype
     [Symbol.iterator]():  Iterator < string [] > ;
     append (name : string , value : string ) : void ;
     delete (name : string ) : void ;

--- a/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
@@ -237,9 +237,11 @@ declare namespace ಠ_ಠ.clutz {
   class Headers_Instance implements Iterable < string [] > {
     private noStructuralTyping_: any;
     constructor (opt_headersInit ? : Headers | string [] [] | IObject < string , string > ) ;
+    // Symbol.iterator inserted by Clutz for Iterable subtype
+    [Symbol.iterator]():  Iterator < string [] > ;
     append (name : string , value : string ) : void ;
     delete (name : string ) : void ;
-    entries ( ) : IteratorIterable < string [] > ;
+    entries ( ) : IterableIterator < string [] > ;
     get (name : string ) : string | null ;
     getAll (name : string ) : string [] ;
     has (name : string ) : boolean ;
@@ -253,17 +255,6 @@ declare namespace ಠ_ಠ.clutz {
   }
   class Image_Instance extends HTMLImageElement {
     constructor (opt_width ? : number , opt_height ? : number ) ;
-  }
-}
-declare namespace ಠ_ಠ.clutz {
-  interface Iterable < VALUE > {
-  }
-}
-declare namespace ಠ_ಠ.clutz {
-  /**
-   * Use this to indicate a type is both an Iterator and an Iterable.
-   */
-  interface IteratorIterable < T > extends Iterator < T > , Iterable < T > {
   }
 }
 declare namespace ಠ_ಠ.clutz {

--- a/src/test/java/com/google/javascript/clutz/implements_iterable_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/implements_iterable_with_platform.d.ts
@@ -3,7 +3,6 @@ declare namespace ಠ_ಠ.clutz.implements_iterable {
   }
   class ImplIterable_Instance implements Iterable < string > {
     private noStructuralTyping_: any;
-    // Symbol.iterator inserted by Clutz for Iterable subtype
     [Symbol.iterator]():  Iterator < string > ;
   }
 }
@@ -19,7 +18,6 @@ declare namespace ಠ_ಠ.clutz.implements_iterable {
   }
   class ImplIterableGeneric_Instance < T > implements Iterable < T > {
     private noStructuralTyping_: any;
-    // Symbol.iterator inserted by Clutz for Iterable subtype
     [Symbol.iterator]():  Iterator < any > ;
   }
 }
@@ -35,7 +33,6 @@ declare namespace ಠ_ಠ.clutz.implements_iterable {
   }
   class ImplIterableIterator_Instance implements IterableIterator < string > {
     private noStructuralTyping_: any;
-    // Symbol.iterator inserted by Clutz for Iterable subtype
     [Symbol.iterator]():  IterableIterator < string > ;
     next (a ? : string ) : IteratorResult < string > ;
   }

--- a/src/test/java/com/google/javascript/clutz/implements_iterable_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/implements_iterable_with_platform.d.ts
@@ -1,0 +1,49 @@
+declare namespace ಠ_ಠ.clutz.implements_iterable {
+  class ImplIterable extends ImplIterable_Instance {
+  }
+  class ImplIterable_Instance implements Iterable < string > {
+    private noStructuralTyping_: any;
+    // Symbol.iterator inserted by Clutz for Iterable subtype
+    [Symbol.iterator]():  Iterator < string > ;
+  }
+}
+declare namespace goog {
+  function require(name: 'implements_iterable.ImplIterable'): typeof ಠ_ಠ.clutz.implements_iterable.ImplIterable;
+}
+declare module 'goog:implements_iterable.ImplIterable' {
+  import alias = ಠ_ಠ.clutz.implements_iterable.ImplIterable;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.implements_iterable {
+  class ImplIterableGeneric < T > extends ImplIterableGeneric_Instance < T > {
+  }
+  class ImplIterableGeneric_Instance < T > implements Iterable < T > {
+    private noStructuralTyping_: any;
+    // Symbol.iterator inserted by Clutz for Iterable subtype
+    [Symbol.iterator]():  Iterator < any > ;
+  }
+}
+declare namespace goog {
+  function require(name: 'implements_iterable.ImplIterableGeneric'): typeof ಠ_ಠ.clutz.implements_iterable.ImplIterableGeneric;
+}
+declare module 'goog:implements_iterable.ImplIterableGeneric' {
+  import alias = ಠ_ಠ.clutz.implements_iterable.ImplIterableGeneric;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.implements_iterable {
+  class ImplIterableIterator extends ImplIterableIterator_Instance {
+  }
+  class ImplIterableIterator_Instance implements IterableIterator < string > {
+    private noStructuralTyping_: any;
+    // Symbol.iterator inserted by Clutz for Iterable subtype
+    [Symbol.iterator]():  IterableIterator < string > ;
+    next (a ? : string ) : IteratorResult < string > ;
+  }
+}
+declare namespace goog {
+  function require(name: 'implements_iterable.ImplIterableIterator'): typeof ಠ_ಠ.clutz.implements_iterable.ImplIterableIterator;
+}
+declare module 'goog:implements_iterable.ImplIterableIterator' {
+  import alias = ಠ_ಠ.clutz.implements_iterable.ImplIterableIterator;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/implements_iterable_with_platform.js
+++ b/src/test/java/com/google/javascript/clutz/implements_iterable_with_platform.js
@@ -1,0 +1,40 @@
+goog.provide('implements_iterable.ImplIterable');
+goog.provide('implements_iterable.ImplIterableGeneric');
+goog.provide('implements_iterable.ImplIterableIterator');
+
+/**
+ * @constructor
+ * @implements {Iterable<string>}
+ */
+implements_iterable.ImplIterable = function() {};
+
+/** @override @final */
+implements_iterable.ImplIterable.prototype[Symbol.iterator] = function() {
+  return new implements_iterable.ImplIterableIterator();
+};
+
+
+/**
+ * @constructor
+ * @template T
+ * @implements {Iterable<T>}
+ */
+implements_iterable.ImplIterableGeneric = function() {};
+
+/** @override @final */
+implements_iterable.ImplIterable.prototype[Symbol.iterator] = function() {
+  return new implements_iterable.ImplIterableIterator();
+};
+
+/**
+ * @constructor
+ * @implements {IteratorIterable<string>}
+ */
+implements_iterable.ImplIterableIterator = function() {};
+
+/**
+ * @return {!IIterableResult<string>}
+ */
+implements_iterable.ImplIterableIterator.prototype.next = function() {
+  return {done: false, value: 'infinite!'};
+};

--- a/src/test/java/com/google/javascript/clutz/implements_iterable_with_platform_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/implements_iterable_with_platform_usage.ts
@@ -1,0 +1,5 @@
+import ImplIterableGeneric from 'goog:implements_iterable.ImplIterableGeneric';
+
+for (const x of new ImplIterableGeneric<string>()) {
+  console.log(x);
+}

--- a/src/test/java/com/google/javascript/clutz/map_entries_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/map_entries_with_platform.d.ts
@@ -1,0 +1,18 @@
+declare namespace ಠ_ಠ.clutz.map_entries {
+  class Map < K , V > extends Map_Instance < K , V > {
+  }
+  class Map_Instance < K , V > {
+    private noStructuralTyping_: any;
+    /**
+     * Closure compiler sadly doesn't support tuples, ie. Iterator<[K,V]>.
+     */
+    entries (): IterableIterator<[ K , V ]>;
+  }
+}
+declare namespace goog {
+  function require(name: 'map_entries.Map'): typeof ಠ_ಠ.clutz.map_entries.Map;
+}
+declare module 'goog:map_entries.Map' {
+  import alias = ಠ_ಠ.clutz.map_entries.Map;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/map_entries_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/map_entries_with_platform.d.ts
@@ -1,7 +1,7 @@
-declare namespace ಠ_ಠ.clutz.map_entries {
-  class Map < K , V > extends Map_Instance < K , V > {
+declare namespace ಠ_ಠ.clutz {
+  class module$exports$map_entries$Map < K , V > extends module$exports$map_entries$Map_Instance < K , V > {
   }
-  class Map_Instance < K , V > {
+  class module$exports$map_entries$Map_Instance < K , V > {
     private noStructuralTyping_: any;
     /**
      * Closure compiler sadly doesn't support tuples, ie. Iterator<[K,V]>.
@@ -10,9 +10,9 @@ declare namespace ಠ_ಠ.clutz.map_entries {
   }
 }
 declare namespace goog {
-  function require(name: 'map_entries.Map'): typeof ಠ_ಠ.clutz.map_entries.Map;
+  function require(name: 'module$exports$map_entries$Map'): typeof ಠ_ಠ.clutz.module$exports$map_entries$Map;
 }
 declare module 'goog:map_entries.Map' {
-  import alias = ಠ_ಠ.clutz.map_entries.Map;
+  import alias = ಠ_ಠ.clutz.module$exports$map_entries$Map;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/map_entries_with_platform.js
+++ b/src/test/java/com/google/javascript/clutz/map_entries_with_platform.js
@@ -1,10 +1,12 @@
-goog.provide('map_entries.Map');
+goog.module('map_entries.Map');
 
 /** @constructor @template K, V */
-map_entries.Map = function() {};
+const Map = function() {};
 
 /**
  * Closure compiler sadly doesn't support tuples, ie. Iterator<[K,V]>.
  * @return {!IteratorIterable<!Array<K|V>>} The iterator-iterable.
  */
-map_entries.Map.prototype.entries = function() {};
+Map.prototype.entries = function() {};
+
+exports = Map;

--- a/src/test/java/com/google/javascript/clutz/map_entries_with_platform.js
+++ b/src/test/java/com/google/javascript/clutz/map_entries_with_platform.js
@@ -1,0 +1,10 @@
+goog.provide('map_entries.Map');
+
+/** @constructor @template K, V */
+map_entries.Map = function() {};
+
+/**
+ * Closure compiler sadly doesn't support tuples, ie. Iterator<[K,V]>.
+ * @return {!IteratorIterable<!Array<K|V>>} The iterator-iterable.
+ */
+map_entries.Map.prototype.entries = function() {};

--- a/src/test/java/com/google/javascript/clutz/map_entries_with_platform_user.ts
+++ b/src/test/java/com/google/javascript/clutz/map_entries_with_platform_user.ts
@@ -1,0 +1,9 @@
+import SpecialMap from 'goog:map_entries.Map';
+
+const m = new SpecialMap<string, number>();
+let sum = 0;
+let keyName: string;
+for (const [k, v] of m.entries()) {
+  keyName = k;
+  sum += v;
+}


### PR DESCRIPTION
While Closure Compiler accepts code iterating types that implement
`[Symbol.iterator]`, it does not have a mechanism to represent computed
properties such as `Symbol.iterator`, so Clutz cannot really emit the
property itself.

As a workaround, simply emit a `[Symbol.iterator]` property for all
types that extend the well-known `Iterable` class, and special case its
return value for the well-known `IteratorIterable` class (called
`IteratorIterable` in Closure).

This also requires not emitting Iterable and IteratorIterable types, and
renaming the involved interfaces, such as `IteratorResult`.