### PR TITLE
Add a const goog block in partial_goog_base.

### DIFF
--- a/src/resources/partial_goog_base.js
+++ b/src/resources/partial_goog_base.js
@@ -5,6 +5,9 @@
  * Note is should be partially matching closure's base.js.
  */
 
+/** @const */
+var goog = {} || goog;
+
 /**
  * @type {!Function}
  */


### PR DESCRIPTION
Strict deps checks fails otherwise, requiring an actual dep on real
base.js which defeats the point.