### PR TITLE
Refactor the known class aliases code to handle goog modules with class aliases.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -17,7 +17,6 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
@@ -222,25 +221,6 @@ class DeclarationGenerator {
           "void",
           "while",
           "with");
-
-  /**
-   * Incremental clutz cannot infer class aliases like:
-   *
-   * <pre>
-   *   /** @constructor *
-   *   an.KlassAlias = some.Missing;
-   * </pre>
-   *
-   * Closure reports an.KlassAlias as regular empty class. In order to emit the correct clutz
-   * description for now we work-around this issue by hardcoding some known aliases.
-   *
-   * <p>So far this works only for classes with no generic type parameters.
-   */
-  private static final ImmutableMap<String, String> KNOWN_CLASS_ALIASES =
-      ImmutableMap.of(
-          "goog.log.Logger", "goog.debug.Logger",
-          "goog.log.Level", "goog.debug.Logger.Level",
-          "goog.log.LogRecord", "goog.debug.LogRecord");
 
   private static final String GOOG_BASE_NAMESPACE = "goog";
 
@@ -1364,6 +1344,12 @@ class DeclarationGenerator {
       if (type.isFunctionType() && !isNewableFunctionType((FunctionType) type)) {
         FunctionType ftype = (FunctionType) type;
 
+        if (opts.knownClassAliases.containsKey(symbol.getName())) {
+          visitKnownTypeValueAlias(
+              getUnqualifiedName(symbol), opts.knownClassAliases.get(symbol.getName()));
+          return;
+        }
+
         if (isOrdinaryFunction(ftype)) {
           maybeEmitJsDoc(symbol.getJSDocInfo(), /* ignoreParams */ false);
           visitFunctionExpression(getUnqualifiedName(symbol), ftype);
@@ -1378,12 +1364,7 @@ class DeclarationGenerator {
         if (!isAliasedClassOrInterface(symbol, ftype)) {
           visitClassOrInterface(getUnqualifiedName(symbol), ftype);
         } else {
-          if (KNOWN_CLASS_ALIASES.containsKey(symbol.getName())) {
-            visitKnownTypeValueAlias(
-                getUnqualifiedName(symbol), KNOWN_CLASS_ALIASES.get(symbol.getName()));
-          } else {
-            visitTypeValueAlias(getUnqualifiedName(symbol), ftype);
-          }
+          visitTypeValueAlias(getUnqualifiedName(symbol), ftype);
         }
       } else {
         maybeEmitJsDoc(symbol.getJSDocInfo(), /* ignoreParams */ false);
@@ -3103,7 +3084,7 @@ class DeclarationGenerator {
     String symbolName = symbol.getName();
     String typeName = type.getDisplayName();
     // Turns out that for aliases the symbol and type name differ.
-    return !symbolName.equals(typeName) || KNOWN_CLASS_ALIASES.containsKey(symbolName);
+    return !symbolName.equals(typeName);
   }
 
   private void emitSkipTypeAlias(TypedVar symbol) {

--- a/src/test/java/com/google/javascript/clutz/OptionsTest.java
+++ b/src/test/java/com/google/javascript/clutz/OptionsTest.java
@@ -143,4 +143,27 @@ public class OptionsTest {
             });
     assertThat(opts.knownGoogProvides).containsExactly("foo.bar", "baz.quux");
   }
+
+  @Test
+  public void testKnownClassAliases() throws Exception {
+    Options opts =
+        new Options(
+            new String[] {
+              "foo.js",
+              "--knownClassAliases",
+              DeclarationGeneratorTests.getTestInputFile("test_known_class_aliases")
+                  .toFile()
+                  .toString()
+            });
+    assertThat(opts.knownClassAliases)
+        .containsExactly(
+            "goog.log.Logger",
+            "goog.debug.Logger",
+            "goog.log.Level",
+            "goog.debug.Logger.Level",
+            "goog.log.LogRecord",
+            "goog.debug.LogRecord",
+            "module$exports$bare$reexport",
+            "module$exports$original$module.Class");
+  }
 }

--- a/src/test/java/com/google/javascript/clutz/ProgramSubject.java
+++ b/src/test/java/com/google/javascript/clutz/ProgramSubject.java
@@ -7,6 +7,7 @@ import static java.util.Collections.singletonList;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.google.common.truth.FailureStrategy;
@@ -117,6 +118,13 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
     if (knownGoogProvides != null) {
       opts.knownGoogProvides = knownGoogProvides;
     }
+    opts.knownClassAliases =
+        ImmutableMap.of(
+            "goog.log.Logger", "goog.debug.Logger",
+            "goog.log.Level", "goog.debug.Logger.Level",
+            "goog.log.LogRecord", "goog.debug.LogRecord",
+            "module$exports$bare$reexport", "module$exports$original$module.Class");
+
     List<SourceFile> sourceFiles = new ArrayList<>();
 
     // base.js is needed for the type declaration of goog.require for

--- a/src/test/java/com/google/javascript/clutz/partial/bare_reexport.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/bare_reexport.d.ts
@@ -1,0 +1,8 @@
+declare namespace ಠ_ಠ.clutz {
+  type module$exports$bare$reexport = ಠ_ಠ.clutz.module$exports$original$module.Class ;
+  var module$exports$bare$reexport : typeof ಠ_ಠ.clutz.module$exports$original$module.Class ;
+}
+declare module 'goog:bare.reexport' {
+  import alias = ಠ_ಠ.clutz.module$exports$bare$reexport;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/bare_reexport.js
+++ b/src/test/java/com/google/javascript/clutz/partial/bare_reexport.js
@@ -1,0 +1,8 @@
+goog.module('bare.reexport');
+
+const {Class} = goog.require('original.module');
+
+//!! Function type annotation is necessary to get clutz to take the branch that
+//!! uses the known_class_aliases
+/** @type {!Function} */
+exports = Class;

--- a/src/test/java/com/google/javascript/clutz/test_known_class_aliases
+++ b/src/test/java/com/google/javascript/clutz/test_known_class_aliases
@@ -1,0 +1,4 @@
+goog.log.Logger,goog.debug.Logger
+goog.log.Level,goog.debug.Logger.Level
+goog.log.LogRecord,goog.debug.LogRecord
+module$exports$bare$reexport,module$exports$original$module.Class


### PR DESCRIPTION
The goog.module requires a type annotation to work, and the known class aliases map is read in from a file instead of being hard coded.