### PR TITLE
Don't emit ಠ_ಠ.clutz for missing symbols.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -1682,7 +1682,7 @@ class DeclarationGenerator {
       if (importRenameMap.containsKey(displayName)) {
         displayName = importRenameMap.get(displayName);
       }
-      emit(Constants.INTERNAL_NAMESPACE + "." + displayName);
+      emit(displayName);
       List<JSType> templateTypes = nType.getTemplateTypes();
       if (templateTypes != null && templateTypes.size() > 0) {
         emitGenericTypeArguments(type.getTemplateTypes().iterator());
@@ -1775,7 +1775,7 @@ class DeclarationGenerator {
               // unit - A ends up as NoType, while B ends up as NamedType.
               if (opts.partialInput && refType.isUnknownType()) {
                 String displayName = type.getDisplayName();
-                emit(Constants.INTERNAL_NAMESPACE + "." + displayName);
+                emit(displayName);
                 List<JSType> templateTypes = type.getTemplateTypes();
                 if (templateTypes != null && templateTypes.size() > 0) {
                   emitGenericTypeArguments(type.getTemplateTypes().iterator());

--- a/src/test/java/com/google/javascript/clutz/partial/missing_base.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_base.d.ts
@@ -1,26 +1,26 @@
 declare namespace ಠ_ಠ.clutz.module$exports$missing$extend {
   class B extends B_Instance {
   }
-  class B_Instance extends ಠ_ಠ.clutz.direct.ref.A {
+  class B_Instance extends direct.ref.A {
   }
   class BTemplated extends BTemplated_Instance {
   }
-  class BTemplated_Instance extends ಠ_ಠ.clutz.direct.ref.ATemplated < string , number > {
+  class BTemplated_Instance extends direct.ref.ATemplated < string , number > {
   }
   class ClassExtendingMissingDestructuredRequire extends ClassExtendingMissingDestructuredRequire_Instance {
   }
-  class ClassExtendingMissingDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$missing$base_MissingDestructuredRequire {
+  class ClassExtendingMissingDestructuredRequire_Instance extends module$exports$missing$base_MissingDestructuredRequire {
   }
   class ClassExtendingMissingRequire extends ClassExtendingMissingRequire_Instance {
   }
-  class ClassExtendingMissingRequire_Instance extends ಠ_ಠ.clutz.module$exports$missing$base {
+  class ClassExtendingMissingRequire_Instance extends module$exports$missing$base {
   }
   class ClassExtendingRenamedDestructuredRequire extends ClassExtendingRenamedDestructuredRequire_Instance {
   }
-  class ClassExtendingRenamedDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$missing$base_OriginalName {
+  class ClassExtendingRenamedDestructuredRequire_Instance extends module$exports$missing$base_OriginalName {
   }
-  var DeclarationOfMissingRequire : ಠ_ಠ.clutz.module$exports$missing$base | null ;
-  function FuncWithMissingRequireParam (c : ಠ_ಠ.clutz.module$exports$missing$base | null ) : void ;
+  var DeclarationOfMissingRequire : module$exports$missing$base | null ;
+  function FuncWithMissingRequireParam (c : module$exports$missing$base | null ) : void ;
 }
 declare module 'goog:missing.extend' {
   import alias = ಠ_ಠ.clutz.module$exports$missing$extend;

--- a/src/test/java/com/google/javascript/clutz/partial/missing_generic.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_generic.d.ts
@@ -4,7 +4,7 @@ declare namespace ಠ_ಠ.clutz.module$exports$missing$gen {
   class GenericClassDefaultsTypeParamToAny_Instance < T = any > {
     private noStructuralTyping_: any;
   }
-  var genericClassUse : ಠ_ಠ.clutz.missing.GenericClass ;
+  var genericClassUse : missing.GenericClass ;
 }
 declare module 'goog:missing.gen' {
   import alias = ಠ_ಠ.clutz.module$exports$missing$gen;

--- a/src/test/java/com/google/javascript/clutz/partial/missing_platform_externs.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_platform_externs.d.ts
@@ -1,0 +1,7 @@
+declare namespace ಠ_ಠ.clutz.module$exports$missing$platform$externs {
+  function foo ( ) : Node | null ;
+}
+declare module 'goog:missing.platform.externs' {
+  import alias = ಠ_ಠ.clutz.module$exports$missing$platform$externs;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/missing_platform_externs.js
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_platform_externs.js
@@ -1,0 +1,7 @@
+goog.module("missing.platform.externs");
+
+//!! Don't need to provide any type for Node, since it's in lib.d.ts
+/** @return {Node} */
+function foo() { return null }
+
+exports.foo = foo;

--- a/src/test/java/com/google/javascript/clutz/partial/missing_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_type.d.ts
@@ -1,7 +1,7 @@
 declare namespace ಠ_ಠ.clutz.module$exports$missing$type {
-  var x : ಠ_ಠ.clutz.Missing ;
-  var xWithGenerics : ಠ_ಠ.clutz.goog.missing.map < string , number > ;
-  var xWithMissingGenerics : ಠ_ಠ.clutz.goog.missing.map < ಠ_ಠ.clutz.mod.ref.A , ಠ_ಠ.clutz.mod.ref.B < ಠ_ಠ.clutz.mod.ref.C > > ;
+  var x : Missing ;
+  var xWithGenerics : goog.missing.map < string , number > ;
+  var xWithMissingGenerics : goog.missing.map < mod.ref.A , mod.ref.B < mod.ref.C > > ;
 }
 declare module 'goog:missing.type' {
   import alias = ಠ_ಠ.clutz.module$exports$missing$type;

--- a/src/test/java/com/google/javascript/clutz/partial/tte_promise_partial.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/tte_promise_partial.d.ts
@@ -1,7 +1,7 @@
 declare namespace ಠ_ಠ.clutz.module$exports$tte$Promise$Partial {
   class PartialDeferred < VALUE = any > extends PartialDeferred_Instance < VALUE > {
   }
-  class PartialDeferred_Instance < VALUE = any > extends ಠ_ಠ.clutz.Base < VALUE > {
+  class PartialDeferred_Instance < VALUE = any > extends Base < VALUE > {
     then < RESULT > (opt_onFulfilled ? : ( (a : VALUE ) => PartialDeferred < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : PartialDeferred < RESULT > ;
   }
 }


### PR DESCRIPTION
Since we declare everything in namespaces that start with ಠ_ಠ.clutz, any symbols that are under the ಠ_ಠ.clutz namespace will be resolved there, but if the missing symbols are in the platform externs (eg Node), then they won't be shadowed by the ಠ_ಠ.clutz namespace, as they were previously.