### PR TITLE
Add test cases to show incorrect behavior for destructuring closure code.

### DIFF
--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.js
@@ -7,6 +7,12 @@ const {foo} = goog.require("named.A.B");
 var namespace = goog.require("namespace.A.B");
 const D = goog.require("both.A.B.C.D");
 const {bar} = goog.require("both.A.B.C.D");
+const {foobar} = goog.require("provides");
+const {R} = goog.require('module');
+
+// Use code in JS.
+const baz = foobar.A;
+const bar = R.A;
 
 // Use imports from a namespace.
 namespace.foo();

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.js
@@ -7,12 +7,12 @@ const {foo} = goog.require("named.A.B");
 var namespace = goog.require("namespace.A.B");
 const D = goog.require("both.A.B.C.D");
 const {bar} = goog.require("both.A.B.C.D");
-const {foobar} = goog.require("provides");
 const {R} = goog.require('module');
+const {foobar} = goog.require('provides');
 
 // Use code in JS.
-const baz = foobar.A;
-const bar = R.A;
+R();
+foobar();
 
 // Use imports from a namespace.
 namespace.foo();

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.js
@@ -8,11 +8,9 @@ var namespace = goog.require("namespace.A.B");
 const D = goog.require("both.A.B.C.D");
 const {bar} = goog.require("both.A.B.C.D");
 const {R} = goog.require('module');
-const {foobar} = goog.require('provides');
 
 // Use code in JS.
 R();
-foobar();
 
 // Use imports from a namespace.
 namespace.foo();

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.ts
@@ -6,12 +6,12 @@ import * as namespace from './export_namespace';
 import {D} from './export_both';
 import * as DExports from './export_both';
 import {bar} from './export_both';
-import foobar from 'goog:provide';
-import {R} from 'goog:provide.R';
-
+import R from 'goog:module.R';
+import foobar from 'goog:provides';
 
 // Use code in JS.
-const baz = foobar.A;
+R();
+foobar();
 
 // Use imports from a namespace.
 namespace.foo();

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.ts
@@ -6,7 +6,7 @@ import * as namespace from './export_namespace';
 import {D} from './export_both';
 import * as DExports from './export_both';
 import {bar} from './export_both';
-import R from 'goog:module.R';
+import {R} from 'goog:module';
 
 // Use code in JS.
 R();

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.ts
@@ -7,11 +7,9 @@ import {D} from './export_both';
 import * as DExports from './export_both';
 import {bar} from './export_both';
 import R from 'goog:module.R';
-import foobar from 'goog:provides';
 
 // Use code in JS.
 R();
-foobar();
 
 // Use imports from a namespace.
 namespace.foo();

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/import_binding.ts
@@ -6,6 +6,12 @@ import * as namespace from './export_namespace';
 import {D} from './export_both';
 import * as DExports from './export_both';
 import {bar} from './export_both';
+import foobar from 'goog:provide';
+import {R} from 'goog:provide.R';
+
+
+// Use code in JS.
+const baz = foobar.A;
 
 // Use imports from a namespace.
 namespace.foo();

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/module_keep.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/module_keep.js
@@ -1,0 +1,4 @@
+goog.module('module');
+
+/** @enum {number} */
+exports.R = {A:0};

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/module_keep.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/module_keep.js
@@ -1,4 +1,3 @@
 goog.module('module');
 
-/** @enum {number} */
-exports.R = {A:0};
+exports.R = function() {}

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/provides_keep.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/provides_keep.js
@@ -1,4 +1,3 @@
 goog.provide('provides');
 
-/** @enum {number} *
-provides.foobar = {J:0};
+provides.foobar = function() {}

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/provides_keep.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/provides_keep.js
@@ -1,3 +1,4 @@
 goog.provide('provides');
 
+// This fails to be required at all. It adds "ERROR - Module provides.foobar does not exist."
 provides.foobar = function() {}

--- a/src/test/java/com/google/javascript/gents/multiTests/module_imports/provides_keep.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/module_imports/provides_keep.js
@@ -1,0 +1,4 @@
+goog.provide('provides');
+
+/** @enum {number} *
+provides.foobar = {J:0};


### PR DESCRIPTION
The correct behavior in the translated TS code should be:

import {R} from 'goog:module';
import {foobar} from 'goog:provides';

instead of
import R from 'goog:module.R';
import foobar from 'goog:provides';