### PR TITLE
add a whitelist for aliasing goog.provides

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Constants.java
+++ b/src/main/java/com/google/javascript/clutz/Constants.java
@@ -14,5 +14,5 @@ public interface Constants {
    * The alias does not affect the external module declaration, thus the user can still import the
    * symbol using unaliased module name (i.e. import bar from 'goog:foo.bar').
    */
-  static final String SYMBOL_ALIAS_POSTFIX = "__clutz_alias";
+  static final String COLLDING_PROVIDE_ALIAS_POSTFIX = "__clutz_alias";
 }

--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -151,6 +151,12 @@ public class Options {
   /** Mappings should be comma separated, with no spaces, one mapping per line */
   String knownClassAliasesFile = null;
 
+  @Option(
+    name = "--collidingProvides",
+    usage = "file containing a list of names that we know conflict with namespaces"
+  )
+  String collidingProvidesFile = null;
+
   @Argument List<String> arguments = new ArrayList<>();
 
   Depgraph depgraph;
@@ -158,6 +164,7 @@ public class Options {
   // library that supports Pattern arguments.
   Pattern skipEmitPattern;
   Set<String> knownGoogProvides = new HashSet<>();
+  Set<String> collidingProvides = new HashSet<>();
 
   /**
    * Incremental clutz cannot infer class aliases like:
@@ -265,6 +272,14 @@ public class Options {
       } catch (IOException e) {
         throw new RuntimeException(
             "Error reading known class aliases file " + knownClassAliasesFile, e);
+      }
+    }
+
+    if (collidingProvidesFile != null) {
+      try {
+        collidingProvides.addAll(Files.readLines(new File(collidingProvidesFile), UTF_8));
+      } catch (IOException e) {
+        throw new RuntimeException("Error reading aliased names file " + collidingProvidesFile, e);
       }
     }
   }

--- a/src/test/java/com/google/javascript/clutz/ProgramSubject.java
+++ b/src/test/java/com/google/javascript/clutz/ProgramSubject.java
@@ -8,6 +8,7 @@ import static java.util.Collections.singletonList;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.google.common.truth.FailureMetadata;
@@ -124,6 +125,7 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
             "goog.log.Level", "goog.debug.Logger.Level",
             "goog.log.LogRecord", "goog.debug.LogRecord",
             "module$exports$bare$reexport", "module$exports$original$module.Class");
+    opts.collidingProvides = ImmutableSet.of("colliding_provide.aliased");
 
     List<SourceFile> sourceFiles = new ArrayList<>();
 

--- a/src/test/java/com/google/javascript/clutz/partial/colliding_provide.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/colliding_provide.d.ts
@@ -1,0 +1,14 @@
+declare namespace ಠ_ಠ.clutz.colliding_provide {
+  var aliased__clutz_alias : any;
+}
+declare module 'goog:colliding_provide.aliased' {
+  import alias = ಠ_ಠ.clutz.colliding_provide.aliased__clutz_alias;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.colliding_provide {
+  var not_aliased : any;
+}
+declare module 'goog:colliding_provide.not_aliased' {
+  import alias = ಠ_ಠ.clutz.colliding_provide.not_aliased;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/colliding_provide.js
+++ b/src/test/java/com/google/javascript/clutz/partial/colliding_provide.js
@@ -1,0 +1,9 @@
+// This first module name is special-cased in the test framework to trigger the aliasing
+// behavior.  Imagine there's some other file that has a goog.provide of
+// colliding_provide.aliased.submodule.
+goog.provide('colliding_provide.aliased');
+// This module name is not special-cased, for comparison in the output.
+goog.provide('colliding_provide.not_aliased');
+
+colliding_provide.aliased = 1;
+colliding_provide.not_aliased = 1;


### PR DESCRIPTION
If a file A has
  goog.provide('mything');
  mything = 3;
and a file B has
  goog.provide('mything.subnamespace');
  mything.subnamespace = 4;

Then the code is nonsense but clutz has a workaround anyway.

In partial mode we look at A without knowledge of B, so we cannot apply
the workaround without providing a global set of broken inputs like
these.  This change adds support for the global set and hooks it up to
a command-line flag.