### PR TITLE
emit subclass constructor when we can't see base constructor

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -2197,13 +2197,16 @@ class DeclarationGenerator {
      * no body (default ctor) for base classes, or the constructor of the superclass.
      *
      * <p>Omitting the constructor is correct only if the closure class and *all* its superclasses
-     * have zero argument constructors.
+     * have zero argument constructors. If the supertype is NoResolvedType we cannot know whether
+     * that's the case so we must return true.
      */
     private boolean mustEmitConstructor(FunctionType type) {
       while (type != null) {
         if (type.getParameters().iterator().hasNext()) return true;
         ObjectType oType = getSuperType(type);
-        type = oType != null ? oType.getConstructor() : null;
+        if (oType == null) return false;
+        if (oType.isNoResolvedType()) return true;
+        type = oType.getConstructor();
       }
       return false;
     }

--- a/src/test/java/com/google/javascript/clutz/partial/missing_base.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_base.d.ts
@@ -1,23 +1,33 @@
 declare namespace ಠ_ಠ.clutz.module$exports$missing$extend {
-  class B extends B_Instance {
+  class ClassExtendingMissing extends ClassExtendingMissing_Instance {
   }
-  class B_Instance extends direct.ref.A {
-  }
-  class BTemplated extends BTemplated_Instance {
-  }
-  class BTemplated_Instance extends direct.ref.ATemplated < string , number > {
+  class ClassExtendingMissing_Instance extends direct.ref.A {
+    constructor ( ) ;
   }
   class ClassExtendingMissingDestructuredRequire extends ClassExtendingMissingDestructuredRequire_Instance {
   }
   class ClassExtendingMissingDestructuredRequire_Instance extends module$exports$missing$base_MissingDestructuredRequire {
+    constructor ( ) ;
   }
   class ClassExtendingMissingRequire extends ClassExtendingMissingRequire_Instance {
   }
   class ClassExtendingMissingRequire_Instance extends module$exports$missing$base {
+    constructor ( ) ;
+  }
+  class ClassExtendingMissingTemplated extends ClassExtendingMissingTemplated_Instance {
+  }
+  class ClassExtendingMissingTemplated_Instance extends direct.ref.ATemplated < string , number > {
+    constructor ( ) ;
+  }
+  class ClassExtendingMissingWithParam extends ClassExtendingMissingWithParam_Instance {
+  }
+  class ClassExtendingMissingWithParam_Instance extends direct.ref.A {
+    constructor (x : number ) ;
   }
   class ClassExtendingRenamedDestructuredRequire extends ClassExtendingRenamedDestructuredRequire_Instance {
   }
   class ClassExtendingRenamedDestructuredRequire_Instance extends module$exports$missing$base_OriginalName {
+    constructor ( ) ;
   }
   var DeclarationOfMissingRequire : module$exports$missing$base | null ;
   function FuncWithMissingRequireParam (c : module$exports$missing$base | null ) : void ;

--- a/src/test/java/com/google/javascript/clutz/partial/missing_base.js
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_base.js
@@ -7,7 +7,7 @@ goog.module('missing.extend');
  * @constructor
  * @extends {direct.ref.A}
  */
-function B() {
+function ClassExtendingMissing() {
 
 }
 
@@ -15,7 +15,16 @@ function B() {
  * @constructor
  * @extends {direct.ref.ATemplated<string, number>}
  */
-function BTemplated() {
+function ClassExtendingMissingTemplated() {
+
+}
+
+/**
+ * @param {number} x
+ * @constructor
+ * @extends {direct.ref.A}
+ */
+function ClassExtendingMissingWithParam(x) {
 
 }
 
@@ -56,8 +65,9 @@ function ClassExtendingRenamedDestructuredRequire() {
 
 }
 
-exports.B = B;
-exports.BTemplated = BTemplated;
+exports.ClassExtendingMissing = ClassExtendingMissing;
+exports.ClassExtendingMissingTemplated = ClassExtendingMissingTemplated;
+exports.ClassExtendingMissingWithParam = ClassExtendingMissingWithParam;
 exports.ClassExtendingMissingRequire = ClassExtendingMissingRequire;
 exports.FuncWithMissingRequireParam = FuncWithMissingRequireParam;
 exports.DeclarationOfMissingRequire = DeclarationOfMissingRequire;

--- a/src/test/java/com/google/javascript/clutz/partial/tte_promise_partial.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/tte_promise_partial.d.ts
@@ -2,6 +2,7 @@ declare namespace ಠ_ಠ.clutz.module$exports$tte$Promise$Partial {
   class PartialDeferred < VALUE = any > extends PartialDeferred_Instance < VALUE > {
   }
   class PartialDeferred_Instance < VALUE = any > extends Base < VALUE > {
+    constructor ( ) ;
     then < RESULT > (opt_onFulfilled ? : ( (a : VALUE ) => PartialDeferred < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : PartialDeferred < RESULT > ;
   }
 }


### PR DESCRIPTION
Clutz attempts to leave out ctors that aren't necessary (e.g.
accepts same params as the parent class).  If Clutz can't see
the parent class, then it must emit a ctor because it can't
know whether the ctor is necessary or not.