### PR TITLE
Gents support for enums that have arithmetic expressions.

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeConversionPass.java
@@ -345,7 +345,7 @@ public final class TypeConversionPass implements CompilerPass {
       }
     }
 
-    private Node transformMembers(Node members, boolean isNumber) {
+    private Node transformMembers(Node members, boolean enumIsOfNumberType) {
       assert members.isObjectLit();
       int lastCount = -1;
       Node enumMembers = new Node(Token.ENUM_MEMBERS);
@@ -355,14 +355,14 @@ public final class TypeConversionPass implements CompilerPass {
         Node newMember;
         // Check whether we can emit simply the name, and rely on the automatic numeric assignment
         // in TypeScript. For example, enum E { A, B } is equivalent to enum E { A = 0, B = 1 }.
-        if (isNumber && value.getDouble() == lastCount + 1) {
+        if (enumIsOfNumberType && value.isNumber() && value.getDouble() == lastCount + 1) {
           newMember = name;
         } else {
           // We cannot reuse the STRING_KEY node here, because it pretty prints as a: 0, and we
           // want a = 1. Instead we recreate an ASSIGN node with same contents as STRING_KEY
           newMember = new Node(Token.ASSIGN, name, value);
         }
-        if (isNumber) {
+        if (enumIsOfNumberType && value.isNumber()) {
           lastCount = (int) value.getDouble();
         }
         enumMembers.addChildToBack(newMember);

--- a/src/test/java/com/google/javascript/gents/singleTests/enum.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/enum.js
@@ -26,6 +26,11 @@ const RepeatedNumEnum = {
   D: 2
 };
 
+/** @enum {number} */
+const EnumWithArithmetics = {
+    A: 10 * 10 + 2,
+    B: 2
+};
 
 /** @enum {string} */
 const StrEnum = {
@@ -57,5 +62,6 @@ exports.C = C;
 exports.NumEnum = NumEnum;
 exports.NonConseqNumEnum = NonConseqNumEnum;
 exports.RepeatedNumEnum = RepeatedNumEnum;
+exports.EnumWithArithmetics = EnumWithArithmetics;
 exports.StrEnum = StrEnum;
 exports.OtherEnum = OtherEnum;

--- a/src/test/java/com/google/javascript/gents/singleTests/enum.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/enum.ts
@@ -25,6 +25,12 @@ export enum RepeatedNumEnum {
   D = 2
 }
 
+/** @enum {number} */
+export enum EnumWithArithmetics {
+  A = 10 * 10 + 2,
+  B = 2
+}
+
 /** @enum {string} */
 export enum StrEnum {
   A = 'foo',


### PR DESCRIPTION
Previously we were assuming all numeric enums contained literal numbers.

Closes #628