### PR TITLE
Special case log.js's class aliases.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -734,6 +734,11 @@ class DeclarationGenerator {
           continue;
         }
 
+        // Symbols in partial_goog_base.js are just stand ins for the real symbols, so don't emit
+        if (symbol.getInputName().endsWith("partial_goog_base.js")) {
+          continue;
+        }
+
         declareNamespace(
             namespace,
             symbol,

--- a/src/resources/partial_goog_base.js
+++ b/src/resources/partial_goog_base.js
@@ -13,3 +13,26 @@ var goog = goog || {};
  */
 goog.abstractMethod = function() {
 };
+
+/**
+ * goog.debug.Logger, goog.debug.Logger.Level, goog.debug.LogRecord are from
+ * closure's log.js, and are used in a weird aliasing pattern that closure doesn't
+ * handle in partial mode.
+ */
+/**
+ * @constructor
+ */
+goog.debug.Logger = function () {
+};
+
+/**
+ * @constructor
+ */
+goog.debug.Logger.Level = function () {
+};
+
+/**
+ * @constructor
+ */
+goog.debug.LogRecord = function () {
+};

--- a/src/test/java/com/google/javascript/clutz/partial/missing_logger_dot_level.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_logger_dot_level.d.ts
@@ -1,0 +1,8 @@
+declare namespace ಠ_ಠ.clutz.goog.log {
+  type Level = ಠ_ಠ.clutz.goog.debug.Logger.Level ;
+  var Level : typeof ಠ_ಠ.clutz.goog.debug.Logger.Level ;
+}
+declare module 'goog:goog.log.Level' {
+  import alias = ಠ_ಠ.clutz.goog.log.Level;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/missing_logger_dot_level.js
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_logger_dot_level.js
@@ -1,0 +1,11 @@
+goog.provide('goog.log.Level');
+
+goog.require('goog.debug.Logger');
+
+//!! goog.log.Level should be an alias for goog.debug.Logger.Level, not an empty
+//!! class
+/**
+ * @constructor
+ * @final
+ */
+goog.log.Level = goog.debug.Logger.Level;


### PR DESCRIPTION
Closure's log.js has this pattern:

/**
 * @constructor
 * @final
 */
goog.log.Level = goog.debug.Logger.Level;

Where the goog.debug.Logger.Level isn't part of the partial compilation.  Closure gives us a type based only on the type comment, totally ignoring the aliased symbol, so there's no easy way to solve the issue in clutz without a closure change.  This pattern only seems to show up in log.js, so just add the relevant symbols to partial_goog_base.js, which causes closure to give a type that knows about the alias.