### PR TITLE
Resolve Module Bindings

### DIFF
--- a/src/main/java/com/google/javascript/clutz/ImportRenameMapBuilder.java
+++ b/src/main/java/com/google/javascript/clutz/ImportRenameMapBuilder.java
@@ -1,0 +1,161 @@
+package com.google.javascript.clutz;
+
+import com.google.javascript.rhino.Node;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * If Clutz is running in incremental mode, closure can't resolve imported symbols, so it gives them
+ * names in the current namespace (ie `module$contents$current$file`), instead of names that
+ * reference the original namespace (ie `module$exports$imported$file`). ImportRenameMapBuilder
+ * builds a map from the local name to the exported name so the original names can be substituted.
+ */
+public class ImportRenameMapBuilder {
+
+  /**
+   * Build takes a collection of source files, parses them with the compiler, and walks the ast to
+   * find any `const variable = goog.require()` statements to build a map from the name closure
+   * generates in incremental mode to the exported name of the import.
+   */
+  public static Map<String, String> build(Collection<Node> parsedInputs) {
+    Map<String, String> importRenameMap = new HashMap<>();
+    for (Node ast : parsedInputs) {
+      String moduleId = getGoogModuleId(ast);
+      // Closure can only put the symbol name into the current module's namespace, if the source
+      // file is a module, so if it isn't a module, just bail
+      if (moduleId != null) {
+        importRenameMap.putAll(build(moduleId, ast));
+      }
+    }
+    return importRenameMap;
+  }
+
+  private static boolean isGoogModuleCall(Node statement) {
+    if (!statement.isExprResult()) {
+      return false;
+    }
+
+    Node expression = statement.getFirstChild();
+    return expression.isCall() && expression.getFirstChild().matchesQualifiedName("goog.module");
+  }
+
+  private static boolean isGoogRequireAssignment(Node statement) {
+    if (!(statement.isConst() || statement.isVar() || statement.isLet())) {
+      return false;
+    }
+
+    Node rightHandSide = statement.getFirstFirstChild();
+
+    return rightHandSide != null
+        && rightHandSide.isCall()
+        && rightHandSide.getFirstChild().matchesQualifiedName("goog.require");
+  }
+
+  private static boolean isGoogRequireDestructuringAssignment(Node statement) {
+    if (!(statement.isConst() || statement.isVar() || statement.isLet())) {
+      return false;
+    }
+
+    if (!statement.getFirstChild().isDestructuringLhs()) {
+      return false;
+    }
+
+    Node destructuringAssignment = statement.getFirstChild();
+
+    Node rightHandSide = destructuringAssignment.getChildAtIndex(1);
+
+    return rightHandSide.isCall()
+        && rightHandSide.getFirstChild().matchesQualifiedName("goog.require");
+  }
+
+  private static String getGoogModuleId(Node astRoot) {
+    if (astRoot.getFirstChild() == null || !astRoot.getFirstChild().isModuleBody()) {
+      return null;
+    }
+
+    Node moduleBody = astRoot.getFirstChild();
+    for (Node statement : moduleBody.children()) {
+      if (isGoogModuleCall(statement)) {
+        return statement.getFirstChild().getChildAtIndex(1).getString();
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Build does the actual work of walking over the AST, finding any goog.require() assignments or
+   * destructuring assignments, parsing them, and generating the mappings from local symbol names to
+   * exported symbol names.
+   */
+  private static Map<String, String> build(String localModuleId, Node astRoot) {
+    Map<String, String> importRenameMap = new HashMap<>();
+    if (astRoot.getFirstChild() == null || !astRoot.getFirstChild().isModuleBody()) {
+      return importRenameMap;
+    }
+
+    Node moduleBody = astRoot.getFirstChild();
+    for (Node statement : moduleBody.children()) {
+      if (isGoogRequireAssignment(statement)) {
+        // `const C = goog.require()`
+        String importedModuleId = statement.getFirstFirstChild().getChildAtIndex(1).getString();
+        String variableName = statement.getFirstChild().getString();
+
+        String localSymbolName = buildLocalSymbolName(localModuleId, variableName);
+        String exportedSymbolName = buildWholeModuleExportSymbolName(importedModuleId);
+        importRenameMap.put(localSymbolName, exportedSymbolName);
+      } else if (isGoogRequireDestructuringAssignment(statement)) {
+        // `const {C, Clazz: RenamedClazz} = goog.require()`
+        String importedModuleId =
+            statement.getFirstChild().getChildAtIndex(1).getChildAtIndex(1).getString();
+        for (Node destructured : statement.getFirstFirstChild().children()) {
+          String originalName = destructured.getString();
+          // Destructuring can use the original name `const {A} = goog.require("foo.a")` or rename
+          // it `const {A: RenamedA} = ...`, and closure uses whichever in the symbol name it
+          // generates, so we have to extract it.
+          String variableName;
+          if (destructured.getFirstChild() != null) {
+            variableName = destructured.getFirstChild().getString();
+          } else {
+            variableName = originalName;
+          }
+
+          String localSymbolName = buildLocalSymbolName(localModuleId, variableName);
+          String exportedSymbolName = buildNamedExportSymbolName(importedModuleId, originalName);
+          importRenameMap.put(localSymbolName, exportedSymbolName);
+        }
+      }
+    }
+
+    return importRenameMap;
+  }
+
+  /**
+   * The exported symbol can take 2 forms - one where it refers to everything that the module
+   * exports and another where it refers to just one thing the module exports. If the original
+   * module used the `exports = ...` style, the symbol name is just the module name.
+   *
+   * <p>TODO(lucassloan): this only holds for importing from a goog.module see:
+   * https://github.com/angular/clutz/issues/596
+   */
+  private static String buildWholeModuleExportSymbolName(String importedModuleId) {
+    return "module$exports$" + importedModuleId.replace(".", "$");
+  }
+
+  /**
+   * The exported symbol can take 2 forms - one where it refers to everything that the module
+   * exports and another where it refers to just one thing the module exports. If the original
+   * module used the `exports.foo = ...` style, the symbol name is the module name plus the
+   * individual export's name.
+   *
+   * <p>TODO(lucassloan): this only holds for importing from a goog.module see:
+   * https://github.com/angular/clutz/issues/596
+   */
+  private static String buildNamedExportSymbolName(String importedModuleId, String originalName) {
+    return "module$exports$" + importedModuleId.replace(".", "$") + "_" + originalName;
+  }
+
+  private static String buildLocalSymbolName(String importingModuleId, String variableName) {
+    return "module$contents$" + importingModuleId.replace(".", "$") + "_" + variableName;
+  }
+}

--- a/src/main/java/com/google/javascript/clutz/InitialParseRetainingCompiler.java
+++ b/src/main/java/com/google/javascript/clutz/InitialParseRetainingCompiler.java
@@ -1,0 +1,66 @@
+package com.google.javascript.clutz;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.javascript.jscomp.Compiler;
+import com.google.javascript.jscomp.CompilerInput;
+import com.google.javascript.jscomp.CompilerOptions;
+import com.google.javascript.jscomp.Result;
+import com.google.javascript.jscomp.SourceFile;
+import com.google.javascript.rhino.Node;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * InitialParseRetainingCompiler clones a copy of the AST of the inputs before any of the compiler
+ * passes are run. The original AST is required by ImportRenameMapBuilder.
+ */
+public class InitialParseRetainingCompiler extends Compiler {
+  private List<Node> parsedInputs = new ArrayList<>();
+
+  /**
+   * Copied verbatim from com.google.javascript.jscomp.Compiler, except using getter methods instead
+   * of private fields and running cloneParsedInputs() at the appropriate time.
+   */
+  public <T1 extends SourceFile, T2 extends SourceFile> Result compile(
+      List<T1> externs, List<T2> inputs, CompilerOptions options) {
+    // The compile method should only be called once.
+    checkState(getRoot() == null);
+
+    try {
+      init(externs, inputs, options);
+      if (!hasErrors()) {
+        parseForCompilation();
+        cloneParsedInputs();
+      }
+      if (!hasErrors()) {
+        if (options.getInstrumentForCoverageOnly()) {
+          // TODO(bradfordcsmith): The option to instrument for coverage only should belong to the
+          //     runner, not the compiler.
+          instrumentForCoverage();
+        } else {
+          stage1Passes();
+          if (!hasErrors()) {
+            stage2Passes();
+          }
+        }
+        performPostCompilationTasks();
+      }
+    } finally {
+      generateReport();
+    }
+    return getResult();
+  }
+
+  /** Loop over all the inputs and clone their ASTs into this.parsedInputs. */
+  private void cloneParsedInputs() {
+    for (CompilerInput ci : getInputsById().values()) {
+      Node n = ci.getAstRoot(this);
+      parsedInputs.add(n.cloneTree());
+    }
+  }
+
+  public List<Node> getParsedInputs() {
+    return parsedInputs;
+  }
+}

--- a/src/test/java/com/google/javascript/clutz/partial/missing_base.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_base.d.ts
@@ -1,4 +1,4 @@
-declare namespace ಠ_ಠ.clutz.module$exports$mising$extend {
+declare namespace ಠ_ಠ.clutz.module$exports$missing$extend {
   class B extends B_Instance {
   }
   class B_Instance extends ಠ_ಠ.clutz.direct.ref.A {
@@ -7,14 +7,22 @@ declare namespace ಠ_ಠ.clutz.module$exports$mising$extend {
   }
   class BTemplated_Instance extends ಠ_ಠ.clutz.direct.ref.ATemplated < string , number > {
   }
-  class D extends D_Instance {
+  class ClassExtendingMissingDestructuredRequire extends ClassExtendingMissingDestructuredRequire_Instance {
   }
-  //!! This emit is wrong and will be fixed with
-  //!! https://github.com/angular/clutz/issues/551.
-  class D_Instance extends ಠ_ಠ.clutz.module$contents$mising$extend_C {
+  class ClassExtendingMissingDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$missing$base_MissingDestructuredRequire {
   }
+  class ClassExtendingMissingRequire extends ClassExtendingMissingRequire_Instance {
+  }
+  class ClassExtendingMissingRequire_Instance extends ಠ_ಠ.clutz.module$exports$missing$base {
+  }
+  class ClassExtendingRenamedDestructuredRequire extends ClassExtendingRenamedDestructuredRequire_Instance {
+  }
+  class ClassExtendingRenamedDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$missing$base_OriginalName {
+  }
+  var DeclarationOfMissingRequire : ಠ_ಠ.clutz.module$exports$missing$base | null ;
+  function FuncWithMissingRequireParam (c : ಠ_ಠ.clutz.module$exports$missing$base | null ) : void ;
 }
-declare module 'goog:mising.extend' {
-  import alias = ಠ_ಠ.clutz.module$exports$mising$extend;
+declare module 'goog:missing.extend' {
+  import alias = ಠ_ಠ.clutz.module$exports$missing$extend;
   export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/partial/missing_base.js
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_base.js
@@ -1,4 +1,4 @@
-goog.module('mising.extend');
+goog.module('missing.extend');
 
 //!! Using class syntax requires default externs but the test runs faster
 //!! without them. Just use @constructor instead.
@@ -15,19 +15,51 @@ function B() {
  * @constructor
  * @extends {direct.ref.ATemplated<string, number>}
  */
-  function BTemplated() {
+function BTemplated() {
 
 }
 
-const C = goog.require('missing.base');
+const MissingGoogRequire = goog.require('missing.base');
 /**
  * @constructor
- * @extends {C}
+ * @extends {MissingGoogRequire}
  */
-function D() {
+function ClassExtendingMissingRequire() {
+
+}
+
+/**
+ * @param {MissingGoogRequire} c
+ */
+function FuncWithMissingRequireParam(c) {
+
+}
+
+/** @type {MissingGoogRequire} */
+const DeclarationOfMissingRequire = null;
+
+const {MissingDestructuredRequire, OriginalName: RenamedDestructuredRequire} = goog.require('missing.base');
+
+/**
+ * @constructor
+ * @extends {MissingDestructuredRequire}
+ */
+function ClassExtendingMissingDestructuredRequire() {
+
+}
+
+/**
+ * @constructor
+ * @extends {RenamedDestructuredRequire}
+ */
+function ClassExtendingRenamedDestructuredRequire() {
 
 }
 
 exports.B = B;
 exports.BTemplated = BTemplated;
-exports.D = D;
+exports.ClassExtendingMissingRequire = ClassExtendingMissingRequire;
+exports.FuncWithMissingRequireParam = FuncWithMissingRequireParam;
+exports.DeclarationOfMissingRequire = DeclarationOfMissingRequire;
+exports.ClassExtendingMissingDestructuredRequire = ClassExtendingMissingDestructuredRequire;
+exports.ClassExtendingRenamedDestructuredRequire = ClassExtendingRenamedDestructuredRequire;


### PR DESCRIPTION
When parsing partial inputs, closure doesn't know the proper name of an imported symbol, so it emits it as part of the current module.

This PR walks the closure ast to grab the module id of the current file as well as the id of the import to construct a map of unresolved symbol names to resolved symbol names, and uses it to replace unresolved names when emitting NoResolvedType nodes.

Fixes #551