### PR TITLE
Remove calls to reportCodeChange, which is going away soon

### DIFF
--- a/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
@@ -133,9 +133,9 @@ public final class ModuleConversionPass implements CompilerPass {
             if (nodeComments.hasComment(n)) {
               nodeComments.replaceWithComment(n, new Node(Token.EMPTY));
             } else {
+              compiler.reportChangeToEnclosingScope(n);
               n.detach();
             }
-            compiler.reportCodeChange();
           }
           break;
         case GETPROP:
@@ -333,7 +333,7 @@ public final class ModuleConversionPass implements CompilerPass {
               Node.newString(Token.NAME, localName),
               Node.newString("goog:" + requiredNamespace));
       nodeComments.replaceWithComment(n, importNode);
-      compiler.reportCodeChange();
+      compiler.reportChangeToEnclosingScope(importNode);
 
       registerLocalSymbol(n.getSourceFileName(), fullLocalName, requiredNamespace, localName);
       return;
@@ -398,8 +398,8 @@ public final class ModuleConversionPass implements CompilerPass {
       nodeComments.moveComment(n, importNode);
     }
 
+    compiler.reportChangeToEnclosingScope(n);
     n.detach();
-    compiler.reportCodeChange();
   }
 
   private void convertRequireForAlreadyConverted(
@@ -421,7 +421,7 @@ public final class ModuleConversionPass implements CompilerPass {
     Node importNode =
         new Node(Token.IMPORT, IR.empty(), importSpec, Node.newString(referencedFile));
     nodeComments.replaceWithComment(n, importNode);
-    compiler.reportCodeChange();
+    compiler.reportChangeToEnclosingScope(importNode);
   }
 
   /**
@@ -469,7 +469,7 @@ public final class ModuleConversionPass implements CompilerPass {
         parent.addChildBefore(export, next);
         exprNode.detach();
 
-        compiler.reportCodeChange();
+        compiler.reportChangeToEnclosingScope(parent);
         return;
       } else if (rhs.isName() && exportedSymbol.equals(rhs.getString())) {
         // Rewrite the export line to: <code>export {rhs}</code>.
@@ -488,8 +488,6 @@ public final class ModuleConversionPass implements CompilerPass {
       // Assume prefix has already been exported and just trim the prefix
       nameUtil.replacePrefixInName(lhs, exportedNamespace, exportedSymbol);
     }
-
-    compiler.reportCodeChange();
   }
 
   /** Saves the local name for imported symbols to be used for code rewriting later. */

--- a/src/main/java/com/google/javascript/gents/RemoveGoogScopePass.java
+++ b/src/main/java/com/google/javascript/gents/RemoveGoogScopePass.java
@@ -94,8 +94,8 @@ public final class RemoveGoogScopePass extends AbstractTopLevelCallback implemen
       nodeToMove = nextNodeToMove;
     }
 
+    compiler.reportChangeToEnclosingScope(n);
     n.detach();
-    compiler.reportCodeChange();
   }
 
   /**
@@ -145,7 +145,6 @@ public final class RemoveGoogScopePass extends AbstractTopLevelCallback implemen
       aliasToProvidedNamespace.put(lhs.getString(), rhs.getQualifiedName());
       Node next = assign.getParent().getNext();
       assign.detach();
-      compiler.reportCodeChange();
       return new RewriteStatus(next);
     }
     return stillAttached;
@@ -183,7 +182,6 @@ public final class RemoveGoogScopePass extends AbstractTopLevelCallback implemen
       String suffix = lhs.getQualifiedName().substring(alias.length());
       Node fullName = NodeUtil.newQName(compiler, providedNamespace + suffix);
       assign.replaceChild(lhs, fullName);
-      compiler.reportCodeChange();
     }
     return;
   }

--- a/src/main/java/com/google/javascript/gents/StyleFixPass.java
+++ b/src/main/java/com/google/javascript/gents/StyleFixPass.java
@@ -105,8 +105,8 @@ public final class StyleFixPass extends AbstractPostOrderCallback implements Com
           String comment = nodeComments.getComment(n);
 
           if (!params.hasChildren() && !block.hasChildren() && comment == null) {
+            compiler.reportChangeToEnclosingScope(n);
             n.detach();
-            compiler.reportCodeChange();
           }
         }
         break;

--- a/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
@@ -230,7 +230,7 @@ public final class TypeAnnotationPass implements CompilerPass {
       }
       nodeComment = nodeComment.replaceFirst("\\n?" + Pattern.quote(toRemove), "");
       nodeComments.setComment(commentNode, nodeComment);
-      compiler.reportCodeChange();
+      compiler.reportChangeToEnclosingScope(commentNode);
     }
 
     /**
@@ -253,14 +253,12 @@ public final class TypeAnnotationPass implements CompilerPass {
       if (parameterType.getRoot().getToken() == Token.ELLIPSIS) {
         attachTypeExpr = IR.rest(node.getString());
         nodeComments.replaceWithComment(node, attachTypeExpr);
-        compiler.reportCodeChange();
       }
       // Modify the AST to represent an optional parameter
       if (parameterType.getRoot().getToken() == Token.EQUALS) {
         attachTypeExpr = IR.name(node.getString());
         attachTypeExpr.putBooleanProp(Node.OPT_ES6_TYPED, true);
         nodeComments.replaceWithComment(node, attachTypeExpr);
-        compiler.reportCodeChange();
       }
       setTypeExpression(attachTypeExpr, parameterType, false);
       return true;
@@ -317,7 +315,7 @@ public final class TypeAnnotationPass implements CompilerPass {
     TypeDeclarationNode node = convert(type, isReturnType);
     if (node != null) {
       n.setDeclaredTypeExpression(node);
-      compiler.reportCodeChange();
+      compiler.reportChangeToEnclosingScope(n);
     }
   }
 


### PR DESCRIPTION
In most cases I replaced the call with a call to reportChangeToEnclosingScope. In some cases I just deleted it entirely, which seems to have been fine, since I didn't see any test failures.