### PR TITLE
Incremental clutz should not add root depgraph externs to the compila…

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -215,14 +215,22 @@ public class Options {
       Set<String> merged = Sets.union(depgraph.getRoots(), depgraph.getNonroots());
       arguments.retainAll(merged);
     }
-    // set union command line externs and depgraph.externs.
-    Set<String> allExterns = new LinkedHashSet<>();
-    allExterns.addAll(depgraph.getRootExterns());
+
     if (!partialInput) {
+      // set union command line externs and depgraph.externs.
+      Set<String> allExterns = new LinkedHashSet<>();
+      allExterns.addAll(depgraph.getRootExterns());
       allExterns.addAll(depgraph.getNonrootExterns());
+      allExterns.addAll(externs);
+      externs = new ArrayList<>(allExterns);
     }
-    allExterns.addAll(externs);
-    externs = new ArrayList<>(allExterns);
+    // Incremental clutz does not use the externs option in regular invocations. Since it is only
+    // ran on a per js_library basis, there is no way to separate sources and externs.
+    // For legacy reasons, it is seperately called on the externs_list's of files, but it those
+    // invocations depgraphs are not used (since they don't exist for bundles of files).
+    //
+    // So either there are no externs present or no depgraphs present. In either case there is no
+    // point doing any union/intersection of those.
 
     // Exclude externs that are already in the sources to avoid duplicated symbols.
     arguments.removeAll(externs);

--- a/src/test/java/com/google/javascript/clutz/DepgraphTest.java
+++ b/src/test/java/com/google/javascript/clutz/DepgraphTest.java
@@ -29,8 +29,8 @@ public class DepgraphTest {
     assertThat(depgraph.getNonroots())
         .containsExactly("javascript/closure/base.js", "javascript/closure/string/string.js")
         .inOrder();
-    assertThat(depgraph.getRootExterns()).isEmpty();
-    assertThat(depgraph.getNonrootExterns()).containsExactly("javascript/common/dom.js").inOrder();
+    assertThat(depgraph.getRootExterns()).containsExactly("my/root/extern.js").inOrder();
+    assertThat(depgraph.getNonrootExterns()).containsExactly("my/nonroot/extern.js").inOrder();
   }
 
   @Test

--- a/src/test/java/com/google/javascript/clutz/OptionsTest.java
+++ b/src/test/java/com/google/javascript/clutz/OptionsTest.java
@@ -31,24 +31,35 @@ public class OptionsTest {
               "javascript/closure/other_file_not_in_depgraph.js",
               "javascript/closure/string/string.js",
               "blaze-out/blah/my/blaze-out-file.js",
+              "--depgraphs",
+              DepgraphTest.DEPGRAPH_PATH.toFile().toString(),
+              "--depgraphs_filter_sources",
+            });
+    // Arguments are filtered by what appears in the depgraph.
+    assertThat(opts.arguments)
+        .containsExactly(
+            "javascript/closure/string/string.js", // kept as a root in depgraph
+            "blaze-out/blah/my/blaze-out-file.js") // kept as a non-root in depgraph
+        .inOrder();
+  }
+
+  @Test
+  public void testFilterSourcesWithExternsInDepgraphs() throws Exception {
+    Options opts =
+        new Options(
+            new String[] {
+              "javascript/closure/string/string.js",
               "--externs",
               "extern1.js",
               "extern2.js",
               "--depgraphs",
               DepgraphTest.DEPGRAPH_PATH.toFile().toString(),
               "--depgraphs_filter_sources",
-              "-o",
-              "output.d.ts"
             });
-    // Outputs are filtered by what appears in the depgraph.
-    assertThat(opts.arguments)
-        .containsExactly(
-            "javascript/closure/string/string.js", "blaze-out/blah/my/blaze-out-file.js")
-        .inOrder();
+    // All depgraph externs are added to the externs list.
     assertThat(opts.externs)
-        .containsExactly("javascript/common/dom.js", "extern1.js", "extern2.js")
+        .containsExactly("my/root/extern.js", "my/nonroot/extern.js", "extern1.js", "extern2.js")
         .inOrder();
-    assertThat(opts.output).isEqualTo("output.d.ts");
   }
 
   @Test
@@ -104,11 +115,12 @@ public class OptionsTest {
         new Options(
             new String[] {
               "--externs",
-              "javascript/common/dom.js",
+              "my/root/extern.js",
               "--depgraphs",
+              // Depgraph also has my/root/extern.js, and additionally my/nonroot/extern.js.
               DepgraphTest.DEPGRAPH_PATH.toFile().toString(),
             });
-    assertThat(opts.externs).containsExactly("javascript/common/dom.js");
+    assertThat(opts.externs).containsExactly("my/root/extern.js", "my/nonroot/extern.js");
   }
 
   @Test
@@ -128,7 +140,9 @@ public class OptionsTest {
         new Options(
             new String[] {
               "--partialInput",
-              "javascript/common/dom.js",
+              // a random file from the depgraph. Not relevant to the test, but we need at least
+              // one input.
+              "my/thing/static/js/0-bootstrap.js",
               "--depgraphs",
               DepgraphTest.DEPGRAPH_PATH.toFile().toString(),
             });
@@ -145,5 +159,23 @@ public class OptionsTest {
               DeclarationGeneratorTests.getTestInputFile("test_goog_provides").toFile().toString()
             });
     assertThat(opts.knownGoogProvides).containsExactly("foo.bar", "baz.quux");
+  }
+
+  @Test
+  public void testPartialInputIgnoresDepgraphRootExternsIfNotPassedToExterns() throws Exception {
+    // Due to "exported" libraries, what the depgraph considers "root" can be incorrect for the
+    // purposes of incremental clutz. Arguments and Externs lists should only be filtered down
+    // with depgraph info and never extended.
+    Options opts =
+        new Options(
+            new String[] {
+              "--partialInput",
+              // a random file from the depgraph. Not relevant to the test, but we need at least
+              // one input.
+              "my/thing/static/js/0-bootstrap.js",
+              "--depgraphs",
+              DepgraphTest.DEPGRAPH_PATH.toFile().toString(),
+            });
+    assertThat(opts.externs).isEmpty();
   }
 }

--- a/src/test/java/com/google/javascript/clutz/closure.depgraph
+++ b/src/test/java/com/google/javascript/clutz/closure.depgraph
@@ -1,7 +1,7 @@
 [ [ "nonroots", [
     [ "javascript/closure/base.js", []],
     [ "javascript/closure/string/string.js", []],
-    [ "javascript/common/dom.js", [
+    [ "my/nonroot/extern.js", [
       ["provides", []],
       ["is_externs", true],
       ["requires", []],
@@ -11,6 +11,11 @@
   [ "roots", [
     [ "my/thing/static/js/0-bootstrap.js", []],
     [ "my/thing/static/js/annotations/annotations-canvas-controller.js", []],
-    [ "[blaze-out/blah/]my/blaze-out-file.js", []]
+    [ "[blaze-out/blah/]my/blaze-out-file.js", []],
+    [ "my/root/extern.js", [
+      ["provides", []],
+      ["is_externs", true],
+      ["requires", []],
+    ]]
   ] ]
 ]


### PR DESCRIPTION
…tion externs.

Depgraph roots can be exaggerated due to a mechanism of "exporting" for
js_library bazel rules. Both sources and externs should only be
filtering with the depgraph roots and not adding new targets. So far
this was true for sources and this change will make it true for externs.