### PR TITLE
Fix for importing symbol S from a module named something.S.

### DIFF
--- a/src/test/java/com/google/javascript/gents/multiTests/repeated_name_import/export.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/repeated_name_import/export.js
@@ -1,0 +1,10 @@
+goog.module('exporting.C');
+
+class A {}
+
+// This test is testing the case where the exported class is also repeated in
+// the name of the module. Here we export C from exporting.C.
+class C {}
+
+exports.A = A;
+exports.C = C;

--- a/src/test/java/com/google/javascript/gents/multiTests/repeated_name_import/export.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/repeated_name_import/export.ts
@@ -1,0 +1,6 @@
+
+export class A {}
+
+// This test is testing the case where the exported class is also repeated in
+// the name of the module. Here we export C from exporting.C.
+export class C {}

--- a/src/test/java/com/google/javascript/gents/multiTests/repeated_name_import/import.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/repeated_name_import/import.js
@@ -1,0 +1,3 @@
+goog.module('importing');
+
+const {A, C} = goog.require('exporting.C');

--- a/src/test/java/com/google/javascript/gents/multiTests/repeated_name_import/import.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/repeated_name_import/import.ts
@@ -1,0 +1,1 @@
+import {A, C} from './export';


### PR DESCRIPTION
Ideally, we shouldn't be generating null nodes, but I could not
reproduce that case from the user reports.