### PR TITLE
Make sure we're using the node_modules clang-format 

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
+++ b/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
@@ -46,7 +46,7 @@ public class TypeScriptGenerator {
    * clang-format of the file type (TS).
    */
   private static final String[] CLANG_FORMAT = {
-    "clang-format", "-assume-filename=a.ts", "-style=Google"
+    "./node_modules/.bin/clang-format", "-assume-filename=a.ts", "-style=Google"
   };
 
   static {


### PR DESCRIPTION
I have google3-trunk clang-format installed locally which formats .ts differently causing test failures.