### PR TITLE
Better bare reexport

### DIFF
--- a/src/main/java/com/google/javascript/clutz/AliasMapBuilder.java
+++ b/src/main/java/com/google/javascript/clutz/AliasMapBuilder.java
@@ -1,0 +1,89 @@
+package com.google.javascript.clutz;
+
+import com.google.javascript.rhino.Node;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Closure doesn't handle alias reexports like the following well:
+ *
+ * <p>`goog.module('bare.reexport'); const {Class} = goog.require('original.module'); exports =
+ * Class;`
+ *
+ * <p>It completely ignores the goog.require() and gives Class the unknown {?} type.
+ *
+ * <p>AliasMapBuilder looks for goog.require statements and generates mappings from the exported
+ * name of Class (here module$exports$bare$reexport) to the name of the imported symbol (here
+ * module$exports$original$module.Class), so if clutz finds a symbol that has no type, it can emit
+ * it as an alias to the correct symbol.
+ */
+public class AliasMapBuilder extends ImportBasedMapBuilder {
+  @Override
+  protected Map<String, String> build(
+      String localModuleId, Node moduleBody, Set<String> knownGoogProvides) {
+    Map<String, String> aliasMap = new HashMap<>();
+    if (localModuleId == null) {
+      //TODO(lucassloan): handle goog.module.get()
+      return aliasMap;
+    }
+
+    for (Node statement : moduleBody.children()) {
+      if (isImportAssignment(statement)) {
+        // `const C = goog.require()` or
+        // `const C = goog.module.get()`
+        String importedModuleId = statement.getFirstFirstChild().getChildAtIndex(1).getString();
+        String variableName = statement.getFirstChild().getString();
+
+        String exportedSymbolName = buildWholeModuleExportSymbolName(importedModuleId);
+        aliasMap.putAll(
+            buildNamedAndWholeModuleMappings(localModuleId, variableName, exportedSymbolName));
+
+      } else if (isImportDestructuringAssignment(statement)) {
+        // `const {C, Clazz: RenamedClazz} = goog.require()` or
+        // `const {C, Clazz: RenamedClazz} = goog.module.get()`
+        String importedModuleId =
+            statement.getFirstChild().getChildAtIndex(1).getChildAtIndex(1).getString();
+        for (Node destructured : statement.getFirstFirstChild().children()) {
+          String originalName = destructured.getString();
+          // Destructuring can use the original name `const {A} = goog.require("foo.a")` or rename
+          // it `const {A: RenamedA} = ...`, and closure uses whichever in the symbol name it
+          // generates, so we have to extract it.
+          String variableName;
+          if (destructured.getFirstChild() != null) {
+            // Renaming
+            variableName = destructured.getFirstChild().getString();
+          } else {
+            // No rename
+            variableName = originalName;
+          }
+
+          String exportedSymbolName = buildNamedExportSymbolName(importedModuleId, originalName);
+          aliasMap.putAll(
+              buildNamedAndWholeModuleMappings(localModuleId, variableName, exportedSymbolName));
+        }
+      }
+    }
+
+    return aliasMap;
+  }
+
+  /**
+   * To avoid parsing for the export statements, generate mappings for both styles of exports from
+   * goog.modules.
+   *
+   * <p>`exports = Foo` produces the name `module$exports$module$Name` `exports.Foo = Foo` produces
+   * the name `module$exports$module$Name.Foo`
+   */
+  private static Map<String, String> buildNamedAndWholeModuleMappings(
+      String localModuleId, String variableName, String exportedSymbolName) {
+    //TODO(lucassloan): handle knownGoogProvides
+    Map<String, String> mappings = new HashMap<>();
+    // exports = Foo
+    mappings.put(buildWholeModuleExportSymbolName(localModuleId), exportedSymbolName);
+    // exports.Foo = Foo
+    mappings.put(buildNamedExportSymbolName(localModuleId, variableName), exportedSymbolName);
+
+    return mappings;
+  }
+}

--- a/src/main/java/com/google/javascript/clutz/ImportBasedMapBuilder.java
+++ b/src/main/java/com/google/javascript/clutz/ImportBasedMapBuilder.java
@@ -1,0 +1,166 @@
+package com.google.javascript.clutz;
+
+import com.google.javascript.rhino.Node;
+import java.util.*;
+
+/**
+ * ImportBasedMapBuilder is a base class for walking the closure AST and gathering information about
+ * imports and exports that the closure compiler doesn't give access to in incremental mode.
+ */
+public abstract class ImportBasedMapBuilder {
+  protected abstract Map<String, String> build(
+      String localModuleId, Node moduleBody, Set<String> knownGoogProvides);
+
+  /**
+   * Build takes a collection of parsed inputs and walks the ast to find any imports into local
+   * variables to build a map based on the concrete class's implementation of build.
+   */
+  public Map<String, String> build(Collection<Node> parsedInputs, Set<String> knownGoogProvides) {
+    Map<String, String> importRenameMap = new HashMap<>();
+    for (Node ast : parsedInputs) {
+      // Symbols can be imported into a variable in a goog.module() file, so look for imports in the
+      // body of the goog module.
+      String moduleId = getGoogModuleId(ast);
+      if (moduleId != null) {
+        importRenameMap.putAll(build(moduleId, ast.getFirstChild(), knownGoogProvides));
+      }
+
+      // Or symbols can be imported into a variable in a top-level goog.scope() block, so look for
+      // imports in the bodies of any goog scopes.
+      List<Node> googScopes = getTopLevelGoogScopes(ast);
+      if (!googScopes.isEmpty()) {
+        for (Node googScope : googScopes) {
+          importRenameMap.putAll(build(null, googScope, knownGoogProvides));
+        }
+      }
+    }
+    return importRenameMap;
+  }
+
+  protected static List<Node> getTopLevelGoogScopes(Node astRoot) {
+    List<Node> googScopes = new ArrayList<>();
+    for (Node statement : astRoot.children()) {
+      if (isGoogScopeCall(statement)) {
+        googScopes.add(statement.getFirstChild().getChildAtIndex(1).getChildAtIndex(2));
+      }
+    }
+    return googScopes;
+  }
+
+  protected static boolean isGoogScopeCall(Node statement) {
+    if (!statement.isExprResult()) {
+      return false;
+    }
+
+    Node expression = statement.getFirstChild();
+    return expression.isCall() && expression.getFirstChild().matchesQualifiedName("goog.scope");
+  }
+
+  protected static boolean isGoogModuleCall(Node statement) {
+    if (!statement.isExprResult()) {
+      return false;
+    }
+
+    Node expression = statement.getFirstChild();
+    return expression.isCall() && expression.getFirstChild().matchesQualifiedName("goog.module");
+  }
+
+  /**
+   * Matches either `const foo = goog.require()` or `const foo = goog.module.get()` depending on if
+   * statement is in a goog.module or a goog.scope.
+   */
+  protected static boolean isImportAssignment(Node statement) {
+    if (!(statement.isConst() || statement.isVar() || statement.isLet())) {
+      return false;
+    }
+
+    Node rightHandSide = statement.getFirstFirstChild();
+
+    return rightHandSide != null
+        && rightHandSide.isCall()
+        && (rightHandSide.getFirstChild().matchesQualifiedName("goog.require")
+            || rightHandSide.getFirstChild().matchesQualifiedName("goog.module.get"));
+  }
+
+  /** Matches destructing from a variable ie `const {foo, bar: baz} = quux;` */
+  protected static boolean isVariableDestructuringAssignment(Node statement) {
+    if (!(statement.isConst() || statement.isVar() || statement.isLet())) {
+      return false;
+    }
+
+    if (!statement.getFirstChild().isDestructuringLhs()) {
+      return false;
+    }
+
+    Node destructuringAssignment = statement.getFirstChild();
+
+    Node rightHandSide = destructuringAssignment.getChildAtIndex(1);
+
+    return rightHandSide.isName();
+  }
+
+  /**
+   * Matches either `const {foo} = goog.require()` or `const {foo} = goog.module.get()` depending on
+   * if statement is in a goog.module or a goog.scope.
+   */
+  protected static boolean isImportDestructuringAssignment(Node statement) {
+    if (!(statement.isConst() || statement.isVar() || statement.isLet())) {
+      return false;
+    }
+
+    if (!statement.getFirstChild().isDestructuringLhs()) {
+      return false;
+    }
+
+    Node destructuringAssignment = statement.getFirstChild();
+
+    Node rightHandSide = destructuringAssignment.getChildAtIndex(1);
+
+    return rightHandSide.isCall()
+        && (rightHandSide.getFirstChild().matchesQualifiedName("goog.require")
+            || rightHandSide.getFirstChild().matchesQualifiedName("goog.module.get"));
+  }
+
+  protected static String getGoogModuleId(Node astRoot) {
+    if (astRoot.getFirstChild() == null || !astRoot.getFirstChild().isModuleBody()) {
+      return null;
+    }
+
+    Node moduleBody = astRoot.getFirstChild();
+    for (Node statement : moduleBody.children()) {
+      if (isGoogModuleCall(statement)) {
+        return statement.getFirstChild().getChildAtIndex(1).getString();
+      }
+    }
+    return null;
+  }
+
+  /**
+   * The exported symbol can take 2 forms - one where it refers to everything that the module
+   * exports and another where it refers to just one thing the module exports. If the original
+   * module used the `exports = ...` style, the symbol name is just the module name.
+   *
+   * <p>TODO(lucassloan): this only holds for importing from a goog.module see:
+   * https://github.com/angular/clutz/issues/596
+   */
+  protected static String buildWholeModuleExportSymbolName(String importedModuleId) {
+    return "module$exports$" + importedModuleId.replace(".", "$");
+  }
+
+  /**
+   * The exported symbol can take 2 forms - one where it refers to everything that the module
+   * exports and another where it refers to just one thing the module exports. If the original
+   * module used the `exports.foo = ...` style, the symbol name is the module name plus the
+   * individual export's name.
+   *
+   * <p>TODO(lucassloan): this only holds for importing from a goog.module see:
+   * https://github.com/angular/clutz/issues/596
+   */
+  protected static String buildNamedExportSymbolName(String importedModuleId, String originalName) {
+    return "module$exports$" + importedModuleId.replace(".", "$") + "." + originalName;
+  }
+
+  protected static String buildLocalSymbolName(String importingModuleId, String variableName) {
+    return "module$contents$" + importingModuleId.replace(".", "$") + "_" + variableName;
+  }
+}

--- a/src/main/java/com/google/javascript/clutz/ImportRenameMapBuilder.java
+++ b/src/main/java/com/google/javascript/clutz/ImportRenameMapBuilder.java
@@ -1,10 +1,7 @@
 package com.google.javascript.clutz;
 
 import com.google.javascript.rhino.Node;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -15,133 +12,7 @@ import java.util.Set;
  * original namespace (ie `module$exports$imported$file`). ImportRenameMapBuilder builds a map from
  * the local name to the exported name so the original names can be substituted.
  */
-public class ImportRenameMapBuilder {
-
-  /**
-   * Build takes a collection of parsed inputs and walks the ast to find any imports into local
-   * variables to build a map from the name closure generates in incremental mode to the exported
-   * name of the import.
-   */
-  public static Map<String, String> build(
-      Collection<Node> parsedInputs, Set<String> knownGoogProvides) {
-    Map<String, String> importRenameMap = new HashMap<>();
-    for (Node ast : parsedInputs) {
-      // Symbols can be imported into a variable in a goog.module() file, so look for imports in the
-      // body of the goog module.
-      String moduleId = getGoogModuleId(ast);
-      if (moduleId != null) {
-        importRenameMap.putAll(build(moduleId, ast.getFirstChild(), knownGoogProvides));
-      }
-
-      // Or symbols can be imported into a variable in a top-level goog.scope() block, so look for
-      // imports in the bodies of any goog scopes.
-      List<Node> googScopes = getTopLevelGoogScopes(ast);
-      if (!googScopes.isEmpty()) {
-        for (Node googScope : googScopes) {
-          importRenameMap.putAll(build(null, googScope, knownGoogProvides));
-        }
-      }
-    }
-    return importRenameMap;
-  }
-
-  private static List<Node> getTopLevelGoogScopes(Node astRoot) {
-    List<Node> googScopes = new ArrayList<>();
-    for (Node statement : astRoot.children()) {
-      if (isGoogScopeCall(statement)) {
-        googScopes.add(statement.getFirstChild().getChildAtIndex(1).getChildAtIndex(2));
-      }
-    }
-    return googScopes;
-  }
-
-  private static boolean isGoogScopeCall(Node statement) {
-    if (!statement.isExprResult()) {
-      return false;
-    }
-
-    Node expression = statement.getFirstChild();
-    return expression.isCall() && expression.getFirstChild().matchesQualifiedName("goog.scope");
-  }
-
-  private static boolean isGoogModuleCall(Node statement) {
-    if (!statement.isExprResult()) {
-      return false;
-    }
-
-    Node expression = statement.getFirstChild();
-    return expression.isCall() && expression.getFirstChild().matchesQualifiedName("goog.module");
-  }
-
-  /**
-   * Matches either `const foo = goog.require()` or `const foo = goog.module.get()` depending on if
-   * statement is in a goog.module or a goog.scope.
-   */
-  private static boolean isImportAssignment(Node statement) {
-    if (!(statement.isConst() || statement.isVar() || statement.isLet())) {
-      return false;
-    }
-
-    Node rightHandSide = statement.getFirstFirstChild();
-
-    return rightHandSide != null
-        && rightHandSide.isCall()
-        && (rightHandSide.getFirstChild().matchesQualifiedName("goog.require")
-            || rightHandSide.getFirstChild().matchesQualifiedName("goog.module.get"));
-  }
-
-  /** Matches destructing from a variable ie `const {foo, bar: baz} = quux;` */
-  private static boolean isVariableDestructuringAssignment(Node statement) {
-    if (!(statement.isConst() || statement.isVar() || statement.isLet())) {
-      return false;
-    }
-
-    if (!statement.getFirstChild().isDestructuringLhs()) {
-      return false;
-    }
-
-    Node destructuringAssignment = statement.getFirstChild();
-
-    Node rightHandSide = destructuringAssignment.getChildAtIndex(1);
-
-    return rightHandSide.isName();
-  }
-
-  /**
-   * Matches either `const {foo} = goog.require()` or `const {foo} = goog.module.get()` depending on
-   * if statement is in a goog.module or a goog.scope.
-   */
-  private static boolean isImportDestructuringAssignment(Node statement) {
-    if (!(statement.isConst() || statement.isVar() || statement.isLet())) {
-      return false;
-    }
-
-    if (!statement.getFirstChild().isDestructuringLhs()) {
-      return false;
-    }
-
-    Node destructuringAssignment = statement.getFirstChild();
-
-    Node rightHandSide = destructuringAssignment.getChildAtIndex(1);
-
-    return rightHandSide.isCall()
-        && (rightHandSide.getFirstChild().matchesQualifiedName("goog.require")
-            || rightHandSide.getFirstChild().matchesQualifiedName("goog.module.get"));
-  }
-
-  private static String getGoogModuleId(Node astRoot) {
-    if (astRoot.getFirstChild() == null || !astRoot.getFirstChild().isModuleBody()) {
-      return null;
-    }
-
-    Node moduleBody = astRoot.getFirstChild();
-    for (Node statement : moduleBody.children()) {
-      if (isGoogModuleCall(statement)) {
-        return statement.getFirstChild().getChildAtIndex(1).getString();
-      }
-    }
-    return null;
-  }
+public class ImportRenameMapBuilder extends ImportBasedMapBuilder {
 
   /**
    * Build does the actual work of walking over the AST, finding any goog.require() or
@@ -149,7 +20,7 @@ public class ImportRenameMapBuilder {
    * mappings from local symbol names to exported symbol names. If the imported module's id is in
    * knownGoogProvides, emit a rename in goog.provide style, otherwise, use goog.module style.
    */
-  private static Map<String, String> build(
+  protected Map<String, String> build(
       String localModuleId, Node moduleBody, Set<String> knownGoogProvides) {
     Map<String, String> importRenameMap = new HashMap<>();
 
@@ -242,34 +113,5 @@ public class ImportRenameMapBuilder {
     }
 
     return importRenameMap;
-  }
-
-  /**
-   * The exported symbol can take 2 forms - one where it refers to everything that the module
-   * exports and another where it refers to just one thing the module exports. If the original
-   * module used the `exports = ...` style, the symbol name is just the module name.
-   *
-   * <p>TODO(lucassloan): this only holds for importing from a goog.module see:
-   * https://github.com/angular/clutz/issues/596
-   */
-  private static String buildWholeModuleExportSymbolName(String importedModuleId) {
-    return "module$exports$" + importedModuleId.replace(".", "$");
-  }
-
-  /**
-   * The exported symbol can take 2 forms - one where it refers to everything that the module
-   * exports and another where it refers to just one thing the module exports. If the original
-   * module used the `exports.foo = ...` style, the symbol name is the module name plus the
-   * individual export's name.
-   *
-   * <p>TODO(lucassloan): this only holds for importing from a goog.module see:
-   * https://github.com/angular/clutz/issues/596
-   */
-  private static String buildNamedExportSymbolName(String importedModuleId, String originalName) {
-    return "module$exports$" + importedModuleId.replace(".", "$") + "." + originalName;
-  }
-
-  private static String buildLocalSymbolName(String importingModuleId, String variableName) {
-    return "module$contents$" + importingModuleId.replace(".", "$") + "_" + variableName;
   }
 }

--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -13,11 +13,9 @@ import com.google.javascript.jscomp.parsing.Config;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.kohsuke.args4j.Argument;
@@ -145,13 +143,6 @@ public class Options {
   String googProvidesFile = null;
 
   @Option(
-    name = "--knownClassAliases",
-    usage = "file containing a map of names that we know are aliases"
-  )
-  /** Mappings should be comma separated, with no spaces, one mapping per line */
-  String knownClassAliasesFile = null;
-
-  @Option(
     name = "--collidingProvides",
     usage = "file containing a list of names that we know conflict with namespaces"
   )
@@ -165,21 +156,6 @@ public class Options {
   Pattern skipEmitPattern;
   Set<String> knownGoogProvides = new HashSet<>();
   Set<String> collidingProvides = new HashSet<>();
-
-  /**
-   * Incremental clutz cannot infer class aliases like:
-   *
-   * <pre>
-   *   /** @constructor *
-   *   an.KlassAlias = some.Missing;
-   * </pre>
-   *
-   * Closure reports an.KlassAlias as regular empty class. In order to emit the correct clutz
-   * description for now we work-around this issue by hardcoding some known aliases.
-   *
-   * <p>So far this works only for classes with no generic type parameters.
-   */
-  Map<String, String> knownClassAliases = new HashMap<>();
 
   public CompilerOptions getCompilerOptions() {
     final CompilerOptions options = new CompilerOptions();
@@ -258,23 +234,6 @@ public class Options {
         throw new RuntimeException("Error reading goog provides file " + googProvidesFile, e);
       }
     }
-
-    if (knownClassAliasesFile != null) {
-      try {
-        for (String line : Files.readLines(new File(knownClassAliasesFile), UTF_8)) {
-          String[] alias = line.split(",");
-          if (alias.length != 2) {
-            throw new RuntimeException(
-                "Badly formatted mapping in known class aliases file: " + line);
-          }
-          knownClassAliases.put(alias[0], alias[1]);
-        }
-      } catch (IOException e) {
-        throw new RuntimeException(
-            "Error reading known class aliases file " + knownClassAliasesFile, e);
-      }
-    }
-
     if (collidingProvidesFile != null) {
       try {
         collidingProvides.addAll(Files.readLines(new File(collidingProvidesFile), UTF_8));

--- a/src/test/java/com/google/javascript/clutz/OptionsTest.java
+++ b/src/test/java/com/google/javascript/clutz/OptionsTest.java
@@ -146,27 +146,4 @@ public class OptionsTest {
             });
     assertThat(opts.knownGoogProvides).containsExactly("foo.bar", "baz.quux");
   }
-
-  @Test
-  public void testKnownClassAliases() throws Exception {
-    Options opts =
-        new Options(
-            new String[] {
-              "foo.js",
-              "--knownClassAliases",
-              DeclarationGeneratorTests.getTestInputFile("test_known_class_aliases")
-                  .toFile()
-                  .toString()
-            });
-    assertThat(opts.knownClassAliases)
-        .containsExactly(
-            "goog.log.Logger",
-            "goog.debug.Logger",
-            "goog.log.Level",
-            "goog.debug.Logger.Level",
-            "goog.log.LogRecord",
-            "goog.debug.LogRecord",
-            "module$exports$bare$reexport",
-            "module$exports$original$module.Class");
-  }
 }

--- a/src/test/java/com/google/javascript/clutz/ProgramSubject.java
+++ b/src/test/java/com/google/javascript/clutz/ProgramSubject.java
@@ -119,12 +119,6 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
     if (knownGoogProvides != null) {
       opts.knownGoogProvides = knownGoogProvides;
     }
-    opts.knownClassAliases =
-        ImmutableMap.of(
-            "goog.log.Logger", "goog.debug.Logger",
-            "goog.log.Level", "goog.debug.Logger.Level",
-            "goog.log.LogRecord", "goog.debug.LogRecord",
-            "module$exports$bare$reexport", "module$exports$original$module.Class");
     opts.collidingProvides = ImmutableSet.of("colliding_provide.aliased");
 
     List<SourceFile> sourceFiles = new ArrayList<>();

--- a/src/test/java/com/google/javascript/clutz/ProgramSubject.java
+++ b/src/test/java/com/google/javascript/clutz/ProgramSubject.java
@@ -7,7 +7,6 @@ import static java.util.Collections.singletonList;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;

--- a/src/test/java/com/google/javascript/clutz/partial/bare_reexport.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/bare_reexport.d.ts
@@ -1,0 +1,8 @@
+declare namespace ಠ_ಠ.clutz {
+  type module$exports$bare$reexport = ಠ_ಠ.clutz.module$exports$original$module.Class ;
+  var module$exports$bare$reexport : typeof ಠ_ಠ.clutz.module$exports$original$module.Class ;
+}
+declare module 'goog:bare.reexport' {
+  import alias = ಠ_ಠ.clutz.module$exports$bare$reexport;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/bare_reexport.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/bare_reexport.d.ts
@@ -1,8 +1,0 @@
-declare namespace ಠ_ಠ.clutz {
-  type module$exports$bare$reexport = ಠ_ಠ.clutz.module$exports$original$module.Class ;
-  var module$exports$bare$reexport : typeof ಠ_ಠ.clutz.module$exports$original$module.Class ;
-}
-declare module 'goog:bare.reexport' {
-  import alias = ಠ_ಠ.clutz.module$exports$bare$reexport;
-  export default alias;
-}

--- a/src/test/java/com/google/javascript/clutz/partial/bare_reexport.js
+++ b/src/test/java/com/google/javascript/clutz/partial/bare_reexport.js
@@ -1,8 +1,0 @@
-goog.module('bare.reexport');
-
-const {Class} = goog.require('original.module');
-
-//!! Function type annotation is necessary to get clutz to take the branch that
-//!! uses the known_class_aliases
-/** @type {!Function} */
-exports = Class;

--- a/src/test/java/com/google/javascript/clutz/partial/bare_reexport.js
+++ b/src/test/java/com/google/javascript/clutz/partial/bare_reexport.js
@@ -1,0 +1,5 @@
+goog.module('bare.reexport');
+
+const {Class} = goog.require('original.module');
+
+exports = Class;

--- a/src/test/java/com/google/javascript/clutz/test_known_class_aliases
+++ b/src/test/java/com/google/javascript/clutz/test_known_class_aliases
@@ -1,4 +1,0 @@
-goog.log.Logger,goog.debug.Logger
-goog.log.Level,goog.debug.Logger.Level
-goog.log.LogRecord,goog.debug.LogRecord
-module$exports$bare$reexport,module$exports$original$module.Class


### PR DESCRIPTION
Read goog.require statements to generate possible export aliases, instead of passing in a map as an option.

Refactor ImportRenameMapBuilder to extend an abstract class, so AliasMapBuilder can rely on the same infrastructure.  Only supports reexports in goog.module() files, continues to rely on KNOWN_CLASS_ALIASES for goog.provide() class aliases.