### PR TITLE
Extract enum values with AST and put them in the declaration files.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/aliased_enums.d.ts
+++ b/src/test/java/com/google/javascript/clutz/aliased_enums.d.ts
@@ -8,7 +8,7 @@ declare module 'goog:nested.bar.HahaEnum' {
 }
 declare namespace ಠ_ಠ.clutz.nested.baz {
   enum Enum {
-    A ,
+    A = 5.0 ,
   }
 }
 declare module 'goog:nested.baz.Enum' {

--- a/src/test/java/com/google/javascript/clutz/aliased_enums.js
+++ b/src/test/java/com/google/javascript/clutz/aliased_enums.js
@@ -3,7 +3,7 @@ goog.provide('nested.bar.HahaEnum');
 
 /** @enum */
 nested.baz.Enum = {
-  A: 1
+  A: 5
 };
 
 /** @enum */

--- a/src/test/java/com/google/javascript/clutz/enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/enum.d.ts
@@ -11,12 +11,19 @@ declare module 'goog:some.ObjectValuedEnum' {
 }
 declare namespace ಠ_ಠ.clutz.some {
   enum SomeEnum {
-    A ,
-    B ,
+    A = 1.0 ,
+    B = 2.0 ,
   }
 }
 declare module 'goog:some.SomeEnum' {
   import alias = ಠ_ಠ.clutz.some.SomeEnum;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.some {
+  function setEnvironment (a : Environment ) : any ;
+}
+declare module 'goog:some.setEnvironment' {
+  import alias = ಠ_ಠ.clutz.some.setEnvironment;
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz {
@@ -24,5 +31,11 @@ declare namespace ಠ_ಠ.clutz {
   }
   class X_Instance {
     private noStructuralTyping_: any;
+  }
+}
+declare namespace ಠ_ಠ.clutz {
+  enum Environment {
+    FAKE = 0.0 ,
+    PROD = 4.0 ,
   }
 }

--- a/src/test/java/com/google/javascript/clutz/enum.js
+++ b/src/test/java/com/google/javascript/clutz/enum.js
@@ -1,5 +1,6 @@
 goog.provide('some.SomeEnum');
 goog.provide('some.ObjectValuedEnum');
+goog.provide('some.setEnvironment');
 
 /** @enum {number} */
 some.SomeEnum = {
@@ -15,3 +16,17 @@ some.ObjectValuedEnum = {
   A: new X(),
   B: new X()
 };
+
+/**
+ * @enum {number}
+ */
+const Environment = {
+  FAKE: 0,
+  PROD: 4
+};
+
+/** @param {!Environment} environment */
+function setEnvironment(environment) {}
+
+/** @param {!Environment} environment */
+some.setEnvironment = setEnvironment;

--- a/src/test/java/com/google/javascript/clutz/enum_from_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/enum_from_enum.d.ts
@@ -1,0 +1,18 @@
+declare namespace ಠ_ಠ.clutz.enum_from_enum.Bar.bar {
+  enum GoodEnum {
+    BAR = 2.0 ,
+    FOO = 1.0 ,
+  }
+}
+declare module 'goog:enum_from_enum.Bar.bar.GoodEnum' {
+  import alias = ಠ_ಠ.clutz.enum_from_enum.Bar.bar.GoodEnum;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.enum_from_enum.Foo.foo {
+  type DeprecatedEnum = enum_from_enum.Bar.bar.GoodEnum ;
+  const DeprecatedEnum : typeof enum_from_enum.Bar.bar.GoodEnum ;
+}
+declare module 'goog:enum_from_enum.Foo.foo.DeprecatedEnum' {
+  import alias = ಠ_ಠ.clutz.enum_from_enum.Foo.foo.DeprecatedEnum;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/enum_from_enum.js
+++ b/src/test/java/com/google/javascript/clutz/enum_from_enum.js
@@ -1,0 +1,14 @@
+goog.provide('enum_from_enum.Bar.bar.GoodEnum');
+goog.provide('enum_from_enum.Foo.foo.DeprecatedEnum');
+
+/** @enum {number} */
+enum_from_enum.Bar.bar.GoodEnum = {
+  FOO: 1,
+  BAR: 2
+};
+
+/**
+ * @enum {number}
+ * @deprecated Use {@link enum_from_enum.Bar.bar.GoodEnum} instead.
+ */
+enum_from_enum.Foo.foo.DeprecatedEnum = enum_from_enum.Bar.bar.GoodEnum;

--- a/src/test/java/com/google/javascript/clutz/enum_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/enum_usage.ts
@@ -1,2 +1,18 @@
 import SomeEnum from 'goog:some.SomeEnum';
-var v: SomeEnum = SomeEnum.A;
+
+const v: SomeEnum = SomeEnum.A;
+
+function exhaustive(v: SomeEnum) {
+  switch (v) {
+    case SomeEnum.A:
+    case SomeEnum.B:
+      break;
+
+    default:
+      neverSayNever(v);
+  }
+}
+
+function neverSayNever(never: never): never {
+  return never;
+}

--- a/src/test/java/com/google/javascript/clutz/enum_with_method.d.ts
+++ b/src/test/java/com/google/javascript/clutz/enum_with_method.d.ts
@@ -1,7 +1,18 @@
 declare namespace ಠ_ಠ.clutz.enums {
+  enum EnumWithInlineMethod {
+    A ,
+    B ,
+    C = 42.0 ,
+  }
+}
+declare module 'goog:enums.EnumWithInlineMethod' {
+  import alias = ಠ_ಠ.clutz.enums.EnumWithInlineMethod;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz.enums {
   enum EnumWithMethod {
-    APPLE ,
-    BANANA ,
+    APPLE = 1.0 ,
+    BANANA = 2.0 ,
   }
 }
 declare module 'goog:enums.EnumWithMethod' {

--- a/src/test/java/com/google/javascript/clutz/enum_with_method.js
+++ b/src/test/java/com/google/javascript/clutz/enum_with_method.js
@@ -1,4 +1,5 @@
 goog.provide('enums.EnumWithMethod');
+goog.provide('enums.EnumWithInlineMethod');
 
 /** @enum {number} */
 enums.EnumWithMethod = {
@@ -8,3 +9,16 @@ enums.EnumWithMethod = {
 
 //!! Known issue: does not get emitted.
 enums.EnumWithMethod.getColor = function() { return 'RED' /* all fruit are */; }
+
+/** @enum {number} */
+enums.EnumWithInlineMethod = {
+  A: 1 + 1,
+  B: f(0),
+  C: 42,
+}
+
+/**
+ * @param {number} input
+ * @return {number}
+ */
+function f(input) { return 5; }

--- a/src/test/java/com/google/javascript/clutz/extern_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/extern_enum.d.ts
@@ -1,5 +1,5 @@
 declare namespace ಠ_ಠ.clutz.ns {
   enum Enum {
-    A ,
+    A = 0.0 ,
   }
 }

--- a/src/test/java/com/google/javascript/clutz/interface.d.ts
+++ b/src/test/java/com/google/javascript/clutz/interface.d.ts
@@ -18,8 +18,8 @@ declare module 'goog:interface_exp' {
 }
 declare namespace ಠ_ಠ.clutz.interface_exp {
   enum SomeEnum {
-    A ,
-    B ,
+    A = 1.0 ,
+    B = 2.0 ,
   }
 }
 declare module 'goog:interface_exp.SomeEnum' {

--- a/src/test/java/com/google/javascript/clutz/nested_typedef_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/nested_typedef_enum.d.ts
@@ -7,7 +7,7 @@ declare module 'goog:nested_typedef_enum.Bar' {
 }
 declare namespace ಠ_ಠ.clutz.nested_typedef_enum.Bar {
   enum Baz {
-    A ,
+    A = 1.0 ,
   }
 }
 declare module 'goog:nested_typedef_enum.Bar.Baz' {

--- a/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/provide_single_class.d.ts
@@ -18,8 +18,8 @@ declare namespace ಠ_ಠ.clutz.foo.bar.Baz {
     private noStructuralTyping_: any;
   }
   enum NestedEnum {
-    A ,
-    B ,
+    B = 1.0 ,
+    XD = 2.0 ,
   }
 }
 declare module 'goog:foo.bar.Baz' {

--- a/src/test/java/com/google/javascript/clutz/provide_single_class.js
+++ b/src/test/java/com/google/javascript/clutz/provide_single_class.js
@@ -1,7 +1,7 @@
 goog.provide('foo.bar.Baz');
 
-// NestedClass and NestedEnum are not provided because this is against JS closure's
-// style guide.
+// NestedClass and NestedEnum are not provided because this is against JS
+// closure's style guide.
 // https://google.github.io/styleguide/javascriptguide.xml?showone=Providing_Dependencies_With_goog.provide#Providing_Dependencies_With_goog.provide
 
 /** @constructor */
@@ -54,6 +54,8 @@ foo.bar.Baz.NestedClass = function() {};
 
 /** @enum */
 foo.bar.Baz.NestedEnum = {
-  A: 1,
-  B: 2
+  // XD goes before B to test for enum value sorting. B should go first in the
+  // declarations file.
+  XD: 2,
+  B: 1
 };

--- a/src/test/java/com/google/javascript/clutz/provide_single_class_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/provide_single_class_usage.ts
@@ -1,9 +1,9 @@
 import C from 'goog:foo.bar.Baz';
 
-var n: number = C.staticMethod("some");
+var n: number = C.staticMethod('some');
 let x = new C();
 let s: string = x.field;
-n = x.method("some");
-let e: C.NestedEnum = C.NestedEnum.A;
+n = x.method('some');
+let e: C.NestedEnum = C.NestedEnum.XD;
 e = C.NestedEnum.B;
 var c: C.NestedClass = new C.NestedClass();

--- a/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch_nested_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_inheritance_mismatch_nested_type.d.ts
@@ -6,7 +6,7 @@ declare namespace ಠ_ಠ.clutz.sim_nested {
 }
 declare namespace ಠ_ಠ.clutz.sim_nested.Child {
   enum Nested {
-    B ,
+    B = 12.0 ,
   }
 }
 declare module 'goog:sim_nested.Child' {
@@ -15,7 +15,7 @@ declare module 'goog:sim_nested.Child' {
 }
 declare namespace ಠ_ಠ.clutz.sim_nested.Child {
   enum NestedAndProvided {
-    B ,
+    B = 12.0 ,
   }
 }
 declare module 'goog:sim_nested.Child.NestedAndProvided' {

--- a/src/test/java/com/google/javascript/clutz/static_provided.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_provided.d.ts
@@ -11,8 +11,8 @@ declare module 'goog:a.b.StaticHolder' {
 }
 declare namespace ಠ_ಠ.clutz.a.b.StaticHolder {
   enum AnEnum {
-    X ,
-    Y ,
+    X = 0.0 ,
+    Y = 1.0 ,
   }
 }
 declare module 'goog:a.b.StaticHolder.AnEnum' {


### PR DESCRIPTION
Improve enum_usage test by adding exhaustive checks for the enum.

Before clutz emitted:
declare namespace ಠ_ಠ.clutz.some {
  enum SomeEnum {
    A ,
    B ,
  }
}

Now it emits:
declare namespace ಠ_ಠ.clutz.some {
  enum SomeEnum {
    A = 1.0 ,
    B = 2.0 ,
  }
}

Closure always has the values present, but we need to use the AST to get
a hold of them. They are not part of the typesystem.

This change only affects number enums.

Fixes #663