### PR TITLE
Emit implicitly forward declared types for partialInputs.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -42,6 +42,7 @@ import com.google.javascript.rhino.jstype.JSType;
 import com.google.javascript.rhino.jstype.JSTypeNative;
 import com.google.javascript.rhino.jstype.JSTypeRegistry;
 import com.google.javascript.rhino.jstype.NamedType;
+import com.google.javascript.rhino.jstype.NoResolvedType;
 import com.google.javascript.rhino.jstype.NoType;
 import com.google.javascript.rhino.jstype.ObjectType;
 import com.google.javascript.rhino.jstype.ProxyObjectType;
@@ -1594,7 +1595,23 @@ class DeclarationGenerator {
 
             @Override
             public Void caseNoType(NoType type) {
-              emit("any");
+              if (!opts.partialInput || !type.isNoResolvedType()) {
+                emit("any");
+                return null;
+              }
+              // When processing partial inputs, this case handles implicitly forward declared types
+              // for which we just emit the literal type written along with any type parameters.
+              NoResolvedType nType = (NoResolvedType) type;
+              if (nType.getReferenceName() != null) {
+                String displayName = type.getDisplayName();
+                emit(Constants.INTERNAL_NAMESPACE + "." + displayName);
+                List<JSType> templateTypes = nType.getTemplateTypes();
+                if (templateTypes != null && templateTypes.size() > 0) {
+                  emitGenericTypeArguments(type.getTemplateTypes().iterator());
+                }
+              } else {
+                emit("any");
+              }
               return null;
             }
 
@@ -1753,6 +1770,11 @@ class DeclarationGenerator {
       }
       emit(templateTypeName);
       typesUsed.add(type.getDisplayName());
+      emitGenericTypeArguments(it);
+      return null;
+    }
+
+    private void emitGenericTypeArguments(Iterator<JSType> it) {
       emit("<");
       while (it.hasNext()) {
         visitType(it.next());
@@ -1761,7 +1783,6 @@ class DeclarationGenerator {
         }
       }
       emit(">");
-      return null;
     }
 
     private void emitIndexSignature(JSType keyType, JSType returnType, boolean emitBreak) {

--- a/src/test/java/com/google/javascript/clutz/DeclarationGeneratorTests.java
+++ b/src/test/java/com/google/javascript/clutz/DeclarationGeneratorTests.java
@@ -102,6 +102,11 @@ public class DeclarationGeneratorTests {
     return filesList;
   }
 
+  public static List<File> getTestInputFilesNoPartial(FilenameFilter filter) {
+    File[] testFiles = getPackagePath().toFile().listFiles(filter);
+    return Arrays.asList(testFiles);
+  }
+
   static Path getTestInputFile(String fileName) {
     return getPackagePath().resolve(fileName);
   }

--- a/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
+++ b/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
@@ -82,7 +82,7 @@ public class DeclarationSyntaxTest {
     // This currently runs *all* test files as one test case. This gives less insight into errors,
     // but improves runtime as TypeScript only has to read its lib.d.ts once, amortizing the cost
     // across test cases.
-    List<File> inputs = DeclarationGeneratorTests.getTestInputFiles(filenameFilter);
+    List<File> inputs = DeclarationGeneratorTests.getTestInputFilesNoPartial(filenameFilter);
     List<String> goldenFilePaths = new ArrayList<>();
     for (File input : inputs) {
       goldenFilePaths.add(DeclarationGeneratorTests.getGoldenFile(input, ".d.ts").getPath());
@@ -107,7 +107,7 @@ public class DeclarationSyntaxTest {
   }
 
   private void doTestDeclarationUsage(FilenameFilter filenameFilter) throws Exception {
-    List<File> inputs = DeclarationGeneratorTests.getTestInputFiles(filenameFilter);
+    List<File> inputs = DeclarationGeneratorTests.getTestInputFilesNoPartial(filenameFilter);
     final List<String> tscCommand = Lists.newArrayList(TSC.toString(), "-m", "commonjs");
     tscCommand.addAll(TSC_FLAGS);
 

--- a/src/test/java/com/google/javascript/clutz/partial/missing_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_type.d.ts
@@ -1,5 +1,6 @@
 declare namespace ಠ_ಠ.clutz.module$exports$missing$type {
-  var x : any ;
+  var x : ಠ_ಠ.clutz.Missing ;
+  var xWithGenerics : ಠ_ಠ.clutz.goog.missing.map < string , number > ;
 }
 declare module 'goog:missing.type' {
   import alias = ಠ_ಠ.clutz.module$exports$missing$type;

--- a/src/test/java/com/google/javascript/clutz/partial/missing_type.js
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_type.js
@@ -1,6 +1,10 @@
 goog.module('missing.type');
 
 /** @const {!Missing} */
-let x = missingFunctionCall();
+const x = missingFunctionCall();
+
+/** @const {!goog.missing.map<string, number>} */
+const xWithGenerics = missingFunctionCall2();
 
 exports.x = x;
+exports.xWithGenerics = xWithGenerics;


### PR DESCRIPTION
Adds supports for generic types. For now exclude 'partial' tests from
usage and syntax tests, so that we do not need to provide all
missing types.