### PR TITLE
Improve the typings for goog.Promise.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
+++ b/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
@@ -85,7 +85,10 @@ public class DeclarationSyntaxTest {
           "--lib",
           "es5,dom,es2015.iterable",
           "--noImplicitAny",
-          "--strictNullChecks");
+          "--strictNullChecks",
+          // TODO(lucassloan): Necessary to allow promise like things that extend other promise like
+          // things.  Turn off when turned off in g3
+          "--noStrictGenericChecks");
 
   @Test
   public void testDeclarationSyntax() throws Exception {

--- a/src/test/java/com/google/javascript/clutz/goog_promise_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_promise_with_platform.d.ts
@@ -1,0 +1,30 @@
+declare namespace ಠ_ಠ.clutz.goog {
+  class Promise < TYPE , RESOLVER_CONTEXT > extends Promise_Instance < TYPE , RESOLVER_CONTEXT > {
+    static all < TYPE > (promises : any [] ) : ಠ_ಠ.clutz.goog.Promise < TYPE [] , any > ;
+    static race < TYPE > (promises : any [] ) : ಠ_ಠ.clutz.goog.Promise < TYPE , any > ;
+    static resolve < T >(value: ಠ_ಠ.clutz.goog.Promise < T , any > | T): any;
+  }
+  class Promise_Instance < TYPE , RESOLVER_CONTEXT > implements ಠ_ಠ.clutz.goog.Thenable < TYPE > {
+    private noStructuralTyping_: any;
+    constructor (resolver : (a : (a ? : TYPE | PromiseLike < TYPE > | null | { then : any } ) => any , b : (a ? : any ) => any ) => void , opt_context ? : RESOLVER_CONTEXT ) ;
+    then < RESULT > (opt_onFulfilled ? : ( (a : TYPE ) =>  any | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) :  any ;
+  }
+}
+declare module 'goog:goog.Promise' {
+  import alias = ಠ_ಠ.clutz.goog.Promise;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.goog {
+  interface Thenable < TYPE > extends PromiseLike < TYPE > {
+    then < RESULT > (opt_onFulfilled ? : ( (a : TYPE ) => ಠ_ಠ.clutz.goog.Thenable < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : ಠ_ಠ.clutz.goog.Thenable < RESULT > ;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog.Thenable {
+  var IMPLEMENTED_BY_PROP : string ;
+  function addImplementation (ctor : { new ( ...a : any [] ) : ಠ_ಠ.clutz.goog.Thenable < any > } ) : void ;
+  function isImplementedBy (object : any ) : boolean ;
+}
+declare module 'goog:goog.Thenable' {
+  import alias = ಠ_ಠ.clutz.goog.Thenable;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/goog_promise_with_platform.js
+++ b/src/test/java/com/google/javascript/clutz/goog_promise_with_platform.js
@@ -1,0 +1,132 @@
+//!! goog.Promise (https://github.com/google/closure-library/blob/master/closure/goog/promise/promise.js),
+//!! unlike other implementations of Promise, has 2 template params this test ensures
+//!! that the specially handled TTE methods work for it as well
+goog.provide('goog.Promise');
+goog.provide('goog.Thenable');
+
+/**
+ * @interface
+ * @extends {IThenable<TYPE>}
+ * @template TYPE
+ */
+goog.Thenable = function() {};
+
+
+/**
+ * @param {?(function(this:THIS, TYPE): VALUE)=} opt_onFulfilled A
+ *     function that will be invoked with the fulfillment value if the Promise
+ *     is fulfilled.
+ * @param {?(function(this:THIS, *): *)=} opt_onRejected A function that will
+ *     be invoked with the rejection reason if the Promise is rejected.
+ * @param {THIS=} opt_context An optional context object that will be the
+ *     execution context for the callbacks. By default, functions are executed
+ *     with the default this.
+ *
+ * @return {RESULT} A new Promise that will receive the result
+ *     of the fulfillment or rejection callback.
+ * @template VALUE
+ * @template THIS
+ *
+ * When a Promise (or thenable) is returned from the fulfilled callback,
+ * the result is the payload of that promise, not the promise itself.
+ *
+ * @template RESULT := type('goog.Promise',
+ *     cond(isUnknown(VALUE), unknown(),
+ *       mapunion(VALUE, (V) =>
+ *         cond(isTemplatized(V) && sub(rawTypeOf(V), 'IThenable'),
+ *           templateTypeOf(V, 0),
+ *           cond(sub(V, 'Thenable'),
+ *              unknown(),
+ *              V)))))
+ *  =:
+ *
+ */
+goog.Thenable.prototype.then = function(
+    opt_onFulfilled, opt_onRejected, opt_context) {};
+
+
+/**
+ * @const
+ */
+goog.Thenable.IMPLEMENTED_BY_PROP = '$goog_Thenable';
+
+
+/**
+ * @param {function(new:goog.Thenable,...?)} ctor The class constructor. The
+ *     corresponding class must have already implemented the interface.
+ */
+goog.Thenable.addImplementation = function(ctor) {};
+
+
+/**
+ * @param {?} object
+ * @return {boolean} Whether a given instance implements `goog.Thenable`.
+ *     The class/superclass of the instance must call `addImplementation`.
+ */
+goog.Thenable.isImplementedBy = function(object) {};
+
+/**
+ * @param {function(
+ *             this:RESOLVER_CONTEXT,
+ *             function((TYPE|IThenable<TYPE>|Thenable)=),
+ *             function(*=)): void} resolver
+ *     Initialization function that is invoked immediately with `resolve`
+ *     and `reject` functions as arguments. The Promise is resolved or
+ *     rejected with the first argument passed to either function.
+ * @param {RESOLVER_CONTEXT=} opt_context An optional context for executing the
+ *     resolver function. If unspecified, the resolver function will be executed
+ *     in the default scope.
+ * @constructor
+ * @struct
+ * @final
+ * @implements {goog.Thenable<TYPE>}
+ * @template TYPE,RESOLVER_CONTEXT
+ */
+goog.Promise = function(resolver, opt_context) {};
+
+/**
+ * @param {VALUE=} opt_value
+ * @return {RESULT} A new Promise that is immediately resolved
+ *     with the given value. If the input value is already a goog.Promise, it
+ *     will be returned immediately without creating a new instance.
+ * @template VALUE
+ * @template RESULT := type('goog.Promise',
+ *     cond(isUnknown(VALUE), unknown(),
+ *       mapunion(VALUE, (V) =>
+ *         cond(isTemplatized(V) && sub(rawTypeOf(V), 'IThenable'),
+ *           templateTypeOf(V, 0),
+ *           cond(sub(V, 'Thenable'),
+ *              unknown(),
+ *              V)))))
+ * =:
+ */
+goog.Promise.resolve = function(opt_value) {};
+
+/**
+ * @param {!Array<?(goog.Promise<TYPE>|goog.Thenable<TYPE>|Thenable|*)>}
+ *     promises
+ * @return {!goog.Promise<TYPE>} A Promise that receives the result of the
+ *     first Promise (or Promise-like) input to settle immediately after it
+ *     settles.
+ * @template TYPE
+ */
+goog.Promise.race = function(promises) {};
+
+
+/**
+ * @param {!Array<?(goog.Promise<TYPE>|goog.Thenable<TYPE>|Thenable|*)>}
+ *     promises
+ * @return {!goog.Promise<!Array<TYPE>>} A Promise that receives a list of
+ *     every fulfilled value once every input Promise (or Promise-like) is
+ *     successfully fulfilled, or is rejected with the first rejection reason
+ *     immediately after it is rejected.
+ * @template TYPE
+ */
+goog.Promise.all = function(promises) {};
+
+/**
+ * @override
+ */
+goog.Promise.prototype.then = function(
+    opt_onFulfilled, opt_onRejected, opt_context) {};
+goog.Thenable.addImplementation(goog.Promise);

--- a/src/test/java/com/google/javascript/clutz/partial/tte_promise_partial.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/tte_promise_partial.d.ts
@@ -3,7 +3,7 @@ declare namespace ಠ_ಠ.clutz.module$exports$tte$Promise$Partial {
   }
   class PartialDeferred_Instance < VALUE = any > extends ಠ_ಠ.clutz.Base < VALUE > {
     constructor ( ) ;
-    then < RESULT > (opt_onFulfilled ? : ( (a : VALUE ) => PartialDeferred < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : PartialDeferred < RESULT > ;
+    then < RESULT > (opt_onFulfilled ? : ( (a : VALUE ) => ಠ_ಠ.clutz.module$exports$tte$Promise$Partial.PartialDeferred < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : ಠ_ಠ.clutz.module$exports$tte$Promise$Partial.PartialDeferred < RESULT > ;
   }
 }
 declare module 'goog:tte.Promise.Partial' {

--- a/src/test/java/com/google/javascript/clutz/tte_promise.d.ts
+++ b/src/test/java/com/google/javascript/clutz/tte_promise.d.ts
@@ -1,13 +1,13 @@
 declare namespace ಠ_ಠ.clutz.tte {
   class Promise < T > extends Promise_Instance < T > {
-    static all(promises : Promise < any > [] ) : Promise < any [] > ;
-    static race < T > (values : T [] ) : Promise < T > ;
-    static resolve < T >(value: Promise < T > | T): Promise < T >;
+    static all(promises : ಠ_ಠ.clutz.tte.Promise < any > [] ) : ಠ_ಠ.clutz.tte.Promise < any [] > ;
+    static race < T > (values : T [] ) : ಠ_ಠ.clutz.tte.Promise < T > ;
+    static resolve < T >(value: ಠ_ಠ.clutz.tte.Promise < T > | T): ಠ_ಠ.clutz.tte.Promise < T >;
   }
   class Promise_Instance < T > {
     private noStructuralTyping_: any;
-    then < RESULT > (opt_onFulfilled ? : ( (a : T ) => Promise < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : Promise < RESULT > ;
-    when < RESULT, T > (value: T, successCallback: (promiseValue: T) => Promise < RESULT >|RESULT, errorCallback: null | undefined |  ((reason: any) => any), notifyCallback?: (state: any) => any): Promise < RESULT >;
+    then < RESULT > (opt_onFulfilled ? : ( (a : T ) => ಠ_ಠ.clutz.tte.Promise < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : ಠ_ಠ.clutz.tte.Promise < RESULT > ;
+    when < RESULT, T > (value: T, successCallback: (promiseValue: T) => ಠ_ಠ.clutz.tte.Promise < RESULT >|RESULT, errorCallback: null | undefined |  ((reason: any) => any), notifyCallback?: (state: any) => any): ಠ_ಠ.clutz.tte.Promise < RESULT >;
   }
 }
 declare module 'goog:tte.Promise' {
@@ -19,7 +19,7 @@ declare namespace ಠ_ಠ.clutz.tte {
   }
   class PromiseService_Instance < T > {
     private noStructuralTyping_: any;
-    all(promises : PromiseService.Promise < any > [] ) : PromiseService.Promise < any [] > ;
+    all(promises : ಠ_ಠ.clutz.tte.PromiseService.Promise < any > [] ) : ಠ_ಠ.clutz.tte.PromiseService.Promise < any [] > ;
   }
 }
 declare namespace ಠ_ಠ.clutz.tte.PromiseService {


### PR DESCRIPTION
Clutz hard codes translations for TTE types, and goog.Promise has 2 type parameters, which wasn't previously accounted for in the translations.

Had to turn on noStrictGenericChecks to make it compile, ts doesn't like extending promise-y things.