### PR TITLE
Emit a default type 'any' for all type parameters when partial input.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/partial/missing_generic.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_generic.d.ts
@@ -1,0 +1,12 @@
+declare namespace ಠ_ಠ.clutz.module$exports$missing$gen {
+  class GenericClassDefaultsTypeParamToAny < T = any > extends GenericClassDefaultsTypeParamToAny_Instance < T > {
+  }
+  class GenericClassDefaultsTypeParamToAny_Instance < T = any > {
+    private noStructuralTyping_: any;
+  }
+  var genericClassUse : ಠ_ಠ.clutz.missing.GenericClass ;
+}
+declare module 'goog:missing.gen' {
+  import alias = ಠ_ಠ.clutz.module$exports$missing$gen;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/missing_generic.js
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_generic.js
@@ -1,0 +1,18 @@
+goog.module('missing.gen');
+
+//!! When emitting with missing sources, we have to emit T = any, to
+//!! support downsteam consumers that use missing.gen.C without passing
+//!! any type parameters.
+/**
+ * @constructor
+ * @template T
+ */
+function GenericClassDefaultsTypeParamToAny(){}
+
+//!! This is here to test how is a missing generic class emitted.
+//!! Assume that missing.GenericClass has a generic param.
+/** @const {!missing.GenericClass} */
+const genericClassUse = new GenericClass();
+
+exports.GenericClassDefaultsTypeParamToAny = GenericClassDefaultsTypeParamToAny;
+exports.genericClassUse = genericClassUse;


### PR DESCRIPTION
Because closure allows generic types to be used without passing any
type arguments, incremental clutz cannot differentiate between
Foo a plain type or Foo a generic type that has implicilty '?' as
a type argument.

However, it is a syntactic mistake in TypeScript to use the generic type
without any type arguments if they do not have default values. To work
around this issue, in incremental mode, clutz will now emit '= any' for
all type parameters.