### PR TITLE
Allow clutz to handle ES6 generator functions.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -663,9 +663,10 @@ class DeclarationGenerator {
           continue;
         }
 
-        // skip extern symbols (they have a separate pass).
+        // Skip extern symbols (they have a separate pass) and skip built-ins.
+        // Built-ins can be indentified by having null as input file.
         CompilerInput symbolInput = this.compiler.getInput(new InputId(symbol.getInputName()));
-        if (symbolInput != null && symbolInput.isExtern()) continue;
+        if (symbolInput == null || symbolInput.isExtern()) continue;
 
         if (shouldSkipVar(symbol)) {
           continue;

--- a/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
+++ b/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
@@ -25,6 +25,7 @@ public class PlatformSymbols {
       new ImmutableMap.Builder<String, String>()
           .put("CSSProperties", "CSSStyleDeclaration")
           .put("IteratorIterable", "IterableIterator")
+          .put("Generator", "IterableIterator")
           .put("IArrayLike", "ArrayLike")
           .put("Arguments", "IArguments")
           .put("IThenable", "PromiseLike")

--- a/src/test/java/com/google/javascript/clutz/generator_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/generator_with_platform.d.ts
@@ -1,0 +1,10 @@
+declare namespace ಠ_ಠ.clutz.module$exports$generators_total {
+  //!! AFAICT, closure just infers ? and we faithfully translate that to 'any'.
+  function inferredG ( ) : any ;
+  function templateG < T > (iter : Iterator < T > ) : IterableIterator < T > ;
+  function typedG ( ) : IterableIterator < number > ;
+}
+declare module 'goog:generators_total' {
+  import alias = ಠ_ಠ.clutz.module$exports$generators_total;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/generator_with_platform.js
+++ b/src/test/java/com/google/javascript/clutz/generator_with_platform.js
@@ -1,0 +1,26 @@
+goog.module('generators_total');
+
+function* inferredG() {
+    yield 0;
+}
+
+/** @return {!Generator<number>} */
+function* typedG() {
+    yield 0;
+}
+
+/**
+ * @template T
+ * @param {!Iterator<T>} iter
+ * @return {!Generator<T>}
+ */
+function* templateG(iter) {
+    for (const item of iter) {
+        yield item;
+    }
+}
+
+
+exports.inferredG = inferredG;
+exports.typedG = typedG;
+exports.templateG = templateG;

--- a/src/test/java/com/google/javascript/clutz/partial/generator_partial.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/generator_partial.d.ts
@@ -1,0 +1,10 @@
+declare namespace ಠ_ಠ.clutz.module$exports$generators {
+  //!! AFAIKT, closure just infers ? and we faithfully translate that to 'any'.
+  function inferredG ( ) : any ;
+  function templateG < T = any > (iter : Iterator < T > ) : IterableIterator < T > ;
+  function typedG ( ) : IterableIterator < number > ;
+}
+declare module 'goog:generators' {
+  import alias = ಠ_ಠ.clutz.module$exports$generators;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/generator_partial.js
+++ b/src/test/java/com/google/javascript/clutz/partial/generator_partial.js
@@ -1,0 +1,26 @@
+goog.module('generators');
+
+function* inferredG() {
+  yield 0;
+}
+
+/** @return {!Generator<number>} */
+function* typedG() {
+    yield 0;
+}
+
+/**
+ * @template T
+ * @param {!Iterator<T>} iter
+ * @return {!Generator<T>}
+ */
+function* templateG(iter) {
+  for (const item of iter) {
+      yield item;
+  }
+}
+
+
+exports.inferredG = inferredG;
+exports.typedG = typedG;
+exports.templateG = templateG;


### PR DESCRIPTION
In closure generator functions implicitly are defined as functions that
return a Generator<T> type. In TypeScript, the closest thing to
Generator type is the IterableIterator.

The difference boils down to the the two methods return and throw, that
are part of the Generator interface in closure, but in TS they are
optional methods on the Iterator<T> type.

This change makes it so that we emit Genarator as IterableIterator in
the .d.ts. Tests added for both partial and total mode.

Special care for not emitting builtins Iterator and Generator, which
appear even if the externs they are defined in are not passed to the
compilation.