### PR TITLE
Add support for skipEmitSuffix in typesUsed processing.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -661,6 +661,11 @@ class DeclarationGenerator {
         // skip extern symbols (they have a separate pass).
         CompilerInput symbolInput = this.compiler.getInput(new InputId(symbol.getInputName()));
         if (symbolInput != null && symbolInput.isExtern()) continue;
+
+        // skip types that come from files that we skip emit on.
+        if (opts.skipEmitSuffix != null && symbolInput.getName().endsWith(opts.skipEmitSuffix))
+          continue;
+
         declareNamespace(
             namespace,
             symbol,

--- a/src/test/java/com/google/javascript/clutz/MultiFileTest.java
+++ b/src/test/java/com/google/javascript/clutz/MultiFileTest.java
@@ -65,6 +65,15 @@ public class MultiFileTest {
         .generatesDeclarations(expected);
   }
 
+  @Test
+  public void tsickle_emit() throws Exception {
+    String expected = DeclarationGeneratorTests.getTestFileText(input("tsickle_emit.d.ts"));
+    assertThatProgram(
+            ImmutableList.of(input("uses_tsickle_type.js")),
+            ImmutableList.of(input("tsickle_emit.skip.tsickle.js")))
+        .generatesDeclarations(expected);
+  }
+
   private File input(String filename) {
     Path testDir = FileSystems.getDefault().getPath("src", "test", "java");
     String packageName = ProgramSubject.class.getPackage().getName();

--- a/src/test/java/com/google/javascript/clutz/tsickle_emit/tsickle_emit.d.ts
+++ b/src/test/java/com/google/javascript/clutz/tsickle_emit/tsickle_emit.d.ts
@@ -1,0 +1,11 @@
+//!! Technically this is an invalid .d.ts by itself. Right now we are lucking
+//!! out that DeclarationSyntax tests do not check MultiFile tests.
+//!! TODO(rado): Add Syntax tests for MultiFile and add an extra .d.ts to match
+//!! the TypeScript compiler output .d.ts.
+declare namespace ಠ_ಠ.clutz.module$exports$uses_tsickle_emit {
+  var k : ಠ_ಠ.clutz.module$exports$tsickle$emit.KlosureKlass | null ;
+}
+declare module 'goog:uses_tsickle_emit' {
+  import alias = ಠ_ಠ.clutz.module$exports$uses_tsickle_emit;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/tsickle_emit/tsickle_emit.skip.tsickle.js
+++ b/src/test/java/com/google/javascript/clutz/tsickle_emit/tsickle_emit.skip.tsickle.js
@@ -1,0 +1,7 @@
+goog.module('tsickle.emit');
+
+class KlosureKlass {
+
+}
+
+exports.KlosureKlass = KlosureKlass;

--- a/src/test/java/com/google/javascript/clutz/tsickle_emit/uses_tsickle_type.js
+++ b/src/test/java/com/google/javascript/clutz/tsickle_emit/uses_tsickle_type.js
@@ -1,0 +1,6 @@
+goog.module('uses_tsickle_emit');
+
+const {KlosureKlass} = goog.require('tsickle.emit');
+
+/** @const {KlosureKlass} */
+exports.k = new KlosureKlass();


### PR DESCRIPTION
Previously, we make sure all types used during the emit are themselves
emitted. This guarantees that the .d.ts is self contained.

To fully support skipEmitSuffix, the typeUsed processing should also
take care of not emitting types from files that end with the
skipEmitSuffix.