### PR TITLE
Use fake incremental numbers for numeric enums.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -1665,8 +1665,11 @@ class DeclarationGenerator {
         emit("{");
         emitBreak();
         indent();
+        int i = 0;
         for (String elem : sorted(type.getElements())) {
           emit(elem);
+          emit("=");
+          emit(String.valueOf(++i));
           emit(",");
           emitBreak();
         }

--- a/src/test/java/com/google/javascript/clutz/aliased_enums.d.ts
+++ b/src/test/java/com/google/javascript/clutz/aliased_enums.d.ts
@@ -8,7 +8,7 @@ declare module 'goog:nested.bar.HahaEnum' {
 }
 declare namespace ಠ_ಠ.clutz.nested.baz {
   enum Enum {
-    A ,
+    A = 1 ,
   }
 }
 declare module 'goog:nested.baz.Enum' {

--- a/src/test/java/com/google/javascript/clutz/enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/enum.d.ts
@@ -11,8 +11,8 @@ declare module 'goog:some.ObjectValuedEnum' {
 }
 declare namespace ಠ_ಠ.clutz.some {
   enum SomeEnum {
-    A ,
-    B ,
+    A = 1 ,
+    B = 2 ,
   }
 }
 declare module 'goog:some.SomeEnum' {

--- a/src/test/java/com/google/javascript/clutz/enum_with_method.d.ts
+++ b/src/test/java/com/google/javascript/clutz/enum_with_method.d.ts
@@ -1,7 +1,7 @@
 declare namespace ಠ_ಠ.clutz.enums {
   enum EnumWithMethod {
-    APPLE ,
-    BANANA ,
+    APPLE = 1 ,
+    BANANA = 2 ,
   }
 }
 declare module 'goog:enums.EnumWithMethod' {

--- a/src/test/java/com/google/javascript/clutz/extern_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/extern_enum.d.ts
@@ -1,5 +1,5 @@
 declare namespace ಠ_ಠ.clutz.ns {
   enum Enum {
-    A ,
+    A = 1 ,
   }
 }

--- a/src/test/java/com/google/javascript/clutz/interface.d.ts
+++ b/src/test/java/com/google/javascript/clutz/interface.d.ts
@@ -18,8 +18,8 @@ declare module 'goog:interface_exp' {
 }
 declare namespace ಠ_ಠ.clutz.interface_exp {
   enum SomeEnum {
-    A ,
-    B ,
+    A = 1 ,
+    B = 2 ,
   }
 }
 declare module 'goog:interface_exp.SomeEnum' {

--- a/src/test/java/com/google/javascript/clutz/nested_typedef_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/nested_typedef_enum.d.ts
@@ -7,7 +7,7 @@ declare module 'goog:nested_typedef_enum.Bar' {
 }
 declare namespace ಠ_ಠ.clutz.nested_typedef_enum.Bar {
   enum Baz {
-    A ,
+    A = 1 ,
   }
 }
 declare module 'goog:nested_typedef_enum.Bar.Baz' {

--- a/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
@@ -18,8 +18,8 @@ declare namespace ಠ_ಠ.clutz.foo.bar.Baz {
     private noStructuralTyping_: any;
   }
   enum NestedEnum {
-    A ,
-    B ,
+    A = 1 ,
+    B = 2 ,
   }
 }
 declare module 'goog:foo.bar.Baz' {

--- a/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch_nested_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch_nested_type.d.ts
@@ -6,7 +6,7 @@ declare namespace ಠ_ಠ.clutz.sim_nested {
 }
 declare namespace ಠ_ಠ.clutz.sim_nested.Child {
   enum Nested {
-    B ,
+    B = 1 ,
   }
 }
 declare module 'goog:sim_nested.Child' {
@@ -15,7 +15,7 @@ declare module 'goog:sim_nested.Child' {
 }
 declare namespace ಠ_ಠ.clutz.sim_nested.Child {
   enum NestedAndProvided {
-    B ,
+    B = 1 ,
   }
 }
 declare module 'goog:sim_nested.Child.NestedAndProvided' {

--- a/src/test/java/com/google/javascript/clutz/static_provided.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_provided.d.ts
@@ -11,8 +11,8 @@ declare module 'goog:a.b.StaticHolder' {
 }
 declare namespace ಠ_ಠ.clutz.a.b.StaticHolder {
   enum AnEnum {
-    X ,
-    Y ,
+    X = 1 ,
+    Y = 2 ,
   }
 }
 declare module 'goog:a.b.StaticHolder.AnEnum' {


### PR DESCRIPTION
The value shouldn't really matter, but one should note that these values are not the real ones.
It would be possible to do myEnum=3 even if 3 is not in the enum when doing this is how real protos behave anyways.

Fixes #663