### PR TITLE
Adds a test that matches the emit pattern of tsickle.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/goog_module_export_redefined.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_module_export_redefined.d.ts
@@ -1,0 +1,16 @@
+declare namespace ಠ_ಠ.clutz.module$exports$module$tsickle$like {
+  type A = ಠ_ಠ.clutz.module$contents$module$tsickle$like_A ;
+  var A : typeof ಠ_ಠ.clutz.module$contents$module$tsickle$like_A ;
+  var moduleId : string ;
+}
+declare module 'goog:module.tsickle.like' {
+  import alias = ಠ_ಠ.clutz.module$exports$module$tsickle$like;
+  export = alias;
+}
+declare namespace ಠ_ಠ.clutz {
+  class module$contents$module$tsickle$like_A extends module$contents$module$tsickle$like_A_Instance {
+  }
+  class module$contents$module$tsickle$like_A_Instance {
+    private noStructuralTyping_: any;
+  }
+}

--- a/src/test/java/com/google/javascript/clutz/goog_module_export_redefined.js
+++ b/src/test/java/com/google/javascript/clutz/goog_module_export_redefined.js
@@ -1,0 +1,10 @@
+goog.module('module.tsickle.like');
+
+//!! This odd pattern is what we do for all tsickle emitted .js.
+exports = {};
+exports.moduleId = 'foo/bar';
+
+class A {
+}
+
+exports.A = A;


### PR DESCRIPTION
Tsickle has to do an odd workaround to append moduleId to each
goog.module.

Turns out this changes the clutz emit significantly, and we need to have
a test to detect changes in that emit.