### PR TITLE
hack around missing base class in partial mode for goog.deferred.Async

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -2446,7 +2446,23 @@ class DeclarationGenerator {
           break;
         }
       }
-      if (!hasTTE) return false;
+
+      // Horrible hack.  goog.async.Deferred has an @override of a TTE function, but when running
+      // in partialInput mode we can't see that.  Identify it by grabbing:
+      // 1) functions named .then()
+      // 2) that use @override
+      // 3) that have no declared parameters/return type.
+      boolean horribleHackForPartialModeWithOverrides = false;
+      JSDocInfo info = type.getJSDocInfo();
+      if (info != null) {
+        boolean isUntypedOverride =
+            info.isOverride() && info.getParameterCount() == 0 && info.getReturnType() == null;
+        if (opts.partialInput && isUntypedOverride && propName.equals("then")) {
+          horribleHackForPartialModeWithOverrides = true;
+        }
+      }
+
+      if (!horribleHackForPartialModeWithOverrides && !hasTTE) return false;
 
       // The same signature can be found in a number of classes - es6 Promise, angular.$q.Promise,
       // custom Thenable classes, etc. While the class names differ the implementations are close

--- a/src/test/java/com/google/javascript/clutz/partial/tte_promise_partial.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/tte_promise_partial.d.ts
@@ -1,0 +1,11 @@
+declare namespace ಠ_ಠ.clutz.module$exports$tte$Promise$Partial {
+  class PartialDeferred < VALUE = any > extends PartialDeferred_Instance < VALUE > {
+  }
+  class PartialDeferred_Instance < VALUE = any > extends ಠ_ಠ.clutz.Base < VALUE > {
+    then < RESULT > (opt_onFulfilled ? : ( (a : VALUE ) => PartialDeferred < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : PartialDeferred < RESULT > ;
+  }
+}
+declare module 'goog:tte.Promise.Partial' {
+  import alias = ಠ_ಠ.clutz.module$exports$tte$Promise$Partial;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/tte_promise_partial.js
+++ b/src/test/java/com/google/javascript/clutz/partial/tte_promise_partial.js
@@ -1,0 +1,14 @@
+goog.module('tte.Promise.Partial');
+
+/**
+ * @constructor
+ * @extends {Base<VALUE>}
+ * @template VALUE
+ */
+function PartialDeferred() {}
+
+// See horribleAsyncHack in DeclarationGenerator.
+/** @override */
+PartialDeferred.prototype.then = function() {}
+
+exports.PartialDeferred = PartialDeferred;


### PR DESCRIPTION
This class @extends Thenable, which means it should inherit a TTE type for
its .then() implementation.  But in partial mode, we don't see the base
class so we can't see that type.

We considered making it just infer to some broad any-based type, but in
in this particular case (the implementation of .then), if you lose the
TTE types then you have to manually annotate all the parameters to your
callback, so we deemed it ok to have a specific hack to see how common
this problem is.