### PR TITLE
Rename missing imported symbols in goog.scope.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/ImportRenameMapBuilder.java
+++ b/src/main/java/com/google/javascript/clutz/ImportRenameMapBuilder.java
@@ -31,9 +31,9 @@ public class ImportRenameMapBuilder {
         importRenameMap.putAll(build(moduleId, ast.getFirstChild()));
       }
 
-      // Or symbols can be imported into a variable in a goog.scope() block, so look for imports in
-      // the bodies of any goog scopes.
-      List<Node> googScopes = getGoogScopes(ast);
+      // Or symbols can be imported into a variable in a top-level goog.scope() block, so look for
+      // imports in the bodies of any goog scopes.
+      List<Node> googScopes = getTopLevelGoogScopes(ast);
       if (!googScopes.isEmpty()) {
         for (Node googScope : googScopes) {
           importRenameMap.putAll(build(null, googScope));
@@ -43,7 +43,7 @@ public class ImportRenameMapBuilder {
     return importRenameMap;
   }
 
-  private static List<Node> getGoogScopes(Node astRoot) {
+  private static List<Node> getTopLevelGoogScopes(Node astRoot) {
     List<Node> googScopes = new ArrayList<>();
     for (Node statement : astRoot.children()) {
       if (isGoogScopeCall(statement)) {
@@ -71,6 +71,10 @@ public class ImportRenameMapBuilder {
     return expression.isCall() && expression.getFirstChild().matchesQualifiedName("goog.module");
   }
 
+  /**
+   * Matches either `const foo = goog.require()` or `const foo = goog.module.get()` depending on if
+   * statement is in a goog.module or a goog.scope.
+   */
   private static boolean isImportAssignment(Node statement) {
     if (!(statement.isConst() || statement.isVar() || statement.isLet())) {
       return false;
@@ -84,6 +88,10 @@ public class ImportRenameMapBuilder {
             || rightHandSide.getFirstChild().matchesQualifiedName("goog.module.get"));
   }
 
+  /**
+   * Matches either `const {foo} = goog.require()` or `const {foo} = goog.module.get()` depending on
+   * if statement is in a goog.module or a goog.scope.
+   */
   private static boolean isImportDestructuringAssignment(Node statement) {
     if (!(statement.isConst() || statement.isVar() || statement.isLet())) {
       return false;

--- a/src/test/java/com/google/javascript/clutz/partial/goog_module_get.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/goog_module_get.d.ts
@@ -1,0 +1,33 @@
+declare namespace ಠ_ಠ.clutz.goog.scope {
+  class ClassExtendingMissingDestructuredRequire extends ClassExtendingMissingDestructuredRequire_Instance {
+  }
+  class ClassExtendingMissingDestructuredRequire_Instance extends module$exports$goog$module$named$exports.MissingDestructuredRequire {
+    constructor ( ) ;
+  }
+}
+declare module 'goog:goog.scope.ClassExtendingMissingDestructuredRequire' {
+  import alias = ಠ_ಠ.clutz.goog.scope.ClassExtendingMissingDestructuredRequire;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.goog.scope {
+  class ClassExtendingMissingGoogModuleGet extends ClassExtendingMissingGoogModuleGet_Instance {
+  }
+  class ClassExtendingMissingGoogModuleGet_Instance extends module$exports$goog$module$default$exports {
+    constructor ( ) ;
+  }
+}
+declare module 'goog:goog.scope.ClassExtendingMissingGoogModuleGet' {
+  import alias = ಠ_ಠ.clutz.goog.scope.ClassExtendingMissingGoogModuleGet;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.goog.scope {
+  class ClassExtendingRenamedDestructuredRequire extends ClassExtendingRenamedDestructuredRequire_Instance {
+  }
+  class ClassExtendingRenamedDestructuredRequire_Instance extends module$exports$goog$module$named$exports.OriginalName {
+    constructor ( ) ;
+  }
+}
+declare module 'goog:goog.scope.ClassExtendingRenamedDestructuredRequire' {
+  import alias = ಠ_ಠ.clutz.goog.scope.ClassExtendingRenamedDestructuredRequire;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/goog_module_get.js
+++ b/src/test/java/com/google/javascript/clutz/partial/goog_module_get.js
@@ -1,0 +1,32 @@
+goog.provide('goog.scope.ClassExtendingMissingGoogModuleGet');
+goog.provide('goog.scope.ClassExtendingMissingDestructuredRequire');
+goog.provide('goog.scope.ClassExtendingRenamedDestructuredRequire');
+
+goog.scope(() => {
+  const MissingGoogModuleGet = goog.module.get('goog.module.default.exports');
+  /**
+   * @constructor
+   * @extends {MissingGoogModuleGet}
+   */
+  goog.scope.ClassExtendingMissingGoogModuleGet = function() {
+
+  }
+
+  const {MissingDestructuredRequire, OriginalName: RenamedDestructuredRequire} = goog.module.get('goog.module.named.exports');
+
+  /**
+   * @constructor
+   * @extends {MissingDestructuredRequire}
+   */
+  goog.scope.ClassExtendingMissingDestructuredRequire = function() {
+
+  }
+
+  /**
+   * @constructor
+   * @extends {RenamedDestructuredRequire}
+   */
+  goog.scope.ClassExtendingRenamedDestructuredRequire = function() {
+
+  }
+});


### PR DESCRIPTION
Similar to having to rename symbols that are imported in goog.modules(), closure doesn't get the right name for symbols imported inside a goog.scope block.  This PR modifies ImportRenameMapBuilder to collect the rename mappings inside goog.scope blocks, in addition to the existing goog.modules.