### PR TITLE
Fix for goog.provides with inferred symbols.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/inferred_provide.d.ts
+++ b/src/test/java/com/google/javascript/clutz/inferred_provide.d.ts
@@ -1,0 +1,8 @@
+declare namespace ಠ_ಠ.clutz.inferred {
+  function fn ( ) : void ;
+  var foo : number ;
+}
+declare module 'goog:inferred' {
+  import alias = ಠ_ಠ.clutz.inferred;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/inferred_provide.js
+++ b/src/test/java/com/google/javascript/clutz/inferred_provide.js
@@ -1,0 +1,4 @@
+goog.provide('inferred');
+
+inferred.foo = 0;
+inferred.fn = function() {};

--- a/src/test/java/com/google/javascript/clutz/inferred_provide_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/inferred_provide_usage.ts
@@ -1,0 +1,3 @@
+import * as inferred from 'goog:inferred';
+
+inferred.foo;


### PR DESCRIPTION
Inferred symbols inside namespace provides are handled specially.

Previously, we had a fix for this issue, but only turned it on for
goog.modules. Now this is turned on for all inputs. Previous concerns
do not appear at least in the test suite.

This issue is more appearant with incremental clutz, because at least in
d3's case an ambient extern was masking the issue. That extern is no
longer visible in incremental scenario.

Note: this affects both modes (incremental and total) of clutz.