### PR TITLE
fix NPE that occurs when a missing type is shadowed by a known namesp…

### DIFF
--- a/src/test/java/com/google/javascript/gents/multiTests/missing_shadowed_namespace/module.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/missing_shadowed_namespace/module.js
@@ -1,0 +1,6 @@
+goog.module('module.to.convert');
+
+/** @const {other.ns.deeper.ns.Type} */
+const aValue = 0;
+
+exports.aValue = aValue;

--- a/src/test/java/com/google/javascript/gents/multiTests/missing_shadowed_namespace/module.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/missing_shadowed_namespace/module.ts
@@ -1,0 +1,2 @@
+
+export const aValue: ns.deeper.ns.Type = 0;

--- a/src/test/java/com/google/javascript/gents/multiTests/missing_shadowed_namespace/other_ns_keep.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/missing_shadowed_namespace/other_ns_keep.js
@@ -1,0 +1,4 @@
+goog.provide('other.ns');
+
+/** @const */
+other.ns = {};


### PR DESCRIPTION
…ace.

In general, gents is designed to be permissive for missing types and
tries to emit them as syntactically seen. However, that requires care
further along to make sure that appearing 'null's are handled.