### PR TITLE
add Float32Array and 64 to list of global workarounds

### DIFF
--- a/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
+++ b/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
@@ -63,7 +63,15 @@ public class PlatformSymbols {
    * Adding a symbol to this list also suppresses the duplicate externs.
    */
   public static final ImmutableSet<String> GLOBAL_SYMBOL_ALIASES =
-      ImmutableSet.of("Element", "Error", "Event", "EventTarget", "Object", "Date");
+      ImmutableSet.of(
+          "Date",
+          "Element",
+          "Error",
+          "Event",
+          "EventTarget",
+          "Float32Array",
+          "Float64Array",
+          "Object");
 
   /**
    * Set of symbols that are defined in a platform externs.js that we don't need a matching

--- a/src/resources/closure.lib.d.ts
+++ b/src/resources/closure.lib.d.ts
@@ -2,6 +2,8 @@
 // All clutz namespaces are below ಠ_ಠ.clutz, thus
 // this acts as global.
 declare namespace ಠ_ಠ.clutz {
+  type GlobalDate = Date;
+  var GlobalDate: typeof Date;
   type GlobalElement = Element;
   var GlobalElement: Element;
   type GlobalError = Error;
@@ -10,10 +12,12 @@ declare namespace ಠ_ಠ.clutz {
   var GlobalEvent: typeof Event;
   type GlobalEventTarget = EventTarget;
   var GlobalEventTarget: typeof EventTarget;
-  var GlobalObject: typeof Object;
   type GlobalObject = Object;
-  var GlobalDate: typeof Date;
-  type GlobalDate = Date;
+  var GlobalObject: typeof Object;
+  type GlobalFloat32Array = Float32Array;
+  var GlobalFloat32Array: typeof Float32Array;
+  type GlobalFloat64Array = Float64Array;
+  var GlobalFloat64Array: typeof Float64Array;
 
   /** Represents the type returned when goog.require-ing an unknown symbol */
   type ClosureSymbolNotGoogProvided = void;


### PR DESCRIPTION
This library defines goog.vec.Float32Array
  https://github.com/google/closure-library/blob/17b6f4d1142d931dcdc5845475af288d5d13d447/closure/goog/vec/float32array.js#L28
while this one in the same namespace wants to refer to the global one
  https://github.com/google/closure-library/blob/17b6f4d1142d931dcdc5845475af288d5d13d447/closure/goog/vec/vec.js#L43
so it causes shadowing in Clutz.