### PR TITLE
mark tests as using the junit runner

### DIFF
--- a/src/test/java/com/google/javascript/clutz/ClutzErrorManagerTest.java
+++ b/src/test/java/com/google/javascript/clutz/ClutzErrorManagerTest.java
@@ -3,7 +3,10 @@ package com.google.javascript.clutz;
 import static com.google.javascript.clutz.ProgramSubject.assertThatProgram;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class ClutzErrorManagerTest {
 
   @Test

--- a/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
+++ b/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
@@ -17,10 +17,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * A test that checks the syntax of all {@code .d.ts} files using {@code tsc}, as a sanity check.
  */
+@RunWith(JUnit4.class)
 public class DeclarationSyntaxTest {
   private static final FilenameFilter TS_SOURCES_WITHOUT_PLATFORM_EXTERNS =
       new FilenameFilter() {

--- a/src/test/java/com/google/javascript/clutz/DepgraphTest.java
+++ b/src/test/java/com/google/javascript/clutz/DepgraphTest.java
@@ -5,7 +5,10 @@ import static com.google.common.truth.Truth.assertThat;
 import java.nio.file.Path;
 import java.util.Collections;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class DepgraphTest {
 
   static final Path DEPGRAPH_PATH = DeclarationGeneratorTests.getTestInputFile("closure.depgraph");

--- a/src/test/java/com/google/javascript/clutz/MultiFileTest.java
+++ b/src/test/java/com/google/javascript/clutz/MultiFileTest.java
@@ -11,7 +11,10 @@ import java.util.Collections;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class MultiFileTest {
 
   @Rule public TestName name = new TestName();

--- a/src/test/java/com/google/javascript/clutz/OptionsTest.java
+++ b/src/test/java/com/google/javascript/clutz/OptionsTest.java
@@ -6,8 +6,11 @@ import static org.junit.Assert.*;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.kohsuke.args4j.CmdLineException;
 
+@RunWith(JUnit4.class)
 public class OptionsTest {
 
   @Test


### PR DESCRIPTION
There's a check within google3 that wants this annotation.
It appears to be harmless(?) to add it.