### PR TITLE
Change DeclarationGeneratorTests and MultifileTests to auto update goldens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ version of TypeScript
 suite runs against the version of `typescript` in `npm-shrinkwrap.json`, so that is
 always a good choice.
 
+## Tests
+You can run the test suite with:
+```shell
+$ ./gradlew test
+```
+Pass the environment variable `UPDATE_GOLDENS=y` to update the golden files.
 
 # Gents - Closure to TypeScript converter
 

--- a/src/test/java/com/google/javascript/clutz/DeclarationGeneratorTests.java
+++ b/src/test/java/com/google/javascript/clutz/DeclarationGeneratorTests.java
@@ -66,7 +66,6 @@ public class DeclarationGeneratorTests {
     List<File> testFiles = getTestInputFiles(JS_NO_EXTERNS);
     for (final File input : testFiles) {
       File golden = getGoldenFile(input, ".d.ts");
-      final String goldenText = getTestFileText(golden);
       ProgramSubject subject = assertThatProgram(input);
       if (input.getName().contains("_with_platform")) {
         subject.withPlatform = true;
@@ -81,7 +80,7 @@ public class DeclarationGeneratorTests {
         subject.partialInput = true;
       }
       subject.extraExternFile = getExternFileNameOrNull(input.getName());
-      suite.addTest(new DeclarationTest(input.getName(), goldenText, subject));
+      suite.addTest(new DeclarationTest(input.getName(), golden, subject));
     }
     return suite;
   }
@@ -140,18 +139,17 @@ public class DeclarationGeneratorTests {
         text += platformGoldenText;
       }
     }
-    String cleanText = GOLDEN_FILE_COMMENTS_REGEXP.matcher(text).replaceAll("");
-    return cleanText;
+    return text;
   }
 
   private static final class DeclarationTest implements Test, Describable {
     private final String testName;
     private final ProgramSubject subject;
-    private final String goldenText;
+    private final File golden;
 
-    private DeclarationTest(String testName, String goldenText, ProgramSubject subject) {
+    private DeclarationTest(String testName, File golden, ProgramSubject subject) {
       this.testName = testName;
-      this.goldenText = goldenText;
+      this.golden = golden;
       this.subject = subject;
     }
 
@@ -159,7 +157,7 @@ public class DeclarationGeneratorTests {
     public void run(TestResult result) {
       result.startTest(this);
       try {
-        subject.generatesDeclarations(goldenText);
+        subject.generatesDeclarations(golden);
       } catch (Throwable t) {
         result.addError(this, t);
       } finally {

--- a/src/test/java/com/google/javascript/clutz/MultiFileTest.java
+++ b/src/test/java/com/google/javascript/clutz/MultiFileTest.java
@@ -19,30 +19,30 @@ public class MultiFileTest {
   // Repro for https://github.com/angular/closure-to-dts/issues/101
   @Test
   public void shouldPruneProvidesFromNonrootFile() throws Exception {
-    String expected = DeclarationGeneratorTests.getTestFileText(input("require.d.ts"));
+    File golden = input("require.d.ts");
     assertThatProgram(singletonList(input("require.js")), singletonList(input("provide.js")))
-        .generatesDeclarations(expected);
+        .generatesDeclarations(golden);
   }
 
   @Test
   public void shouldResolveNamedTypes() throws Exception {
-    String expected = DeclarationGeneratorTests.getTestFileText(input("index.d.ts"));
+    File golden = input("index.d.ts");
     assertThatProgram(
             ImmutableList.of(input("index.js"), input("dep.js")), Collections.<File>emptyList())
-        .generatesDeclarations(expected);
+        .generatesDeclarations(golden);
   }
 
   @Test
   public void shouldWorkWithOutOfOrderProvides() throws Exception {
-    String expected = DeclarationGeneratorTests.getTestFileText(input("index.d.ts"));
+    File golden = input("index.d.ts");
     assertThatProgram(
             ImmutableList.of(input("index.js"), input("dep.js")), Collections.<File>emptyList())
-        .generatesDeclarations(expected);
+        .generatesDeclarations(golden);
   }
 
   @Test
   public void googModule() throws Exception {
-    String expected = DeclarationGeneratorTests.getTestFileText(input("goog_module.d.ts"));
+    File golden = input("goog_module.d.ts");
     assertThatProgram(
             ImmutableList.of(
                 input("required_module.js"),
@@ -50,49 +50,49 @@ public class MultiFileTest {
                 input("required.js"),
                 input("goog_module.js")),
             Collections.<File>emptyList())
-        .generatesDeclarations(expected);
+        .generatesDeclarations(golden);
   }
 
   @Test
   public void depgraph() throws Exception {
-    String expected = DeclarationGeneratorTests.getTestFileText(input("depgraph.d.ts"));
+    File golden = input("depgraph.d.ts");
     assertThatProgram(
             ImmutableList.of(input("root.js")),
             ImmutableList.of(
                 input("transitive.js"),
                 input("transitive_unused.js"),
                 input("transitive_namespace.js")))
-        .generatesDeclarations(expected);
+        .generatesDeclarations(golden);
   }
 
   @Test
   public void tsickleEmit() throws Exception {
-    String expected = DeclarationGeneratorTests.getTestFileText(input("tsickle_emit.d.ts"));
+    File golden = input("tsickle_emit.d.ts");
     assertThatProgram(
             ImmutableList.of(input("uses_tsickle_type.js")),
             ImmutableList.of(input("tsickle_emit.skip.tsickle.js")))
-        .generatesDeclarations(expected);
+        .generatesDeclarations(golden);
   }
 
   @Test
   public void skipEmitWithTypedefs() throws Exception {
-    String expected = DeclarationGeneratorTests.getTestFileText(input("skipped.d.ts"));
+    File golden = input("skipped.d.ts");
     assertThatProgram(
             ImmutableList.of(input("uses_type.js")),
             ImmutableList.of(input("skipped_typedef.skip.tsickle.js")))
-        .generatesDeclarations(expected);
+        .generatesDeclarations(golden);
   }
 
   @Test
   public void multifilePartial() throws Exception {
-    String expected = DeclarationGeneratorTests.getTestFileText(input("total.d.ts"));
+    File golden = input("total.d.ts");
     assertThatProgram(
             ImmutableList.of(input("missing_imported_base.js")),
             ImmutableList.of(
                 input("named_base_exporter.js"),
                 input("default_base_exporter.js"),
                 input("default_object_exporter.js")))
-        .generatesDeclarations(expected);
+        .generatesDeclarations(golden);
   }
 
   private File input(String filename) {

--- a/src/test/java/com/google/javascript/clutz/ProgramSubject.java
+++ b/src/test/java/com/google/javascript/clutz/ProgramSubject.java
@@ -86,6 +86,9 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
     String expectedClean =
         DeclarationGeneratorTests.GOLDEN_FILE_COMMENTS_REGEXP.matcher(expected).replaceAll("");
     if (!stripped.equals(expectedClean)) {
+      // If the `UPDATE_GOLDENS` flag is set, overwrite the golden files, unless it's a `_with_platform.d.ts`
+      // which have 2 golden files that are concatenated, or if the golden has comments, both of which
+      // shouldn't be blindly overwritten
       if (System.getenv("UPDATE_GOLDENS") != null
           && !golden.getName().endsWith("_with_platform.d.ts")
           && expected.equals(expectedClean)) {


### PR DESCRIPTION
Passing the environment variable UPDATE_GOLDENS=y when running declaration generators now auto updates all goldens.  _with_platform goldens and goldens with comments are exempted, so as not to mess things up.