### PR TITLE
Add Date to the set of Global symbols.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -227,9 +227,27 @@ class DeclarationGenerator {
    * </pre>
    *
    * by replacing the second Error with GlobalError.
+   *
+   * <p>Closure has internal "externs" for some global symbols:
+   * https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/rhino/jstype/JSTypeRegistry.java
+   * Which will be emitted in each file that references them in partial mode. For example, using
+   * Date in a file results in:
+   *
+   * <pre>
+   * declare namespace ಠ_ಠ.clutz {
+   *   class Date extends Date_Instance {
+   *   }
+   *   class Date_Instance {
+   *     private noStructuralTyping_: any;
+   *     constructor (a ? : any , b ? : any , c ? : any , d ? : any , e ? : any , f ? : any , g ? : any ) ;
+   *   }
+   * }
+   * </pre>
+   *
+   * Adding a symbol to this list also suppresses the duplicate externs.
    */
   private static final ImmutableSet<String> GLOBAL_SYMBOL_ALIASES =
-      ImmutableSet.of("Error", "Event", "EventTarget", "Object");
+      ImmutableSet.of("Error", "Event", "EventTarget", "Object", "Date");
 
   private static final String MODULE_PREFIX = "module$exports$";
 

--- a/src/resources/closure.lib.d.ts
+++ b/src/resources/closure.lib.d.ts
@@ -10,6 +10,8 @@ declare namespace ಠ_ಠ.clutz {
   var GlobalEventTarget: typeof EventTarget;
   var GlobalObject: typeof Object;
   type GlobalObject = Object;
+  var GlobalDate: typeof Date;
+  type GlobalDate = Date;
 
   /** Represents the type returned when goog.require-ing an unknown symbol */
   type ClosureSymbolNotGoogProvided = void;

--- a/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
@@ -183,7 +183,7 @@ declare namespace ಠ_ಠ.clutz {
   }
   class Metadata_Instance {
     private noStructuralTyping_: any;
-    modificationTime : Date ;
+    modificationTime : GlobalDate ;
     size : number ;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/partial/date_like.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/date_like.d.ts
@@ -1,0 +1,7 @@
+declare namespace ಠ_ಠ.clutz.module$exports$date$like {
+  var D : GlobalDate | null | ಠ_ಠ.clutz.goog.date.Date ;
+}
+declare module 'goog:date.like' {
+  import alias = ಠ_ಠ.clutz.module$exports$date$like;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/date_like.js
+++ b/src/test/java/com/google/javascript/clutz/partial/date_like.js
@@ -1,0 +1,14 @@
+goog.module('date.like')
+//!! This test is match a real issue with goog.date.DateLike and the underlying
+//!! issue would still appear if this were a proper goog.require().
+goog.forwardDeclare('goog.date.Date');
+
+/**
+ * @typedef {(Date|goog.date.Date)}
+ */
+goog.date.DateLike;
+
+/** @type {goog.date.DateLike} */
+const D = null;
+
+exports.D = D;


### PR DESCRIPTION
Added a test to repro issue with DateLike declaration.  Fixed by introducing the indirection of GlobalDate by adding Date to the list of Global symbols, and adding GlobalDate to closure.lib.d.ts.

Fixes #602