### PR TITLE
Remove [Symbol.iterator()] from incremental clutz.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/partial/iterator_record_extends.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/iterator_record_extends.d.ts
@@ -1,0 +1,10 @@
+declare namespace ಠ_ಠ.clutz.module$exports$record$extending {
+  interface AnExtendingInterface extends ಠ_ಠ.clutz.MissingBaseI {
+  }
+  interface AnExtendingRecord extends ಠ_ಠ.clutz.MissingBaseR {
+  }
+}
+declare module 'goog:record.extending' {
+  import alias = ಠ_ಠ.clutz.module$exports$record$extending;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/iterator_record_extends.js
+++ b/src/test/java/com/google/javascript/clutz/partial/iterator_record_extends.js
@@ -1,0 +1,18 @@
+goog.module('record.extending');
+
+//!! This test checks that we do not accidentally add an [Symbol.iterator()]
+//!! property on the record or interface.
+/**
+ * @record
+ * @extends {MissingBaseR}
+ */
+var AnExtendingRecord = function() {};
+
+/**
+ * @interface
+ * @extends {MissingBaseI}
+ */
+var AnExtendingInterface = function() {};
+
+exports.AnExtendingRecord = AnExtendingRecord;
+exports.AnExtendingInterface = AnExtendingInterface;


### PR DESCRIPTION
It appears that records extending unknown records spuriously trigger
that branch. Since the use case of extending records is a lot more
common than Iterator classes/interfaces, I am turning off this branch
for incremental clutz.