### PR TITLE
Make the knownGoogProvides whitelist work with destructuring imports.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/ImportRenameMapBuilder.java
+++ b/src/main/java/com/google/javascript/clutz/ImportRenameMapBuilder.java
@@ -195,7 +195,7 @@ public class ImportRenameMapBuilder {
           if (!knownGoogProvides.contains(importedModuleId)) {
             exportedSymbolName = buildNamedExportSymbolName(importedModuleId, originalName);
           } else {
-            exportedSymbolName = importedModuleId;
+            exportedSymbolName = importedModuleId + "." + originalName;
           }
           importRenameMap.put(variableName, exportedSymbolName);
           // If there's a local module id, a goog.module is being processed, so there needs to be a

--- a/src/test/java/com/google/javascript/clutz/DeclarationGeneratorTests.java
+++ b/src/test/java/com/google/javascript/clutz/DeclarationGeneratorTests.java
@@ -82,7 +82,8 @@ public class DeclarationGeneratorTests {
         subject.partialInput = true;
       }
       if (input.getParentFile().getName().equals("partialCrossModuleTypeImports")) {
-        subject.knownGoogProvides = ImmutableSet.of("googprovide.exporter");
+        subject.knownGoogProvides =
+            ImmutableSet.of("googprovide.exporter", "goog.legacy.namespace.exporter");
       }
       subject.extraExternFile = getExternFileNameOrNull(input.getName());
       suite.addTest(new DeclarationTest(input.getName(), golden, subject));

--- a/src/test/java/com/google/javascript/clutz/MultiFileTest.java
+++ b/src/test/java/com/google/javascript/clutz/MultiFileTest.java
@@ -100,7 +100,8 @@ public class MultiFileTest {
     File golden = input("total.d.ts");
     assertThatProgram(
             ImmutableList.of(input("goog_module_importer.js")),
-            ImmutableList.of(input("goog_provide_exporter.js")))
+            ImmutableList.of(
+                input("goog_provide_exporter.js"), input("goog_legacy_namespace_exporter.js")))
         .generatesDeclarations(golden);
   }
 

--- a/src/test/java/com/google/javascript/clutz/partialCrossModuleTypeImports/goog_legacy_namespace_exporter.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partialCrossModuleTypeImports/goog_legacy_namespace_exporter.d.ts
@@ -1,0 +1,24 @@
+declare namespace ಠ_ಠ.clutz.goog.legacy.namespace.exporter {
+  type LegacyBaseClass = ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_LegacyBaseClass ;
+  var LegacyBaseClass : typeof ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_LegacyBaseClass ;
+  type OriginalName = ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_OriginalName ;
+  var OriginalName : typeof ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_OriginalName ;
+}
+declare module 'goog:goog.legacy.namespace.exporter' {
+  import alias = ಠ_ಠ.clutz.goog.legacy.namespace.exporter;
+  export = alias;
+}
+declare namespace ಠ_ಠ.clutz {
+  class module$contents$goog$legacy$namespace$exporter_LegacyBaseClass extends module$contents$goog$legacy$namespace$exporter_LegacyBaseClass_Instance {
+  }
+  class module$contents$goog$legacy$namespace$exporter_LegacyBaseClass_Instance {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz {
+  class module$contents$goog$legacy$namespace$exporter_OriginalName extends module$contents$goog$legacy$namespace$exporter_OriginalName_Instance {
+  }
+  class module$contents$goog$legacy$namespace$exporter_OriginalName_Instance {
+    private noStructuralTyping_: any;
+  }
+}

--- a/src/test/java/com/google/javascript/clutz/partialCrossModuleTypeImports/goog_legacy_namespace_exporter.js
+++ b/src/test/java/com/google/javascript/clutz/partialCrossModuleTypeImports/goog_legacy_namespace_exporter.js
@@ -1,0 +1,13 @@
+goog.module("goog.legacy.namespace.exporter");
+//!! legacy namespace vs. goog.provide not relevant to the test, just the first
+//!! instance of destructuring a namespace require was a legacy namespace.
+goog.module.declareLegacyNamespace();
+
+/**@constructor */
+function LegacyBaseClass() {}
+
+/**@constructor */
+function OriginalName() {}
+
+exports.LegacyBaseClass = LegacyBaseClass;
+exports.OriginalName = OriginalName;

--- a/src/test/java/com/google/javascript/clutz/partialCrossModuleTypeImports/goog_module_importer.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partialCrossModuleTypeImports/goog_module_importer.d.ts
@@ -1,7 +1,17 @@
 declare namespace ಠ_ಠ.clutz.module$exports$goog$module$importer {
+  class ClassExtendingLegacyBaseClass extends ClassExtendingLegacyBaseClass_Instance {
+  }
+  class ClassExtendingLegacyBaseClass_Instance extends goog.legacy.namespace.exporter.LegacyBaseClass {
+    constructor ( ) ;
+  }
   class ClassExtendingMissingRequire extends ClassExtendingMissingRequire_Instance {
   }
   class ClassExtendingMissingRequire_Instance extends googprovide.exporter {
+    constructor ( ) ;
+  }
+  class ClassExtendingRename extends ClassExtendingRename_Instance {
+  }
+  class ClassExtendingRename_Instance extends goog.legacy.namespace.exporter.OriginalName {
     constructor ( ) ;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/partialCrossModuleTypeImports/goog_module_importer.js
+++ b/src/test/java/com/google/javascript/clutz/partialCrossModuleTypeImports/goog_module_importer.js
@@ -9,4 +9,22 @@ function ClassExtendingMissingRequire() {
 
 }
 
+const {LegacyBaseClass, OriginalName: Rename} = goog.require('goog.legacy.namespace.exporter');
+/**
+ * @constructor
+ * @extends {LegacyBaseClass}
+ */
+function ClassExtendingLegacyBaseClass() {
+
+}
+/**
+ * @constructor
+ * @extends {Rename}
+ */
+function ClassExtendingRename() {
+
+}
+
 exports.ClassExtendingMissingRequire = ClassExtendingMissingRequire;
+exports.ClassExtendingLegacyBaseClass = ClassExtendingLegacyBaseClass;
+exports.ClassExtendingRename = ClassExtendingRename;

--- a/src/test/java/com/google/javascript/clutz/partialCrossModuleTypeImports/total.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partialCrossModuleTypeImports/total.d.ts
@@ -1,7 +1,15 @@
 declare namespace ಠ_ಠ.clutz.module$exports$goog$module$importer {
+  class ClassExtendingLegacyBaseClass extends ClassExtendingLegacyBaseClass_Instance {
+  }
+  class ClassExtendingLegacyBaseClass_Instance extends module$contents$goog$legacy$namespace$exporter_LegacyBaseClass_Instance {
+  }
   class ClassExtendingMissingRequire extends ClassExtendingMissingRequire_Instance {
   }
   class ClassExtendingMissingRequire_Instance extends ಠ_ಠ.clutz.googprovide.exporter_Instance {
+  }
+  class ClassExtendingRename extends ClassExtendingRename_Instance {
+  }
+  class ClassExtendingRename_Instance extends module$contents$goog$legacy$namespace$exporter_OriginalName_Instance {
   }
 }
 declare module 'goog:goog.module.importer' {
@@ -12,6 +20,20 @@ declare namespace ಠ_ಠ.clutz.googprovide {
   class exporter extends exporter_Instance {
   }
   class exporter_Instance {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz {
+  class module$contents$goog$legacy$namespace$exporter_LegacyBaseClass extends module$contents$goog$legacy$namespace$exporter_LegacyBaseClass_Instance {
+  }
+  class module$contents$goog$legacy$namespace$exporter_LegacyBaseClass_Instance {
+    private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz {
+  class module$contents$goog$legacy$namespace$exporter_OriginalName extends module$contents$goog$legacy$namespace$exporter_OriginalName_Instance {
+  }
+  class module$contents$goog$legacy$namespace$exporter_OriginalName_Instance {
     private noStructuralTyping_: any;
   }
 }


### PR DESCRIPTION
Previously all symbols in the knownGoogProvides list were aliased to the bare namespace, but if the import is destructured, need to alias to namespace + symbol name.