### PR TITLE
Fix clutz to emit properly modules that default export a single typedef.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/module_typedef.d.ts
+++ b/src/test/java/com/google/javascript/clutz/module_typedef.d.ts
@@ -1,0 +1,7 @@
+declare namespace ಠ_ಠ.clutz {
+  type module$exports$a$module = { a : number } ;
+}
+declare module 'goog:a.module' {
+  import alias = ಠ_ಠ.clutz.module$exports$a$module;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/module_typedef.js
+++ b/src/test/java/com/google/javascript/clutz/module_typedef.js
@@ -1,0 +1,6 @@
+goog.module('a.module');
+
+/** @typedef {{a: number}} */
+let TypeDef;
+
+exports = TypeDef;

--- a/src/test/java/com/google/javascript/clutz/module_typedef_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/module_typedef_usage.ts
@@ -1,0 +1,3 @@
+import TypeDef from 'goog:a.module';
+
+const obj: TypeDef = {a: 0};


### PR DESCRIPTION
A type-only goog.module appears significantly different from one with
values, so we need a new code path for that.