### PR TITLE
Replace args4j StringArrayOptionHandler to handle quoted params

### DIFF
--- a/src/test/java/com/google/javascript/clutz/OptionsTest.java
+++ b/src/test/java/com/google/javascript/clutz/OptionsTest.java
@@ -107,4 +107,15 @@ public class OptionsTest {
             });
     assertThat(opts.externs).containsExactly("javascript/common/dom.js");
   }
+
+  @Test
+  public void testShouldSupportFilePathsWithSpaces() throws Exception {
+    Options opts =
+        new Options(
+            new String[] {
+              "--externs", "dir with spaces/common/dom.js", "--externs", "common/browser api.js",
+            });
+    assertThat(opts.externs)
+        .containsExactly("dir with spaces/common/dom.js", "common/browser api.js");
+  }
 }


### PR DESCRIPTION
This PR fixes the handling of quoted command line arguments by replacing the args4j string array option handler with one that does not split params on their whitespace.

As an example, running the following should respect the conventional shell quoting:

```bash
clutz a.js b.js c.js \
    --externs foo.js bar.js 'baz qux.js' \
    -o out.d.ts
```

And should read `baz qux.js` as a file name with a space in it.

The `StringArrayOptionHandler` included in args4j incorrectly split `baz qux.js` into two tokens.