### PR TITLE
Fix interaction between importRewriter and Global aliases.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -1716,7 +1716,6 @@ class DeclarationGenerator {
         emit(defaultEmit);
         return;
       }
-      if (maybeEmitGlobalType(type)) return;
       // When processing partial inputs, this case handles implicitly forward declared types
       // for which we just emit the literal type written along with any type parameters.
       NoResolvedType nType = (NoResolvedType) type;
@@ -1727,6 +1726,8 @@ class DeclarationGenerator {
         return;
       }
       String displayName = maybeRewriteImportedName(type.getDisplayName());
+      if (maybeEmitGlobalType(displayName)) return;
+
       // In partial mode, closure doesn't know the correct name of imported symbols, if the name
       // matches one in the precomputed map, replace it with the original declared name
       // The displayName can be of the form foo.bar, but the symbol that was goog required was just
@@ -2835,7 +2836,7 @@ class DeclarationGenerator {
         return emitTemplatizedType(
             typeRegistry.createTemplatizedType(type), false, inExtendsImplementsPosition);
       }
-      if (maybeEmitGlobalType(type)) return null;
+      if (maybeEmitGlobalType(type.getDisplayName())) return null;
       if (type.isRecordType()) {
         visitRecordType((RecordType) type);
       } else if (type.isDict()) {
@@ -2865,11 +2866,10 @@ class DeclarationGenerator {
     }
 
     /**
-     * If ObjectType refers to a "platform" type (e.g. Promise) emit it specially here and return
+     * If a symbol refers to a "platform" type (e.g. Promise) emit it specially here and return
      * true.
      */
-    private boolean maybeEmitGlobalType(ObjectType type) {
-      String name = type.getDisplayName();
+    private boolean maybeEmitGlobalType(String name) {
       if (name == null) return false;
 
       if (PlatformSymbols.GLOBAL_SYMBOL_ALIASES.contains(name)) {

--- a/src/test/java/com/google/javascript/clutz/DeclarationGeneratorTests.java
+++ b/src/test/java/com/google/javascript/clutz/DeclarationGeneratorTests.java
@@ -80,6 +80,7 @@ public class DeclarationGeneratorTests {
       if (Arrays.asList("partial", "multifilePartial", "partialCrossModuleTypeImports")
           .contains(input.getParentFile().getName())) {
         subject.partialInput = true;
+        subject.knownGoogProvides = ImmutableSet.of("goog.events.EventTarget");
       }
       if (input.getParentFile().getName().equals("partialCrossModuleTypeImports")) {
         subject.knownGoogProvides =

--- a/src/test/java/com/google/javascript/clutz/partial/platform_goog_require.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/platform_goog_require.d.ts
@@ -1,0 +1,11 @@
+declare namespace ಠ_ಠ.clutz.module$exports$platform$goog$require {
+  class C extends C_Instance {
+  }
+  class C_Instance extends ಠ_ಠ.clutz.goog.events.EventTarget {
+    constructor ( ...var_args : any [] ) ;
+  }
+}
+declare module 'goog:platform.goog.require' {
+  import alias = ಠ_ಠ.clutz.module$exports$platform$goog$require;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/platform_goog_require.js
+++ b/src/test/java/com/google/javascript/clutz/partial/platform_goog_require.js
@@ -1,0 +1,15 @@
+/**
+ * This tests that EventTarget is expanded to goog.events.EventTarget, while processing a
+ * symbolic reference. Thus not confused with the platform global EventTarget, and not rewritten
+ * to GlobalEventTarget.
+ *
+ * All tests in partial add goog.events.EventTarget as a knownGoogRequire.
+ */
+goog.module('platform.goog.require');
+
+var EventTarget = goog.require('goog.events.EventTarget');
+
+class C extends EventTarget {
+}
+
+exports.C = C;


### PR DESCRIPTION
The import rewriter has to be run before the code that looks for global
aliases. For example:

const EventTarget = goog.require('goog.events.EventTarget');

/** @type {EventTarget} */

The name has to be expanded to goog.events.EventTarget, otherwise we
would rewrite it as GlobalEventTarget.