### PR TITLE
Update Error Prone Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
   id 'com.github.sherter.google-java-format' version '0.6'
 
   // enforces java style
-  id 'net.ltgt.errorprone' version '0.0.9'
+  id 'net.ltgt.errorprone' version '0.0.11'
 }
 
 def createScript(project, mainClass, name) {


### PR DESCRIPTION
This PR updates the version of the Error Prone Gradle plugin used to `0.0.11` to expand the range of Gradle versions that can be used to build clutz. The current version, `0.0.9`, doesn't support Gradle versions above 3.4 as per [the table in the project's docs][1]:

> Gradle error-prone plugin version | Supported Gradle versions | Supported error-prone version | Supported javac version
> --------------------------------- | ------------------------- | ----------------------------- | -----------------------
> 0.0.1, 0.0.2                      | 1.8 - 1.11                | 1.+                           | 7
> 0.0.3                             | 1.8 - 1.12                | 1.+                           | 7
> 0.0.4                             | 2.1                       | 1.+                           | 7
> 0.0.5                             | 2.2 - 2.3                 | 1.+                           | 7
> 0.0.6                             | 2.2 - 2.3                 | 1.+¹, 2.+                     | 7, 8
> 0.0.7, 0.0.7.1                    | 2.4 - 2.5                 | 1.+¹, 2.+                     | 7, 8
> 0.0.8                             | 2.6 - 3.4                 | 1.+¹, 2.+                     | 7, 8
> 0.0.9                             | 2.6 - 3.4                 | 1.+¹, 2.+                     | 7, 8
> 0.0.10                            | 2.6 - 4.3                 | 1.+¹, 2.+                     | 7, 8
> 0.0.11                            | 2.6 - 4.3                 | 1.+¹, 2.+                     | 7, 8
> 0.0.12                            | 2.6 - 4.3                 | 2.+                           | 8
> 0.0.13                            | 2.6 - 4.3                 | 2.+                           | 8, 9
> _master_                          | 2.6 - 4.3                 | 2.+                           | 8, 9

I've updated it to `0.0.11` as that's the latest version that supports both Java 7 and 8.

  [1]:https://github.com/tbroyer/gradle-errorprone-plugin/tree/22c3bc4b5cc10edd2fb2cb669f3fea0ca6b86d1b