### PR TITLE
Add goog.provide to the Logger symbols in partial_base.

### DIFF
--- a/src/resources/partial_goog_base.js
+++ b/src/resources/partial_goog_base.js
@@ -13,26 +13,3 @@ var goog = goog || {};
  */
 goog.abstractMethod = function() {
 };
-
-/**
- * goog.debug.Logger, goog.debug.Logger.Level, goog.debug.LogRecord are from
- * closure's log.js, and are used in a weird aliasing pattern that closure doesn't
- * handle in partial mode.
- */
-/**
- * @constructor
- */
-goog.debug.Logger = function () {
-};
-
-/**
- * @constructor
- */
-goog.debug.Logger.Level = function () {
-};
-
-/**
- * @constructor
- */
-goog.debug.LogRecord = function () {
-};

--- a/src/test/java/com/google/javascript/clutz/partial/goog_debug.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/goog_debug.d.ts
@@ -1,0 +1,8 @@
+declare namespace ಠ_ಠ.clutz.goog.debug {
+  //!! Intentionally missing Logger.
+  var foo : number ;
+}
+declare module 'goog:goog.debug' {
+  import alias = ಠ_ಠ.clutz.goog.debug;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/goog_debug.js
+++ b/src/test/java/com/google/javascript/clutz/partial/goog_debug.js
@@ -1,0 +1,15 @@
+goog.provide('goog.debug');
+
+
+//!! In the closure library, one file debug/debug.js - goog.provides('goog.debug'),
+//!! another debug/logger goog.provides('goog.debug.Logger').
+//!!
+//!! We have some workaround so that every incremental clutz run knows that
+//!! there exists a goog.debug.Logger. However, extra caution is needed to
+//!! make sure that goog.debug.Logger does not appear in the base debug/debug.js
+//!! file emit.
+//!!
+//!! Emitting goog.debug.Logger in two .d.ts files causes conflicts.
+
+/** @const */
+goog.debug = {foo: 0};


### PR DESCRIPTION
This fixes the issue that Logger starts to appear in goog.debug
namespace. However, now we have to exclude partial_base from
debug/logger compilations, which also sucks :( WIP