### PR TITLE
Gents translates ES6 classes with @interface annotation to interfaces.

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
@@ -490,6 +490,8 @@ public final class TypeAnnotationPass implements CompilerPass {
         // remains the same.
       case EQUALS:
         return convertTypeNodeAST(n.getFirstChild());
+      case NAME:
+        return namedType(n.getString());
       default:
         throw new IllegalArgumentException("Unsupported node type:\n" + n.toStringTree());
     }

--- a/src/test/java/com/google/javascript/gents/singleTests/class_interface.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/class_interface.js
@@ -1,0 +1,62 @@
+goog.module('klass.interface');
+
+//!! This file contains a mix of different ways of declaring an interface with methods and properties in Closure.
+//!! The only commonality is that the user meant to write an interface, and attached it to an ES6 class out of
+//!! convenience.
+//!! Fields and methods are declared in three different ways:
+//!! - in the ctor body
+//!! - class body
+//!! - using the prototype chain.
+//!! Extending mechanism is both ES6 'class extends', and closure @extends.
+
+/**
+ * Some non-trivial comments.
+ * @interface
+ */
+class IBase {
+    constructor() {
+        /** @const {number} */
+        this.a;
+    }
+    /** @return {boolean} */
+    method1() {}
+}
+
+/**
+ * @interface
+ */
+class IExtendsUsingEs6 extends IBase {
+
+}
+
+
+/** @const {number} */
+IExtendsUsingEs6.prototype.b;
+
+/** @returns {boolean} */
+IExtendsUsingEs6.prototype.method2 = function() {};
+
+/**
+ * @record
+ */
+class RExtendsUsingEs6 extends IBase {
+
+}
+
+/** @const {number} */
+RExtendsUsingEs6.prototype.c;
+
+/**
+ * Some non-trivial comments.
+ * @interface
+ * @extends {IBase}
+ */
+class IExtendsUsingClosure {
+    /** @return {boolean} */
+    method3() {}
+}
+
+exports.IBase = IBase;
+exports.IExtendsUsingEs6 = IExtendsUsingEs6;
+exports.RExtendsUsingEs6 = RExtendsUsingEs6;
+exports.IExtendsUsingClosure = IExtendsUsingClosure;

--- a/src/test/java/com/google/javascript/gents/singleTests/class_interface.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/class_interface.ts
@@ -1,0 +1,19 @@
+
+/**
+ * Some non-trivial comments.
+ */
+//!! Missing field declared in the ctor.
+export interface IBase { method1(): boolean; }
+
+export interface IExtendsUsingEs6 extends IBase {
+  b: number;
+
+  method2(): boolean;
+}
+
+export interface RExtendsUsingEs6 extends IBase { c: number; }
+
+/**
+ * Some non-trivial comments.
+ */
+export interface IExtendsUsingClosure extends IBase { method3(): boolean; }


### PR DESCRIPTION
Some closure users prefer to write /** @interface */ class IFoo, instead
of the more common function syntax. The intent is nevertheless for this
to be a pure interface and not class, so gents will correspondingly
convert that.

Some complications arrise from adding @extends and ES6's class extend
keyword and method/field definitions.

Closes #630,627