### PR TITLE
refactors import conversion pass

### DIFF
--- a/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
@@ -142,34 +142,34 @@ public final class ModuleConversionPass implements CompilerPass {
           }
           break;
         case GETPROP:
-        {
-          JSDocInfo jsdoc = NodeUtil.getBestJSDocInfo(child);
-          if (jsdoc == null || !jsdoc.containsTypeDefinition()) {
-            // GETPROPs on the root level are only exports for @typedefs
+          {
+            JSDocInfo jsdoc = NodeUtil.getBestJSDocInfo(child);
+            if (jsdoc == null || !jsdoc.containsTypeDefinition()) {
+              // GETPROPs on the root level are only exports for @typedefs
+              break;
+            }
+            if (!fileToModule.containsKey(fileName)) {
+              break;
+            }
+            FileModule module = fileToModule.get(fileName);
+            Map<String, String> symbols = module.exportedNamespacesToSymbols;
+            String exportedNamespace = nameUtil.findLongestNamePrefix(child, symbols.keySet());
+            if (exportedNamespace != null) {
+              String localName = symbols.get(exportedNamespace);
+              Node export =
+                  new Node(
+                      Token.EXPORT,
+                      new Node(
+                          Token.EXPORT_SPECS,
+                          new Node(Token.EXPORT_SPEC, Node.newString(Token.NAME, localName))));
+              export.useSourceInfoFromForTree(child);
+              parent.addChildAfter(export, n);
+              // Registers symbol for rewriting local uses.
+              registerLocalSymbol(
+                  child.getSourceFileName(), exportedNamespace, exportedNamespace, localName);
+            }
             break;
           }
-          if (!fileToModule.containsKey(fileName)) {
-            break;
-          }
-          FileModule module = fileToModule.get(fileName);
-          Map<String, String> symbols = module.exportedNamespacesToSymbols;
-          String exportedNamespace = nameUtil.findLongestNamePrefix(child, symbols.keySet());
-          if (exportedNamespace != null) {
-            String localName = symbols.get(exportedNamespace);
-            Node export =
-                new Node(
-                    Token.EXPORT,
-                    new Node(
-                        Token.EXPORT_SPECS,
-                        new Node(Token.EXPORT_SPEC, Node.newString(Token.NAME, localName))));
-            export.useSourceInfoFromForTree(child);
-            parent.addChildAfter(export, n);
-            // Registers symbol for rewriting local uses.
-            registerLocalSymbol(
-                child.getSourceFileName(), exportedNamespace, exportedNamespace, localName);
-          }
-          break;
-        }
         case ASSIGN:
           if (!fileToModule.containsKey(fileName)) {
             break;


### PR DESCRIPTION
The original `convertRequireToImportStatements()` function contains a big Cartesian product:
{`goog.require()`, `var x = goog.require()`, `var {x} = goog.require()`} × { `import x from 'goog:';`, `import {x} from './foo';`, `import * as x from './foo';`, `import './sideEffects';`} × {imported file kept in JS, imported file already in TS, imported file has side effect}
There are some hacks so all these conditions are handled in one function. For example `requiredNamespace` is appended with the local name in some cases and the suffix is stripped later.

This refactoring tries to split the destructuring case out. It also makes the variables really reflect what they contain. For example, `requiredNamespace` will be always the required namespace or module with no local names appended, making future code reading and bug fixes a little easier.