### PR TITLE
update closure version to v20180204

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
   if (System.getenv().get('CI_MODE') == 'Nightly') {
     compile 'com.google.javascript:closure-compiler:1.0-SNAPSHOT'
   } else {
-    compile 'com.google.javascript:closure-compiler:v20180101'
+    compile 'com.google.javascript:closure-compiler:v20180204'
   }
 
   compile 'com.google.code.findbugs:jsr305:3.0.1'

--- a/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
@@ -549,7 +549,9 @@ public final class TypeAnnotationPass implements CompilerPass {
           importSpec = Node.newString(Token.NAME, symbol);
           importFile = Node.newString("goog:" + importedNamespace);
         } else {
-          importSpec = new Node(Token.IMPORT_SPECS, new Node(Token.IMPORT_SPEC, IR.name(symbol)));
+          Node spec = new Node(Token.IMPORT_SPEC, IR.name(symbol));
+          spec.setShorthandProperty(true);
+          importSpec = new Node(Token.IMPORT_SPECS, spec);
           importFile = Node.newString(pathUtil.getImportPath(sourceFile, module.file));
         }
         Node importNode = new Node(Token.IMPORT, IR.empty(), importSpec, importFile);

--- a/src/test/java/com/google/javascript/clutz/implements_iterable_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/implements_iterable_with_platform.d.ts
@@ -28,7 +28,7 @@ declare namespace ಠ_ಠ.clutz.implements_iterable {
   class ImplIterableIterator_Instance implements IterableIterator < string > {
     private noStructuralTyping_: any;
     [Symbol.iterator]():  IterableIterator < string > ;
-    next (a ? : string ) : IteratorResult < string > ;
+    next (a ? : any ) : IteratorResult < string > ;
   }
 }
 declare module 'goog:implements_iterable.ImplIterableIterator' {


### PR DESCRIPTION
Two changes required:

- The test output changed for a platform extern; this was an intentional
  change in the upstream extern (the function param should have been {?}).

- In gents, set the "shorthand property" flag on all imports/exports.
  This is related to the AST for statments like:
    export {x as x};
  This flag is saying whether the code is ok with that being emitted as
    export {x};
  which we want in all cases.  (If it's an {x as y}, where x!=y, then
  the flag has no effect.)