### PR TITLE
Add an option to skip emit on certain suffixes.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -424,8 +424,10 @@ class DeclarationGenerator {
     out = new StringWriter();
 
     for (CompilerInput compilerInput : compiler.getInputsById().values()) {
+      String originalPath = compilerInput.getSourceFile().getOriginalPath();
+      if (opts.skipEmitSuffix != null && originalPath.endsWith(opts.skipEmitSuffix)) continue;
       transitiveProvides.addAll(compilerInput.getProvides());
-      if (depgraph.isRoot(compilerInput.getSourceFile().getOriginalPath())) {
+      if (depgraph.isRoot(originalPath)) {
         provides.addAll(compilerInput.getProvides());
         emitComment(
             String.format(

--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -79,6 +79,14 @@ public class Options {
   )
   boolean partialInput;
 
+  @Option(
+    name = "--skipEmitSuffix",
+    usage =
+        "Symbols in files that end with this suffix will not be included in the emit. Note that"
+            + "the files would still be part of the internal compilation."
+  )
+  String skipEmitSuffix = null;
+
   @Argument List<String> arguments = new ArrayList<>();
 
   Depgraph depgraph;

--- a/src/test/java/com/google/javascript/clutz/ProgramSubject.java
+++ b/src/test/java/com/google/javascript/clutz/ProgramSubject.java
@@ -83,6 +83,7 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
     }
     opts.debug = true;
     opts.emitPlatformExterns = emitPlatformExterns;
+    opts.skipEmitSuffix = ".skip.tsickle.js";
     List<SourceFile> sourceFiles = new ArrayList<>();
 
     // base.js is needed for the type declaration of goog.require for

--- a/src/test/java/com/google/javascript/clutz/tsickle_emit.skip.tsickle.d.ts
+++ b/src/test/java/com/google/javascript/clutz/tsickle_emit.skip.tsickle.d.ts
@@ -1,0 +1,1 @@
+//!! This file intentionally left blank.

--- a/src/test/java/com/google/javascript/clutz/tsickle_emit.skip.tsickle.js
+++ b/src/test/java/com/google/javascript/clutz/tsickle_emit.skip.tsickle.js
@@ -1,0 +1,7 @@
+goog.module('a.path.to.the.module');
+
+class KlosureKlass {
+
+}
+
+exports.KlosureKlass = KlosureKlass;


### PR DESCRIPTION
This is going to be used for tsickle
(https://github.com/angular/tsickle) emitted files, where we plan to
glue up the .d.ts instead of reemitting in clutz.