### PR TITLE
add GlobalFoo alias for Element

### DIFF
--- a/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
+++ b/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
@@ -57,7 +57,7 @@ public class PlatformSymbols {
    * Adding a symbol to this list also suppresses the duplicate externs.
    */
   public static final ImmutableSet<String> GLOBAL_SYMBOL_ALIASES =
-      ImmutableSet.of("Error", "Event", "EventTarget", "Object", "Date");
+      ImmutableSet.of("Element", "Error", "Event", "EventTarget", "Object", "Date");
 
   /**
    * Set of symbols that are defined in a platform externs.js that we don't need a matching

--- a/src/resources/closure.lib.d.ts
+++ b/src/resources/closure.lib.d.ts
@@ -2,6 +2,8 @@
 // All clutz namespaces are below ಠ_ಠ.clutz, thus
 // this acts as global.
 declare namespace ಠ_ಠ.clutz {
+  type GlobalElement = Element;
+  var GlobalElement: Element;
   type GlobalError = Error;
   var GlobalError: ErrorConstructor;
   type GlobalEvent = Event;

--- a/src/test/java/com/google/javascript/clutz/types_externs_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types_externs_with_platform.d.ts
@@ -13,7 +13,7 @@ declare namespace ಠ_ಠ.clutz.typesWithExterns {
   var a : { a : number } ;
   var b : IArguments ;
   var c : NodeList ;
-  function elementMaybe ( ) : Element | null ;
+  function elementMaybe ( ) : GlobalElement | null ;
   var myScope : ಠ_ಠ.clutz.namespace.Foo ;
   function topLevelFunction ( ...a : any [] ) : any ;
 }
@@ -115,5 +115,5 @@ declare namespace ಠ_ಠ.clutz.namespace.atypedef {
   type get = (a : string ) => ಠ_ಠ.clutz.namespace.atypedef.Cache < any > | null ;
 }
 declare namespace ಠ_ಠ.clutz.namespace {
-  function bootstrap (arg1 : Element | null | HTMLDocument , opt_arg2 ? : ( string | Function | null ) [] | null ) : any ;
+  function bootstrap (arg1 : GlobalElement | null | HTMLDocument , opt_arg2 ? : ( string | Function | null ) [] | null ) : any ;
 }


### PR DESCRIPTION
A library declares a local Element that then shadows the global one,
so use the same workaround we always use.