### PR TITLE
Upgrade to closure v20171023

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
   if (System.getenv().get('CI_MODE') == 'Nightly') {
     compile 'com.google.javascript:closure-compiler:1.0-SNAPSHOT'
   } else {
-    compile 'com.google.javascript:closure-compiler:v20170910'
+    compile 'com.google.javascript:closure-compiler:v20171023'
   }
 
   compile 'com.google.code.findbugs:jsr305:3.0.1'


### PR DESCRIPTION
Files without goog.module or goog.provide, appear to report a new
synthetic provide 'module$src$...', which we now filter out in clutz.