### PR TITLE
Fix emits in the goog namespace.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/DeclarationGeneratorTests.java
+++ b/src/test/java/com/google/javascript/clutz/DeclarationGeneratorTests.java
@@ -74,6 +74,9 @@ public class DeclarationGeneratorTests {
       if (input.getName().contains("_emit_platform_externs")) {
         subject.emitPlatformExterns = true;
       }
+      if (input.getName().contains("_output_base")) {
+        subject.emitBase = true;
+      }
       if (Arrays.asList("partial", "multifilePartial").contains(input.getParentFile().getName())) {
         subject.partialInput = true;
       }
@@ -102,9 +105,12 @@ public class DeclarationGeneratorTests {
     // compiled in a single run in MultiFileTest
     File[] testMultifilePartailFiles =
         getPackagePath().resolve("multifilePartial").toFile().listFiles(filter);
+    // Output base files live in the 'outputBase' dir and impilicitly have base.js in their roots
+    File[] testOutputBaseFiles = getPackagePath().resolve("outputBase").toFile().listFiles(filter);
     List<File> filesList = Lists.newArrayList(testFiles);
     filesList.addAll(Arrays.asList(testPartialFiles));
     filesList.addAll(Arrays.asList(testMultifilePartailFiles));
+    filesList.addAll(Arrays.asList(testOutputBaseFiles));
     return filesList;
   }
 

--- a/src/test/java/com/google/javascript/clutz/ProgramSubject.java
+++ b/src/test/java/com/google/javascript/clutz/ProgramSubject.java
@@ -45,6 +45,7 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
   public boolean partialInput = false;
   public String extraExternFile = null;
   public boolean emitPlatformExterns;
+  public boolean emitBase = false;
 
   static ProgramSubject assertThatProgram(String... sourceLines) {
     String sourceText = Joiner.on('\n').join(sourceLines);
@@ -128,6 +129,10 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
     if (actual().sourceText != null) {
       sourceFiles.add(SourceFile.fromCode("main.js", actual().sourceText));
       roots.add("main.js");
+    }
+
+    if (emitBase) {
+      roots.add(CLUTZ_GOOG_BASE_TOTAL.getName());
     }
 
     List<SourceFile> externFiles;

--- a/src/test/java/com/google/javascript/clutz/base.js
+++ b/src/test/java/com/google/javascript/clutz/base.js
@@ -11,6 +11,11 @@ var COMPILED = false;
 var goog = goog || {};
 
 /**
+ * Reference to the global context.  In most cases this will be 'window'.
+ */
+goog.global = this;
+
+/**
  * @param {string} name
  * @return {?}
  */
@@ -31,3 +36,85 @@ goog.isDef = function(val) {};
 goog.provide('goog.Uri');
 /** @constructor */
 goog.Uri =  function() {}
+
+/**
+ * Exports a property unobfuscated into the object's namespace.
+ * ex. goog.exportProperty(Foo, 'staticFunction', Foo.staticFunction);
+ * ex. goog.exportProperty(Foo.prototype, 'myMethod', Foo.prototype.myMethod);
+ * @param {Object} object Object whose static property is being exported.
+ * @param {string} publicName Unobfuscated name to export.
+ * @param {*} symbol Object the name should point to.
+ */
+goog.exportProperty = function(object, publicName, symbol) {
+  object[publicName] = symbol;
+};
+
+/** @struct @constructor @final */
+goog.Transpiler = function() {
+  /** @private {?Object<string, boolean>} */
+  this.requiresTranspilation_ = null;
+};
+
+/** @private @final {!goog.Transpiler} */
+goog.transpiler_ = new goog.Transpiler();
+
+/**
+ * A debug loader is responsible for downloading and executing javascript
+ * files in an unbundled, uncompiled environment.
+ *
+ * @struct @constructor
+ */
+goog.DebugLoader = function() {
+  /**
+   * This object is used to keep track of dependencies and other data that is
+   * used for loading scripts.
+   * @private
+   * @type {{
+     *   loadFlags: !Object<string, !Object<string, string>>,
+     *   nameToPath: !Object<string, string>,
+     *   requires: !Object<string, !Object<string, boolean>>,
+     *   visited: !Object<string, boolean>,
+     *   written: !Object<string, boolean>,
+     *   deferred: !Object<string, string>
+     * }}
+   */
+  this.dependencies_ = {
+    loadFlags: {},  // 1 to 1
+
+    nameToPath: {},  // 1 to 1
+
+    requires: {},  // 1 to many
+
+    // Used when resolving dependencies to prevent us from visiting file
+    // twice.
+    visited: {},
+
+    written: {},  // Used to keep track of script files we have written.
+
+    deferred: {}  // Used to track deferred module evaluations in old IEs
+  };
+
+  /**
+   * Whether IE9 or earlier is waiting on a dependency.  This ensures that
+   * deferred modules that have no non-deferred dependencies actually get
+   * loaded, since if we defer them and then never pull in a non-deferred
+   * script, then `this.loadQueuedModules_` will never be called.  Instead,
+   * if not waiting on anything we simply don't defer in the first place.
+   * @private {boolean}
+   */
+  this.oldIeWaiting_ = false;
+
+  /** @private {!Array<string>} */
+  this.queuedModules_ = [];
+
+  /** @private {number} */
+  this.lastNonModuleScriptIndex_ = 0;
+};
+
+/**
+ * @return {!goog.Transpiler}
+ * @protected @final
+ */
+goog.DebugLoader.prototype.getTranspiler = function() {
+  return goog.transpiler_;
+};

--- a/src/test/java/com/google/javascript/clutz/outputBase/function_alias_output_base.d.ts
+++ b/src/test/java/com/google/javascript/clutz/outputBase/function_alias_output_base.d.ts
@@ -23,7 +23,7 @@ declare namespace goog {
    * @param symbol Object the name should point to.
    */
   function exportProperty (object : ಠ_ಠ.clutz.GlobalObject | null , publicName : string , symbol : any ) : void ;
-  function inherits (childCtor : Function , parentCtor : Function ) : void ;
+  function inherits (childCtor : ಠ_ಠ.clutz.partial.FunctionAlias , parentCtor : ಠ_ಠ.clutz.partial.FunctionAlias ) : void ;
   function isDef (val : any ) : boolean ;
   function require (name : string ) : ಠ_ಠ.clutz.ClosureSymbolNotGoogProvided;
   var /**
@@ -40,5 +40,12 @@ declare namespace ಠ_ಠ.clutz.goog {
 }
 declare module 'goog:goog.Uri' {
   import alias = ಠ_ಠ.clutz.goog.Uri;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.partial {
+  type FunctionAlias = Function ;
+}
+declare module 'goog:partial.FunctionAlias' {
+  import alias = ಠ_ಠ.clutz.partial.FunctionAlias;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/clutz/outputBase/function_alias_output_base.js
+++ b/src/test/java/com/google/javascript/clutz/outputBase/function_alias_output_base.js
@@ -1,0 +1,18 @@
+//!! FunctionAlias creates a type alias for Function, which is used in base.js
+//!! This test checks that that alias is emitted in a valid format in the goog
+//!! namespace
+goog.provide('partial.FunctionAlias');
+
+/**
+ * @typedef {function(number, number)}
+ */
+partial.FunctionType1;
+/**
+ * @typedef {function(string, string, string)}
+ */
+partial.FunctionType2;
+
+/**
+ * @typedef {partial.FunctionType1 | partial.FunctionType2}
+ */
+partial.FunctionAlias;

--- a/src/test/java/com/google/javascript/clutz/private_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/private_type.d.ts
@@ -10,11 +10,11 @@ declare namespace ಠ_ಠ.clutz.privatetype {
   class Foo_Instance {
     private noStructuralTyping_: any;
     constructor (a : any ) ;
-    foo ( ) : ಠ_ಠ.clutz.PrivateType ;
+    foo ( ) : PrivateType ;
   }
 }
 declare namespace ಠ_ಠ.clutz.privatetype.Foo {
-  type typedef = { a : ಠ_ಠ.clutz.PrivateType } ;
+  type typedef = { a : PrivateType } ;
 }
 declare module 'goog:privatetype.Foo' {
   import alias = ಠ_ಠ.clutz.privatetype.Foo;
@@ -34,7 +34,7 @@ declare module 'goog:privatetype.X_' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.privatetype {
-  var enumUser : ಠ_ಠ.clutz.PrivateType ;
+  var enumUser : PrivateType ;
 }
 declare module 'goog:privatetype.enumUser' {
   import alias = ಠ_ಠ.clutz.privatetype.enumUser;


### PR DESCRIPTION
Clutz had the assumption that every namespace it emits is a subnamespace of the ಠ_ಠ.clutz namespace.  This caused 2 problems:

1. Clutz refered to other types within the goog namespace with the ಠ_ಠ.clutz prefix.
2. Clutz refered to types in the ಠ_ಠ.clutz namespace within the goog namespace without the ಠ_ಠ.clutz prefix.

This PR fixes the above by only ever refering to a symbol inside a namespace with the ಠ_ಠ.clutz prefix when refering to a global symbol (ie in closure.lib.d.ts) while in the goog namespace.  In every other case, Clutz can rely on Typescript looking for the symbol in the parent namespaces if the prefix is omitted.