### PR TITLE
Remove StringArrayOptionHandler from depgraphs and externs options

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -29,16 +29,14 @@ public class Options {
   @Option(
     name = "--externs",
     usage = "list of files to read externs definitions (as separate args)",
-    metaVar = "EXTERN...",
-    handler = StringArrayOptionHandler.class
+    metaVar = "EXTERN..."
   )
   List<String> externs = new ArrayList<>();
 
   @Option(
     name = "--depgraphs",
     usage = "only generate output for files listed as a root in the given depgraphs",
-    metaVar = "file.depgraph...",
-    handler = StringArrayOptionHandler.class
+    metaVar = "file.depgraph..."
   )
   List<String> depgraphFiles = new ArrayList<>();
 

--- a/src/test/java/com/google/javascript/clutz/OptionsTest.java
+++ b/src/test/java/com/google/javascript/clutz/OptionsTest.java
@@ -114,4 +114,10 @@ public class OptionsTest {
             });
     assertThat(opts.externs).containsExactly("javascript/common/dom.js");
   }
+
+  @Test
+  public void testShouldAllowFileNameWithSpaces() throws Exception {
+    Options opts = new Options(new String[] {"--externs", "extern 1.js"});
+    assertThat(opts.externs).containsExactly("extern 1.js");
+  }
 }

--- a/src/test/java/com/google/javascript/clutz/OptionsTest.java
+++ b/src/test/java/com/google/javascript/clutz/OptionsTest.java
@@ -14,7 +14,9 @@ public class OptionsTest {
   public void testFullUsage() throws Exception {
     Options opts =
         new Options(
-            new String[] {"foo.js", "--externs", "extern1.js", "extern2.js", "-o", "output.d.ts"});
+            new String[] {
+              "foo.js", "--externs", "extern1.js", "--externs", "extern2.js", "-o", "output.d.ts"
+            });
     assertThat(opts.arguments).containsExactly("foo.js");
     assertThat(opts.externs).containsExactly("extern1.js", "extern2.js").inOrder();
     assertThat(opts.output).isEqualTo("output.d.ts");
@@ -30,6 +32,7 @@ public class OptionsTest {
               "blaze-out/blah/my/blaze-out-file.js",
               "--externs",
               "extern1.js",
+              "--externs",
               "extern2.js",
               "--depgraphs",
               DepgraphTest.DEPGRAPH_PATH.toFile().toString(),
@@ -59,6 +62,7 @@ public class OptionsTest {
               "ns.entryPoint2",
               "--externs",
               "extern1.js",
+              "--externs",
               "extern2.js",
               "-o",
               "output.d.ts"
@@ -90,7 +94,10 @@ public class OptionsTest {
   @Test
   public void testShouldPruneRepeatedExterns() throws Exception {
     Options opts =
-        new Options(new String[] {"a.js", "extern1.js", "--externs", "extern1.js", "extern2.js"});
+        new Options(
+            new String[] {
+              "a.js", "extern1.js", "--externs", "extern1.js", "--externs", "extern2.js"
+            });
     assertThat(opts.externs).containsExactly("extern1.js", "extern2.js");
     assertThat(opts.arguments).containsExactly("a.js");
   }


### PR DESCRIPTION
This change removes `StringArrayOptionHandler` from the depgraphs and externs options (`--depsgraphs` and `--externs`) as they cause file names with spaces to be incorrectly split on the spaces.

As per conventional shell quoting, passing `--externs 'foo bar.js'` should result in `["foo bar.js"]` but with the handler attached it would result in `["foo", "bar.js"]`. This behaviour is the expected behaviour according to [the source for `StringArrayOptionHandler` in args4j](https://git.io/vF92d) that contains a comment with the following:

>     java -jar aaa.jar -s banan hruska jablko
>     java -jar aaa.jar -s banan "hruska jablko"
>     java -jar aaa.jar -s "banan hruska jablko"
>     java -jar aaa.jar -s banan hruska jablko -l 4 -r
>     java -jar aaa.jar -t 222 -s banan hruska jablko -r
>
> All of them result in a single string array that contains three tokens:
> `banan`, `hruska`, and `jablko`.

I don't think this handler is appropriate for options representing file names.