### PR TITLE
Switch language in to ECMASCRIPT_2017.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -159,7 +159,7 @@ public class Options {
     // Late Provides are errors by default, but they do not prevent clutz from transpiling.
     options.setWarningLevel(DiagnosticGroups.LATE_PROVIDE, CheckLevel.OFF);
 
-    options.setLanguage(LanguageMode.ECMASCRIPT_NEXT);
+    options.setLanguage(LanguageMode.ECMASCRIPT_2017);
     options.setLanguageOut(LanguageMode.ECMASCRIPT5);
     options.setCheckTypes(true);
     options.setInferTypes(true);


### PR DESCRIPTION
This is the default for closure and _NEXT can cause printing unwanted
warnings for no real benefits. NEXT features parsing is not supported in
closure yet.