### PR TITLE
Only add entries to aliasMap if the imported variable is reexported.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/partial/bare_named_reexport.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/bare_named_reexport.d.ts
@@ -1,0 +1,8 @@
+declare namespace ಠ_ಠ.clutz.module$exports$bare$named$reexport {
+  type Class = ಠ_ಠ.clutz.module$exports$original$module ;
+  var Class : typeof ಠ_ಠ.clutz.module$exports$original$module ;
+}
+declare module 'goog:bare.named.reexport' {
+  import alias = ಠ_ಠ.clutz.module$exports$bare$named$reexport;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/bare_named_reexport.js
+++ b/src/test/java/com/google/javascript/clutz/partial/bare_named_reexport.js
@@ -1,0 +1,5 @@
+goog.module('bare.named.reexport');
+
+const Class = goog.require('original.module');
+
+exports.Class = Class;

--- a/src/test/java/com/google/javascript/clutz/partial/import_without_reexport.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/import_without_reexport.d.ts
@@ -1,7 +1,8 @@
-declare namespace ಠ_ಠ.clutz {
-  var module$exports$import$without$reexport : ಠ_ಠ.clutz.type.not.present | null ;
+declare namespace ಠ_ಠ.clutz.module$exports$import$without$reexport {
+  var x : ಠ_ಠ.clutz.type.not.present | null ;
+  var y : any ;
 }
 declare module 'goog:import.without.reexport' {
   import alias = ಠ_ಠ.clutz.module$exports$import$without$reexport;
-  export default alias;
+  export = alias;
 }

--- a/src/test/java/com/google/javascript/clutz/partial/import_without_reexport.js
+++ b/src/test/java/com/google/javascript/clutz/partial/import_without_reexport.js
@@ -1,7 +1,5 @@
 //!! Tests that the alias map doesn't force aliases for things that aren't
 //!! actually aliases
-//!! TODO(lucassloan): actually parse the `exports = foo` or `exports.foo = foo`
-//!! statements, to actually solve this problem
 goog.module('import.without.reexport');
 
 const {Class} = goog.require('original.module');
@@ -9,4 +7,7 @@ const {Class} = goog.require('original.module');
 /** @const {type.not.present} */
 const x = null;
 
-exports = x;
+const y = unknown.function(Class);
+
+exports.x = x;
+exports.y = y;


### PR DESCRIPTION
Previously, AliasMapBuilder optimistically produced the possible aliases for an import, without checking for a corresponding export.  This caused exports to be treated as aliases even if they weren't.  By only adding entries for variables that are known to be reexported, only actual aliases will be treated as such.