### PR TITLE
Add a partial_goog_base.js file that is used for all incremental clutz.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -2676,7 +2676,8 @@ class DeclarationGenerator {
           emitNoSpace("" + pName);
           paramCount++;
         }
-        if (param.isOptionalArg() || makeAllParametersOptional) {
+        // In TypeScript ...a?: any[] is illegal, so we can only make non-varargs optional.
+        if ((param.isOptionalArg() || makeAllParametersOptional) && !param.isVarArgs()) {
           emit("?");
           visitTypeDeclaration(param.getJSType(), param.isVarArgs(), true);
         } else {

--- a/src/resources/partial_goog_base.js
+++ b/src/resources/partial_goog_base.js
@@ -1,0 +1,12 @@
+/**
+ * This file is added to all partial clutz compilations, so that inference
+ * can work across some commonly seen methods.
+ *
+ * Note is should be partially matching closure's base.js.
+ */
+
+/**
+ * @type {!Function}
+ */
+goog.abstractMethod = function() {
+};

--- a/src/test/java/com/google/javascript/clutz/partial/abstract_method_partial.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/abstract_method_partial.d.ts
@@ -1,0 +1,19 @@
+declare namespace ಠ_ಠ.clutz {
+  class module$exports$abst$method extends module$exports$abst$method_Instance {
+  }
+  class module$exports$abst$method_Instance {
+    private noStructuralTyping_: any;
+    /**
+     * It appears that this one is emitted correctly without partial_goog_base.js
+     */
+    methodWithTypes ( ) : number ;
+    /**
+     * But this one needs partial_goog_base.js
+     */
+    methodWithoutTypes ( ...a : any [] ) : any ;
+  }
+}
+declare module 'goog:abst.method' {
+  import alias = ಠ_ಠ.clutz.module$exports$abst$method;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/abstract_method_partial.js
+++ b/src/test/java/com/google/javascript/clutz/partial/abstract_method_partial.js
@@ -1,0 +1,17 @@
+goog.module('abst.method');
+
+/** @constructor */
+let C = function () {};
+
+/**
+ * It appears that this one is emitted correctly without partial_goog_base.js
+ * @return {number}
+ */
+C.prototype.methodWithTypes = goog.abstractMethod;
+
+/**
+ * But this one needs partial_goog_base.js
+ */
+C.prototype.methodWithoutTypes = goog.abstractMethod;
+
+exports = C;


### PR DESCRIPTION
Knowing that 'goog.abstractMethod' is a function allows for incremental
clutz to emit 'C.prototype.fn = goog.abstractMethod' as a method and not
a field. TypeScript asserts that methods can only override other
methods, so this is crucial knowledge for incremental clutz.

To achieve this we add an extra mock version of base.js -
mock_goog_base.js that will be passed to every partial clutz
compilation. It will not affect the output in other ways than allowing
inference works to work better in its presence.