### PR TITLE
Add forward declared noResolvedTypes to typesUsed.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -1738,10 +1738,12 @@ class DeclarationGenerator {
     private void emitNoResolvedTypeAsumingForwardDeclare(ObjectType type) {
       String displayName = maybeRewriteImportedName(type.getDisplayName());
       String maybeGlobalName = maybeRenameGlobalType(displayName);
-      displayName =
-          maybeGlobalName == null
-              ? Constants.INTERNAL_NAMESPACE + "." + displayName
-              : maybeGlobalName;
+      if (maybeGlobalName == null) {
+        typesUsed.add(displayName);
+        displayName = Constants.INTERNAL_NAMESPACE + "." + displayName;
+      } else {
+        displayName = maybeGlobalName;
+      }
       emit(displayName);
       List<JSType> templateTypes = type.getTemplateTypes();
       if (templateTypes != null && templateTypes.size() > 0) {

--- a/src/test/java/com/google/javascript/clutz/partial/aliased_template_argument.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/aliased_template_argument.d.ts
@@ -1,0 +1,19 @@
+declare namespace ಠ_ಠ.clutz {
+  class module$exports$aliased$template$argument extends module$exports$aliased$template$argument_Instance {
+  }
+  class module$exports$aliased$template$argument_Instance {
+    private noStructuralTyping_: any;
+    methodWithBareArg ( ) : ಠ_ಠ.clutz.module$exports$aliased$template$argument.typedef ;
+    methodWithTemplateArg ( ) : ಠ_ಠ.clutz.unknown.extern.type < ಠ_ಠ.clutz.module$contents$aliased$template$argument_aliasedtypedef > ;
+  }
+}
+declare namespace ಠ_ಠ.clutz.module$exports$aliased$template$argument {
+  type typedef = { field ? : number } ;
+}
+declare module 'goog:aliased.template.argument' {
+  import alias = ಠ_ಠ.clutz.module$exports$aliased$template$argument;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz {
+  type module$contents$aliased$template$argument_aliasedtypedef = { field ? : number } ;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/aliased_template_argument.js
+++ b/src/test/java/com/google/javascript/clutz/partial/aliased_template_argument.js
@@ -1,0 +1,33 @@
+//!! Closure somehow doesn't properly collapse Class.typedef, aliasedtypedef, and
+//!! aliasedtypedef the template type argument.  Make sure to emit types for both
+//!! Class.typedef (module$exports$aliased$template$argument.typedef) and
+//!! aliasedtypedef (module$contents$aliased$template$argument_aliasedtypedef),
+//!! so that emitting the name of aliasedtypedef the template type argument corresponds
+//!! to a defined type
+goog.module('aliased.template.argument');
+
+var Class = class {
+  /**
+   * @return {!unknown.extern.type<!aliasedtypedef>}
+   */
+  methodWithTemplateArg() {
+  }
+  /**
+   * @return {!aliasedtypedef}
+   */
+  methodWithBareArg() {
+  }
+};
+
+/**
+ * @typedef {{
+ *   field: (number|undefined),
+ * }}
+ */
+Class.typedef;
+
+/** @typedef{Class.typedef} */
+var aliasedtypedef = Class.typedef;
+
+
+exports = Class;


### PR DESCRIPTION
Works around an issue where an aliased type used as a type parameter to an unknown type doesn't resolve to the original type.  Adding the type to typesUsed ensures that the type alias is emitted as a type.