### PR TITLE
Goog.require ambiguity rewriting now works for generic type params.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/partial/renaming_with_generics.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/renaming_with_generics.d.ts
@@ -1,0 +1,8 @@
+declare namespace ಠ_ಠ.clutz.module$exports$renaming$with$generics {
+  var x : angular.IPromise < module$exports$other$module > | null ;
+  var y : angular.IPromise < module$exports$other$module$destruct.D > | null ;
+}
+declare module 'goog:renaming.with.generics' {
+  import alias = ಠ_ಠ.clutz.module$exports$renaming$with$generics;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/renaming_with_generics.js
+++ b/src/test/java/com/google/javascript/clutz/partial/renaming_with_generics.js
@@ -1,0 +1,10 @@
+goog.module('renaming.with.generics');
+
+const C = goog.require('other.module');
+const {D} = goog.require('other.module.destruct');
+
+/** @type {angular.IPromise<!C>} */
+exports.x = null;
+
+/** @type {angular.IPromise<!D>} */
+exports.y = null;


### PR DESCRIPTION
The rewriter logic is now hooked in one more symbol emit code path.