### PR TITLE
Make gents not throw on missing rewritelog option.

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
+++ b/src/main/java/com/google/javascript/gents/TypeScriptGenerator.java
@@ -144,7 +144,9 @@ public class TypeScriptGenerator {
       }
     }
     try {
-      Files.write(result.moduleRewriteLog, new File(opts.moduleRewriteLog), UTF_8);
+      if (opts.moduleRewriteLog != null) {
+        Files.write(result.moduleRewriteLog, new File(opts.moduleRewriteLog), UTF_8);
+      }
     } catch (IOException e) {
       throw new IllegalArgumentException("Unable to write to file " + opts.moduleRewriteLog, e);
     }


### PR DESCRIPTION
Just skip emitting if the user does not provide that option.

Closes #633