### PR TITLE
Fixes emit in partial mode on module local typedefs used in generics.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/partial/inner_typedef_npe.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/inner_typedef_npe.d.ts
@@ -1,0 +1,15 @@
+declare namespace ಠ_ಠ.clutz {
+  class module$exports$odd$npe$typedef extends module$exports$odd$npe$typedef_Instance {
+  }
+  class module$exports$odd$npe$typedef_Instance {
+    private noStructuralTyping_: any;
+    foo ( ) : ಠ_ಠ.clutz.some.type < ಠ_ಠ.clutz.module$contents$odd$npe$typedef_ATypeDef > ;
+  }
+}
+declare module 'goog:odd.npe.typedef' {
+  import alias = ಠ_ಠ.clutz.module$exports$odd$npe$typedef;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz {
+  type module$contents$odd$npe$typedef_ATypeDef = { a : string } ;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/inner_typedef_npe.js
+++ b/src/test/java/com/google/javascript/clutz/partial/inner_typedef_npe.js
@@ -1,0 +1,19 @@
+goog.module('odd.npe.typedef');
+
+class C {
+    //!! The generics are significant here. Usually closure inlines typedefs by the time
+    //!! clutz see them. But because of the missing type, closure only resolves ATypeDef
+    //!! to modules$contents$...$ATypeDef but doesn't inline.
+    /**
+     * @return {!some.type<!ATypeDef>}
+     */
+    foo() {}
+}
+
+/** @typedef {{
+ *   a: string,
+ * }}
+ */
+let ATypeDef;
+
+exports = C;


### PR DESCRIPTION
Usually closure inlines typedefs, but in partial mode with generics
involved it only resolves the name to $module$contents. Our secondary
types used pass has to deal with finding the typedef definition and
emitting it correctly.