### PR TITLE
Fixes the regression on the static-instance split for classes.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/class_alias.d.ts
+++ b/src/test/java/com/google/javascript/clutz/class_alias.d.ts
@@ -1,6 +1,8 @@
 declare namespace ಠ_ಠ.clutz.alias {
   type A = ಠ_ಠ.clutz.original.A ;
   var A : typeof ಠ_ಠ.clutz.original.A ;
+  type A_Instance = ಠ_ಠ.clutz.original.A_Instance ;
+  var A_Instance : typeof ಠ_ಠ.clutz.original.A_Instance ;
 }
 declare module 'goog:alias.A' {
   import alias = ಠ_ಠ.clutz.alias.A;

--- a/src/test/java/com/google/javascript/clutz/goog_module_declare_legacy.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_module_declare_legacy.d.ts
@@ -1,6 +1,8 @@
 declare namespace ಠ_ಠ.clutz.module.Foo {
   type Legacy = ಠ_ಠ.clutz.module$contents$module$Foo$Legacy_A ;
   var Legacy : typeof ಠ_ಠ.clutz.module$contents$module$Foo$Legacy_A ;
+  type Legacy_Instance = ಠ_ಠ.clutz.module$contents$module$Foo$Legacy_A_Instance ;
+  var Legacy_Instance : typeof ಠ_ಠ.clutz.module$contents$module$Foo$Legacy_A_Instance ;
 }
 declare module 'goog:module.Foo.Legacy' {
   import alias = ಠ_ಠ.clutz.module.Foo.Legacy;

--- a/src/test/java/com/google/javascript/clutz/goog_module_export_redefined.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_module_export_redefined.d.ts
@@ -1,6 +1,8 @@
 declare namespace ಠ_ಠ.clutz.module$exports$module$tsickle$like {
   type A = ಠ_ಠ.clutz.module$contents$module$tsickle$like_A ;
   var A : typeof ಠ_ಠ.clutz.module$contents$module$tsickle$like_A ;
+  type A_Instance = ಠ_ಠ.clutz.module$contents$module$tsickle$like_A_Instance ;
+  var A_Instance : typeof ಠ_ಠ.clutz.module$contents$module$tsickle$like_A_Instance ;
   var moduleId : string ;
 }
 declare module 'goog:module.tsickle.like' {

--- a/src/test/java/com/google/javascript/clutz/goog_scope.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_scope.d.ts
@@ -1,6 +1,8 @@
 declare namespace ಠ_ಠ.clutz.foo {
   type Bar = ಠ_ಠ.clutz.$jscomp.scope.Bar ;
   var Bar : typeof ಠ_ಠ.clutz.$jscomp.scope.Bar ;
+  type Bar_Instance = ಠ_ಠ.clutz.$jscomp.scope.Bar_Instance ;
+  var Bar_Instance : typeof ಠ_ಠ.clutz.$jscomp.scope.Bar_Instance ;
 }
 declare module 'goog:foo.Bar' {
   import alias = ಠ_ಠ.clutz.foo.Bar;

--- a/src/test/java/com/google/javascript/clutz/multifilePartial/default_object_exporter.d.ts
+++ b/src/test/java/com/google/javascript/clutz/multifilePartial/default_object_exporter.d.ts
@@ -1,6 +1,8 @@
 declare namespace ಠ_ಠ.clutz.module$exports$default$object$exporter {
   type BaseClass = ಠ_ಠ.clutz.module$contents$default$object$exporter_BaseClass ;
   var BaseClass : typeof ಠ_ಠ.clutz.module$contents$default$object$exporter_BaseClass ;
+  type BaseClass_Instance = ಠ_ಠ.clutz.module$contents$default$object$exporter_BaseClass_Instance ;
+  var BaseClass_Instance : typeof ಠ_ಠ.clutz.module$contents$default$object$exporter_BaseClass_Instance ;
 }
 declare module 'goog:default.object.exporter' {
   import alias = ಠ_ಠ.clutz.module$exports$default$object$exporter;

--- a/src/test/java/com/google/javascript/clutz/multifilePartial/missing_imported_base.d.ts
+++ b/src/test/java/com/google/javascript/clutz/multifilePartial/missing_imported_base.d.ts
@@ -1,22 +1,22 @@
 declare namespace ಠ_ಠ.clutz.module$exports$missing$imported$base {
   class ClassExtendingDefaultObjectExporterBaseClass extends ClassExtendingDefaultObjectExporterBaseClass_Instance {
   }
-  class ClassExtendingDefaultObjectExporterBaseClass_Instance extends ಠ_ಠ.clutz.module$exports$default$object$exporter.BaseClass {
+  class ClassExtendingDefaultObjectExporterBaseClass_Instance extends ಠ_ಠ.clutz.module$exports$default$object$exporter.BaseClass_Instance {
     constructor ( ) ;
   }
   class ClassExtendingMissingDestructuredRequire extends ClassExtendingMissingDestructuredRequire_Instance {
   }
-  class ClassExtendingMissingDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$named$base$exporter.MissingDestructuredRequire {
+  class ClassExtendingMissingDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$named$base$exporter.MissingDestructuredRequire_Instance {
     constructor ( ) ;
   }
   class ClassExtendingMissingRequire extends ClassExtendingMissingRequire_Instance {
   }
-  class ClassExtendingMissingRequire_Instance extends ಠ_ಠ.clutz.module$exports$default$base$exporter {
+  class ClassExtendingMissingRequire_Instance extends ಠ_ಠ.clutz.module$exports$default$base$exporter_Instance {
     constructor ( ) ;
   }
   class ClassExtendingRenamedDestructuredRequire extends ClassExtendingRenamedDestructuredRequire_Instance {
   }
-  class ClassExtendingRenamedDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$named$base$exporter.OriginalName {
+  class ClassExtendingRenamedDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$named$base$exporter.OriginalName_Instance {
     constructor ( ) ;
   }
   var DeclarationOfMissingRequire : ಠ_ಠ.clutz.module$exports$default$base$exporter | null ;

--- a/src/test/java/com/google/javascript/clutz/partial/declare_legacy_namespace.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/declare_legacy_namespace.d.ts
@@ -1,6 +1,8 @@
 declare namespace ಠ_ಠ.clutz.declare.legacy {
   type namespace = ಠ_ಠ.clutz.module$contents$declare$legacy$namespace_Class ;
   var namespace : typeof ಠ_ಠ.clutz.module$contents$declare$legacy$namespace_Class ;
+  type namespace_Instance = ಠ_ಠ.clutz.module$contents$declare$legacy$namespace_Class_Instance ;
+  var namespace_Instance : typeof ಠ_ಠ.clutz.module$contents$declare$legacy$namespace_Class_Instance ;
 }
 declare module 'goog:declare.legacy.namespace' {
   import alias = ಠ_ಠ.clutz.declare.legacy.namespace;
@@ -16,4 +18,6 @@ declare namespace ಠ_ಠ.clutz {
 declare namespace ಠ_ಠ.clutz {
   type module$exports$declare$legacy$namespace = ಠ_ಠ.clutz.module$contents$declare$legacy$namespace_Class ;
   var module$exports$declare$legacy$namespace : typeof ಠ_ಠ.clutz.module$contents$declare$legacy$namespace_Class ;
+  type module$exports$declare$legacy$namespace_Instance = ಠ_ಠ.clutz.module$contents$declare$legacy$namespace_Class_Instance ;
+  var module$exports$declare$legacy$namespace_Instance : typeof ಠ_ಠ.clutz.module$contents$declare$legacy$namespace_Class_Instance ;
 }

--- a/src/test/java/com/google/javascript/clutz/partial/declare_legacy_namespace_object_literal_export.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/declare_legacy_namespace_object_literal_export.d.ts
@@ -1,8 +1,12 @@
 declare namespace ಠ_ಠ.clutz.object.literal.exports {
   type Class1 = ಠ_ಠ.clutz.module$contents$object$literal$exports_Class1 ;
   var Class1 : typeof ಠ_ಠ.clutz.module$contents$object$literal$exports_Class1 ;
+  type Class1_Instance = ಠ_ಠ.clutz.module$contents$object$literal$exports_Class1_Instance ;
+  var Class1_Instance : typeof ಠ_ಠ.clutz.module$contents$object$literal$exports_Class1_Instance ;
   type RenamedClass2 = ಠ_ಠ.clutz.module$contents$object$literal$exports_Class2 ;
   var RenamedClass2 : typeof ಠ_ಠ.clutz.module$contents$object$literal$exports_Class2 ;
+  type RenamedClass2_Instance = ಠ_ಠ.clutz.module$contents$object$literal$exports_Class2_Instance ;
+  var RenamedClass2_Instance : typeof ಠ_ಠ.clutz.module$contents$object$literal$exports_Class2_Instance ;
   var aConstant : number ;
   function aFunction ( ) : void ;
 }
@@ -27,8 +31,12 @@ declare namespace ಠ_ಠ.clutz {
 declare namespace ಠ_ಠ.clutz.module$exports$object$literal$exports {
   type Class1 = ಠ_ಠ.clutz.module$contents$object$literal$exports_Class1 ;
   var Class1 : typeof ಠ_ಠ.clutz.module$contents$object$literal$exports_Class1 ;
+  type Class1_Instance = ಠ_ಠ.clutz.module$contents$object$literal$exports_Class1_Instance ;
+  var Class1_Instance : typeof ಠ_ಠ.clutz.module$contents$object$literal$exports_Class1_Instance ;
 }
 declare namespace ಠ_ಠ.clutz.module$exports$object$literal$exports {
   type RenamedClass2 = ಠ_ಠ.clutz.module$contents$object$literal$exports_Class2 ;
   var RenamedClass2 : typeof ಠ_ಠ.clutz.module$contents$object$literal$exports_Class2 ;
+  type RenamedClass2_Instance = ಠ_ಠ.clutz.module$contents$object$literal$exports_Class2_Instance ;
+  var RenamedClass2_Instance : typeof ಠ_ಠ.clutz.module$contents$object$literal$exports_Class2_Instance ;
 }

--- a/src/test/java/com/google/javascript/clutz/partial/es6_missing_imported_base.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/es6_missing_imported_base.d.ts
@@ -1,22 +1,22 @@
 declare namespace ಠ_ಠ.clutz.module$exports$missing$imported$base {
   class ClassExtendingDefaultObjectExporterBaseClass extends ClassExtendingDefaultObjectExporterBaseClass_Instance {
   }
-  class ClassExtendingDefaultObjectExporterBaseClass_Instance extends ಠ_ಠ.clutz.module$exports$default$object$exporter.BaseClass {
+  class ClassExtendingDefaultObjectExporterBaseClass_Instance extends ಠ_ಠ.clutz.module$exports$default$object$exporter.BaseClass_Instance {
     constructor ( ...var_args : any [] ) ;
   }
   class ClassExtendingMissingDestructuredRequire extends ClassExtendingMissingDestructuredRequire_Instance {
   }
-  class ClassExtendingMissingDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$named$base$exporter.MissingDestructuredRequire {
+  class ClassExtendingMissingDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$named$base$exporter.MissingDestructuredRequire_Instance {
     constructor ( ...var_args : any [] ) ;
   }
   class ClassExtendingMissingRequire extends ClassExtendingMissingRequire_Instance {
   }
-  class ClassExtendingMissingRequire_Instance extends ಠ_ಠ.clutz.module$exports$default$base$exporter {
+  class ClassExtendingMissingRequire_Instance extends ಠ_ಠ.clutz.module$exports$default$base$exporter_Instance {
     constructor ( ...var_args : any [] ) ;
   }
   class ClassExtendingRenamedDestructuredRequire extends ClassExtendingRenamedDestructuredRequire_Instance {
   }
-  class ClassExtendingRenamedDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$named$base$exporter.OriginalName {
+  class ClassExtendingRenamedDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$named$base$exporter.OriginalName_Instance {
     constructor ( ...var_args : any [] ) ;
   }
   var DeclarationOfMissingRequire : ಠ_ಠ.clutz.module$exports$default$base$exporter | null ;

--- a/src/test/java/com/google/javascript/clutz/partial/goog_module_get.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/goog_module_get.d.ts
@@ -1,7 +1,7 @@
 declare namespace ಠ_ಠ.clutz.goog.scope {
   class ClassExtendingMissingDestructuredRequire extends ClassExtendingMissingDestructuredRequire_Instance {
   }
-  class ClassExtendingMissingDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$goog$module$named$exports.MissingDestructuredRequire {
+  class ClassExtendingMissingDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$goog$module$named$exports.MissingDestructuredRequire_Instance {
     constructor ( ) ;
   }
 }
@@ -12,7 +12,7 @@ declare module 'goog:goog.scope.ClassExtendingMissingDestructuredRequire' {
 declare namespace ಠ_ಠ.clutz.goog.scope {
   class ClassExtendingMissingGoogModuleGet extends ClassExtendingMissingGoogModuleGet_Instance {
   }
-  class ClassExtendingMissingGoogModuleGet_Instance extends ಠ_ಠ.clutz.module$exports$goog$module$default$exports {
+  class ClassExtendingMissingGoogModuleGet_Instance extends ಠ_ಠ.clutz.module$exports$goog$module$default$exports_Instance {
     constructor ( ) ;
   }
 }
@@ -23,7 +23,7 @@ declare module 'goog:goog.scope.ClassExtendingMissingGoogModuleGet' {
 declare namespace ಠ_ಠ.clutz.goog.scope {
   class ClassExtendingRenamedDestructuredRequire extends ClassExtendingRenamedDestructuredRequire_Instance {
   }
-  class ClassExtendingRenamedDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$goog$module$named$exports.OriginalName {
+  class ClassExtendingRenamedDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$goog$module$named$exports.OriginalName_Instance {
     constructor ( ) ;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/partial/missing_direct_ref_base.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_direct_ref_base.d.ts
@@ -1,17 +1,17 @@
 declare namespace ಠ_ಠ.clutz.module$exports$missing$extend {
   class ClassExtendingMissing extends ClassExtendingMissing_Instance {
   }
-  class ClassExtendingMissing_Instance extends ಠ_ಠ.clutz.direct.ref.A {
+  class ClassExtendingMissing_Instance extends ಠ_ಠ.clutz.direct.ref.A_Instance {
     constructor ( ) ;
   }
   class ClassExtendingMissingTemplated extends ClassExtendingMissingTemplated_Instance {
   }
-  class ClassExtendingMissingTemplated_Instance extends ಠ_ಠ.clutz.direct.ref.ATemplated < string , number > {
+  class ClassExtendingMissingTemplated_Instance extends ಠ_ಠ.clutz.direct.ref.ATemplated_Instance < string , number > {
     constructor ( ) ;
   }
   class ClassExtendingMissingWithParam extends ClassExtendingMissingWithParam_Instance {
   }
-  class ClassExtendingMissingWithParam_Instance extends ಠ_ಠ.clutz.direct.ref.A {
+  class ClassExtendingMissingWithParam_Instance extends ಠ_ಠ.clutz.direct.ref.A_Instance {
     constructor (x : number ) ;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/partial/optional_export_object_property.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/optional_export_object_property.d.ts
@@ -6,6 +6,4 @@ declare module 'goog:optional.export.object.property' {
   export = alias;
 }
 declare namespace ಠ_ಠ.clutz {
-  type module$exports$optional$export$object$property = ಠ_ಠ.clutz.module$contents$optional$export$object$property_exportObject ;
-  var module$exports$optional$export$object$property : typeof ಠ_ಠ.clutz.module$contents$optional$export$object$property_exportObject ;
 }

--- a/src/test/java/com/google/javascript/clutz/partial/override.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/override.d.ts
@@ -10,7 +10,7 @@ declare namespace ಠ_ಠ.clutz.module$exports$override {
   }
   class ExtendsInvisible extends ExtendsInvisible_Instance {
   }
-  class ExtendsInvisible_Instance extends ಠ_ಠ.clutz.module$exports$override.Invisible {
+  class ExtendsInvisible_Instance extends ಠ_ಠ.clutz.module$exports$override.Invisible_Instance {
     constructor ( ) ;
     /**
      * This function has no known type, so its parameter should be optional.

--- a/src/test/java/com/google/javascript/clutz/partial/platform_goog_require.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/platform_goog_require.d.ts
@@ -1,7 +1,7 @@
 declare namespace ಠ_ಠ.clutz.module$exports$platform$goog$require {
   class C extends C_Instance {
   }
-  class C_Instance extends ಠ_ಠ.clutz.module$exports$goog$events$EventTarget {
+  class C_Instance extends ಠ_ಠ.clutz.module$exports$goog$events$EventTarget_Instance {
     constructor ( ...var_args : any [] ) ;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/partial/separated_destructure.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/separated_destructure.d.ts
@@ -1,12 +1,12 @@
 declare namespace ಠ_ಠ.clutz.module$exports$separated$destructure {
   class ClassExtendingMissingDestructuredRequire extends ClassExtendingMissingDestructuredRequire_Instance {
   }
-  class ClassExtendingMissingDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$named$base$exporter.MissingDestructuredRequire {
+  class ClassExtendingMissingDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$named$base$exporter.MissingDestructuredRequire_Instance {
     constructor ( ) ;
   }
   class ClassExtendingRenamedDestructuredRequire extends ClassExtendingRenamedDestructuredRequire_Instance {
   }
-  class ClassExtendingRenamedDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$named$base$exporter.OriginalName {
+  class ClassExtendingRenamedDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$named$base$exporter.OriginalName_Instance {
     constructor ( ) ;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/partial/tte_promise_partial.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/tte_promise_partial.d.ts
@@ -1,7 +1,7 @@
 declare namespace ಠ_ಠ.clutz.module$exports$tte$Promise$Partial {
   class PartialDeferred < VALUE = any > extends PartialDeferred_Instance < VALUE > {
   }
-  class PartialDeferred_Instance < VALUE = any > extends ಠ_ಠ.clutz.Base < VALUE > {
+  class PartialDeferred_Instance < VALUE = any > extends ಠ_ಠ.clutz.Base_Instance < VALUE > {
     constructor ( ) ;
     then < RESULT > (opt_onFulfilled ? : ( (a : VALUE ) => ಠ_ಠ.clutz.module$exports$tte$Promise$Partial.PartialDeferred < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : ಠ_ಠ.clutz.module$exports$tte$Promise$Partial.PartialDeferred < RESULT > ;
   }

--- a/src/test/java/com/google/javascript/clutz/partialCrossModuleTypeImports/goog_legacy_namespace_exporter.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partialCrossModuleTypeImports/goog_legacy_namespace_exporter.d.ts
@@ -1,8 +1,12 @@
 declare namespace ಠ_ಠ.clutz.goog.legacy.namespace.exporter {
   type LegacyBaseClass = ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_LegacyBaseClass ;
   var LegacyBaseClass : typeof ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_LegacyBaseClass ;
+  type LegacyBaseClass_Instance = ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_LegacyBaseClass_Instance ;
+  var LegacyBaseClass_Instance : typeof ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_LegacyBaseClass_Instance ;
   type OriginalName = ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_OriginalName ;
   var OriginalName : typeof ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_OriginalName ;
+  type OriginalName_Instance = ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_OriginalName_Instance ;
+  var OriginalName_Instance : typeof ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_OriginalName_Instance ;
 }
 declare module 'goog:goog.legacy.namespace.exporter' {
   import alias = ಠ_ಠ.clutz.goog.legacy.namespace.exporter;
@@ -25,8 +29,12 @@ declare namespace ಠ_ಠ.clutz {
 declare namespace ಠ_ಠ.clutz.module$exports$goog$legacy$namespace$exporter {
   type OriginalName = ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_OriginalName ;
   var OriginalName : typeof ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_OriginalName ;
+  type OriginalName_Instance = ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_OriginalName_Instance ;
+  var OriginalName_Instance : typeof ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_OriginalName_Instance ;
 }
 declare namespace ಠ_ಠ.clutz.module$exports$goog$legacy$namespace$exporter {
   type LegacyBaseClass = ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_LegacyBaseClass ;
   var LegacyBaseClass : typeof ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_LegacyBaseClass ;
+  type LegacyBaseClass_Instance = ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_LegacyBaseClass_Instance ;
+  var LegacyBaseClass_Instance : typeof ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_LegacyBaseClass_Instance ;
 }

--- a/src/test/java/com/google/javascript/clutz/partialCrossModuleTypeImports/goog_module_importer.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partialCrossModuleTypeImports/goog_module_importer.d.ts
@@ -1,17 +1,17 @@
 declare namespace ಠ_ಠ.clutz.module$exports$goog$module$importer {
   class ClassExtendingLegacyBaseClass extends ClassExtendingLegacyBaseClass_Instance {
   }
-  class ClassExtendingLegacyBaseClass_Instance extends ಠ_ಠ.clutz.module$exports$goog$legacy$namespace$exporter.LegacyBaseClass {
+  class ClassExtendingLegacyBaseClass_Instance extends ಠ_ಠ.clutz.module$exports$goog$legacy$namespace$exporter.LegacyBaseClass_Instance {
     constructor ( ) ;
   }
   class ClassExtendingMissingRequire extends ClassExtendingMissingRequire_Instance {
   }
-  class ClassExtendingMissingRequire_Instance extends ಠ_ಠ.clutz.googprovide.exporter {
+  class ClassExtendingMissingRequire_Instance extends ಠ_ಠ.clutz.googprovide.exporter_Instance {
     constructor ( ) ;
   }
   class ClassExtendingRename extends ClassExtendingRename_Instance {
   }
-  class ClassExtendingRename_Instance extends ಠ_ಠ.clutz.module$exports$goog$legacy$namespace$exporter.OriginalName {
+  class ClassExtendingRename_Instance extends ಠ_ಠ.clutz.module$exports$goog$legacy$namespace$exporter.OriginalName_Instance {
     constructor ( ) ;
   }
 }


### PR DESCRIPTION
Also reworks support for declareLegacyNamespace() to ensure that there's an alias for the instance half.