### PR TITLE
Emit missing types as template parameters.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/partial/missing_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_type.d.ts
@@ -1,6 +1,7 @@
 declare namespace ಠ_ಠ.clutz.module$exports$missing$type {
   var x : ಠ_ಠ.clutz.Missing ;
   var xWithGenerics : ಠ_ಠ.clutz.goog.missing.map < string , number > ;
+  var xWithMissingGenerics : ಠ_ಠ.clutz.goog.missing.map < ಠ_ಠ.clutz.mod.ref.A , ಠ_ಠ.clutz.mod.ref.B < ಠ_ಠ.clutz.mod.ref.C > > ;
 }
 declare module 'goog:missing.type' {
   import alias = ಠ_ಠ.clutz.module$exports$missing$type;

--- a/src/test/java/com/google/javascript/clutz/partial/missing_type.js
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_type.js
@@ -6,5 +6,9 @@ const x = missingFunctionCall();
 /** @const {!goog.missing.map<string, number>} */
 const xWithGenerics = missingFunctionCall2();
 
+/** @const {!goog.missing.map<!mod.ref.A, !mod.ref.B<!mod.ref.C>>} */
+const xWithMissingGenerics = missingFunctionCall3();
+
 exports.x = x;
 exports.xWithGenerics = xWithGenerics;
+exports.xWithMissingGenerics = xWithMissingGenerics;


### PR DESCRIPTION
For unknown to me reason those end up as NamedType instead of NoType,
thus they need special handling logic.