### PR TITLE
Add a null check in ModuleImport.

### DIFF
--- a/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
@@ -351,8 +351,10 @@ public final class ModuleConversionPass implements CompilerPass {
       this.requiredNamespace = requiredNamespace;
       this.isDestructuringImport = isDestructuringImport;
       this.module = namespaceToModule.get(requiredNamespace);
-      this.referencedFile =
-          pathUtil.getImportPath(originalImportNode.getSourceFileName(), module.file);
+      if (this.module != null) {
+        this.referencedFile =
+            pathUtil.getImportPath(originalImportNode.getSourceFileName(), module.file);
+      }
       this.moduleSuffix = nameUtil.lastStepOfName(requiredNamespace);
       this.backupName = this.moduleSuffix;
       this.localNames = new ArrayList<String>();


### PR DESCRIPTION
The previous code immediately tried to use the retrieved module, which
is sometimes `null` (either because a dependency is missing from the
manifest, or perhaps also for newly-converted namespaces). There is
already an additional check in `validateImport` that provides much
better error output (which is now reachable).