### PR TITLE
Make some type unions emit all constituent pieces.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -1854,7 +1854,11 @@ class DeclarationGenerator {
         String propName = it.next();
         emit(propName);
         UnionType unionType = type.getPropertyType(propName).toMaybeUnionType();
-        if (unionType != null && unionType.getAlternates().stream().anyMatch(JSType::isVoidType)) {
+        if (unionType != null
+            && unionType
+                .getAlternatesWithoutStructuralTyping()
+                .stream()
+                .anyMatch(JSType::isVoidType)) {
           emit("?");
           visitTypeDeclaration(type.getPropertyType(propName), false, true);
         } else {
@@ -1881,7 +1885,15 @@ class DeclarationGenerator {
     }
 
     private void visitUnionType(UnionType ut, boolean inOptionalPosition) {
-      Collection<JSType> alts = ut.getAlternates();
+      // We intentionally use getAlternatesWithoutStructuralTyping instead of getAlternates because
+      // the former unifies some types like Function into supertypes. The rules are murky as usual
+      // but it appears that getAlternatesWithoutStructuralTyping does less collapsing, see
+      // all_optional_type test.
+      // This is very far from perfect, because Closure still unifies some type
+      // unions.
+      // For example, if one writes <code>{a: string|undefined} | {b:string}</code>, at this point
+      // we only see <code>{a: string|undefined}</code>.
+      Collection<JSType> alts = ut.getAlternatesWithoutStructuralTyping();
 
       // When visiting an optional function argument or optional field (`foo?` syntax),
       // TypeScript will augment the provided type with an union of undefined, i.e. `foo?: T` will
@@ -2189,7 +2201,11 @@ class DeclarationGenerator {
       if (!propertyType.isFunctionType() || forcePropDeclaration) {
         UnionType unionType = propertyType.toMaybeUnionType();
         boolean isOptionalProperty = false;
-        if (unionType != null && unionType.getAlternates().stream().anyMatch(JSType::isVoidType)) {
+        if (unionType != null
+            && unionType
+                .getAlternatesWithoutStructuralTyping()
+                .stream()
+                .anyMatch(JSType::isVoidType)) {
           emit("?");
           isOptionalProperty = true;
         }
@@ -2243,11 +2259,12 @@ class DeclarationGenerator {
       }
       JSType arrayMembers = ttypes.get(0).toMaybeTemplatizedType().getTemplateTypes().get(0);
       if (!arrayMembers.isUnionType()
-          || arrayMembers.toMaybeUnionType().getAlternates().size() != 2) {
+          || arrayMembers.toMaybeUnionType().getAlternatesWithoutStructuralTyping().size() != 2) {
         return false;
       }
       emit("(): IterableIterator<[");
-      Iterator<JSType> it = arrayMembers.toMaybeUnionType().getAlternates().iterator();
+      Iterator<JSType> it =
+          arrayMembers.toMaybeUnionType().getAlternatesWithoutStructuralTyping().iterator();
       visitType(it.next());
       emit(",");
       visitType(it.next());

--- a/src/test/java/com/google/javascript/clutz/all_optional_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/all_optional_type.d.ts
@@ -1,0 +1,9 @@
+declare namespace ಠ_ಠ.clutz.module$exports$collapsed$union {
+  function fn (arg : { opt_some ? : string } | Function | null ) : void ;
+  //!! TODO(rado): It would be better if {other: string} was not omitted.
+  function fn2 (arg : { opt_some ? : string } ) : void ;
+}
+declare module 'goog:collapsed.union' {
+  import alias = ಠ_ಠ.clutz.module$exports$collapsed$union;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/all_optional_type.js
+++ b/src/test/java/com/google/javascript/clutz/all_optional_type.js
@@ -1,0 +1,11 @@
+goog.module('collapsed.union');
+
+/**
+ * @param {{opt_some: (string|undefined)} | Function} arg
+ */
+exports.fn = function(arg) {};
+
+/**
+ * @param {{opt_some: (string|undefined)} | {other: string}} arg
+ */
+exports.fn2 = function(arg) {};

--- a/src/test/java/com/google/javascript/clutz/all_optional_type_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/all_optional_type_usage.ts
@@ -1,0 +1,7 @@
+import {fn} from 'goog:collapsed.union';
+
+fn({});
+fn({opt_some: ''});
+//!! Surprisingly, this is accepted by TS even if we emit {opt_some?: string},
+//!! but that sounds more like a bug with weak types.
+fn(() => {});


### PR DESCRIPTION
Union types have two apis .getAlternates and
.getAlternatesWithoutStructuralTyping and it appears the second one
does not unify some types like 'Function'. Since, I see no downside to
using the second one, all calls are replaced for consistancy.

Describe the issue that is still present with general union types in
comments. Roughly, clutz sees types after closure has collapsed subtypes
into supertypes. Because of TypeScript features like weak types,
emitting post-collapse creates .d.ts that rejects valid code.