### PR TITLE
Fix emit for optional properties on export objects.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/partial/optional_export_object_property.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/optional_export_object_property.d.ts
@@ -1,0 +1,11 @@
+declare namespace ಠ_ಠ.clutz.optional.export.object.property {
+  var optional : number | undefined ;
+}
+declare module 'goog:optional.export.object.property' {
+  import alias = ಠ_ಠ.clutz.optional.export.object.property;
+  export = alias;
+}
+declare namespace ಠ_ಠ.clutz {
+  type module$exports$optional$export$object$property = ಠ_ಠ.clutz.module$contents$optional$export$object$property_exportObject ;
+  var module$exports$optional$export$object$property : typeof ಠ_ಠ.clutz.module$contents$optional$export$object$property_exportObject ;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/optional_export_object_property.js
+++ b/src/test/java/com/google/javascript/clutz/partial/optional_export_object_property.js
@@ -1,0 +1,19 @@
+goog.module('optional.export.object.property');
+goog.module.declareLegacyNamespace();
+
+//!! Need to use a function to initialize optional to get around closure's
+//!! type inference.
+/**
+ * @return {number|undefined}
+ */
+function getNumberOrUndefined() {}
+
+
+/** @type {number|undefined} */
+const optional = getNumberOrUndefined();
+
+const exportObject = {
+  optional
+};
+
+exports = exportObject;


### PR DESCRIPTION
We use visitProperty() for visiting object properties and for visiting certain namespace members.  If we're visiting a namespace member that is a type union including undefined, the old code would incorrectly use the question mark syntax for optionality.