### PR TITLE
Rename all references to symbols, not just top level ones.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/partial/static_method.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/static_method.d.ts
@@ -1,0 +1,18 @@
+declare namespace ಠ_ಠ.clutz {
+  class module$exports$foo$bar$Class extends module$exports$foo$bar$Class_Instance {
+    static equals (c1 : module$exports$foo$bar$Class | null , c2 : module$exports$foo$bar$Class | null ) : boolean ;
+  }
+  class module$exports$foo$bar$Class_Instance {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.module$exports$foo.bar {
+  export import Class = ಠ_ಠ.clutz.module$exports$foo$bar$Class;
+}
+declare namespace ಠ_ಠ.clutz.module$exports$foo$bar {
+  export import Class = ಠ_ಠ.clutz.module$exports$foo$bar$Class;
+}
+declare module 'goog:foo.bar.Class' {
+  import alias = ಠ_ಠ.clutz.module$exports$foo$bar$Class;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/static_method.js
+++ b/src/test/java/com/google/javascript/clutz/partial/static_method.js
@@ -1,0 +1,18 @@
+goog.provide('foo.bar.Class');
+
+/**
+ * @constructor
+ */
+foo.bar.Class = function() {
+};
+
+//!! The method param references to foo.bar.Class should be renamed to
+//!!  goog.module/dollar style, to match the rename of the class
+/**
+ * @param {foo.bar.Class} c1
+ * @param {foo.bar.Class} c2
+ * @return {boolean}
+ */
+foo.bar.Class.equals = function(c1, c2) {
+  return true;
+};


### PR DESCRIPTION
To ensure compatibility between goog.module and goog.provide code, symbols have to be renamed.  Previously, only top level references to goog.provide symbols were renamed.  This PR renames other references in a given file (ie method params).