### PR TITLE
Attach the Global* emit logic for missing type too

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -1685,6 +1685,7 @@ class DeclarationGenerator {
         emit(defaultEmit);
         return;
       }
+      if (maybeEmitGlobalAlias(type)) return;
       // When processing partial inputs, this case handles implicitly forward declared types
       // for which we just emit the literal type written along with any type parameters.
       NoResolvedType nType = (NoResolvedType) type;
@@ -2762,10 +2763,7 @@ class DeclarationGenerator {
 
     public Void emitObjectType(
         ObjectType type, boolean extendingInstanceClass, boolean inExtendsImplementsPosition) {
-      if (type.getDisplayName() != null && GLOBAL_SYMBOL_ALIASES.contains(type.getDisplayName())) {
-        emit("Global" + type.getDisplayName());
-        return null;
-      }
+      if (maybeEmitGlobalAlias(type)) return null;
       // Closure doesn't require that all the type params be declared, but TS does
       if (!type.getTemplateTypeMap().isEmpty()
           && !typeRegistry.getNativeType(OBJECT_TYPE).equals(type)) {
@@ -2794,6 +2792,15 @@ class DeclarationGenerator {
         emit("GlobalObject");
       }
       return null;
+    }
+
+    /** See comment on GLOBAL_SYMBOL_ALIASES. */
+    private boolean maybeEmitGlobalAlias(ObjectType type) {
+      if (type.getDisplayName() != null && GLOBAL_SYMBOL_ALIASES.contains(type.getDisplayName())) {
+        emit("Global" + type.getDisplayName());
+        return true;
+      }
+      return false;
     }
 
     /**

--- a/src/test/java/com/google/javascript/clutz/partial/global_alias_missing.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/global_alias_missing.d.ts
@@ -1,0 +1,8 @@
+declare namespace ಠ_ಠ.clutz.ns.event {
+  function f (t : GlobalEventTarget | null ) : void ;
+  function f2 (t : ns.event.EventTarget | null ) : void ;
+}
+declare module 'goog:ns.event' {
+  import alias = ಠ_ಠ.clutz.ns.event;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/global_alias_missing.js
+++ b/src/test/java/com/google/javascript/clutz/partial/global_alias_missing.js
@@ -1,0 +1,12 @@
+goog.provide('ns.event');
+
+//!! Assume there exists a ns.event.EventTarget, then
+//!! emitting just t: EventTarget would be wrong.
+//!! TypeScript will pick up ns.event.EventTarget instead
+//!! of the global EventTarget.
+/** @param {EventTarget} t */
+ns.event.f = function(t) {};
+
+//!! In contrast, this function uses the namespace local EventTarget.
+/** @param {ns.event.EventTarget} t */
+ns.event.f2 = function(t) {};


### PR DESCRIPTION
We already emit Global* for some global types that can get shadowed by
other namespace types. For example

goog.events.EventTarget;

/** @param {EventTarget} */
goog.events.listen

cannot be

namespace goog.events {
  interface EventTarget {}
  listen(t: EventTarget) {}
}

because the fn argument refers to the global one. Instead we have
GlobalEventTartget alias the global EventTarget and emit that name
instead.

With incremental clutz, we have to add that logic to the
emitNoResolvedType function too.