### PR TITLE
mark partial overridden function parameters as optional

### DIFF
--- a/src/test/java/com/google/javascript/clutz/partial/override.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/override.d.ts
@@ -1,0 +1,51 @@
+declare namespace ಠ_ಠ.clutz.module$exports$override {
+  class ExtendsBase extends ExtendsBase_Instance {
+  }
+  class ExtendsBase_Instance extends module$contents$override_Base_Instance {
+    /**
+     * This function has no type information, but its base class is visible, so it should inherit
+     * the types from the base.
+     */
+    method (x : number ) : void ;
+  }
+  class ExtendsInvisible extends ExtendsInvisible_Instance {
+  }
+  class ExtendsInvisible_Instance extends module$exports$override.Invisible {
+    constructor ( ) ;
+    /**
+     * This function has no known type, so its parameter should be optional.
+     */
+    inferredOverride (x ? : any ) : void ;
+    /**
+     * Ordinary function, for comparison with the others.
+     */
+    nonOverride (x : number ) : void ;
+    /**
+     * This function uses @override, but it includes type information, so that type should persist.
+     */
+    overrideWithType (x : number ) : number ;
+  }
+  interface Template < T = any > {
+    /**
+     * The type of T in the callback should not be marked optional.
+     */
+    callbackWithTemplateArg < R = any > (f : (a : T ) => R ) : void ;
+    /**
+     * Note: we currently get this wrong, in that we mark the callback param as optional.
+     * We can fix later if it matters.
+     */
+    callbackWithUnknownArg < R = any > (f : (a ? : any ) => R ) : void ;
+  }
+}
+declare module 'goog:override' {
+  import alias = ಠ_ಠ.clutz.module$exports$override;
+  export = alias;
+}
+declare namespace ಠ_ಠ.clutz {
+  class module$contents$override_Base extends module$contents$override_Base_Instance {
+  }
+  class module$contents$override_Base_Instance {
+    private noStructuralTyping_: any;
+    method (x : number ) : void ;
+  }
+}

--- a/src/test/java/com/google/javascript/clutz/partial/override.js
+++ b/src/test/java/com/google/javascript/clutz/partial/override.js
@@ -1,0 +1,78 @@
+goog.module('override');
+
+/**
+ * @constructor
+ * @extends {override.Invisible}
+ */
+function ExtendsInvisible() {
+}
+
+/**
+ * Ordinary function, for comparison with the others.
+ * @param {number} x
+ */
+ExtendsInvisible.prototype.nonOverride = function(x) {};
+
+/**
+ * This function has no known type, so its parameter should be optional.
+ * @override
+ */
+ExtendsInvisible.prototype.inferredOverride = function(x) {
+  x = 3;
+};
+
+/**
+ * This function uses @override, but it includes type information, so that type should persist.
+ * @param {number} x
+ * @return {number}
+ * @override
+ */
+ExtendsInvisible.prototype.overrideWithType = function(x) { return 3; };
+
+/**
+ * @constructor
+ */
+function Base() {}
+
+/**
+ * @param {number} x
+ */
+Base.prototype.method = function(x) {}
+
+/**
+ * @constructor
+ * @extends {Base}
+ */
+function ExtendsBase() {}
+
+/**
+ * This function has no type information, but its base class is visible, so it should inherit
+ * the types from the base.
+ * @override
+ */
+ExtendsBase.prototype.method = function(x) {}
+
+/**
+ * @interface
+ * @template T
+ */
+function Template() {}
+
+/**
+ * The type of T in the callback should not be marked optional.
+ * @param {function(T): R} f
+ * @template R
+ */
+Template.prototype.callbackWithTemplateArg = function(f) {}
+
+/**
+ * Note: we currently get this wrong, in that we mark the callback param as optional.
+ * We can fix later if it matters.
+ * @param {function(?): R} f
+ * @template R
+ */
+Template.prototype.callbackWithUnknownArg = function(f) {}
+
+exports.ExtendsInvisible = ExtendsInvisible;
+exports.ExtendsBase = ExtendsBase;
+exports.Template = Template;


### PR DESCRIPTION
When a method @override's a superclass method, and we can't see the
superclass due to partial mode, we can't know whether the parameters
are optional or not.  Try to detect when this happens (when all the
parameters are type {?}) and defensively mark them all as optional.

This change is walking a fine line between multiple competing concerns.
For example, we don't want to rely on specifically @override because
of @inheritDoc, and we also want to do the right thing when the
superclass is visible.  See the test case for some examples.