### PR TITLE
Emit object literal types when visiting objects.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -48,7 +48,6 @@ import com.google.javascript.rhino.jstype.NoResolvedType;
 import com.google.javascript.rhino.jstype.NoType;
 import com.google.javascript.rhino.jstype.ObjectType;
 import com.google.javascript.rhino.jstype.ProxyObjectType;
-import com.google.javascript.rhino.jstype.RecordType;
 import com.google.javascript.rhino.jstype.TemplateType;
 import com.google.javascript.rhino.jstype.TemplateTypeMap;
 import com.google.javascript.rhino.jstype.TemplatizedType;
@@ -2201,7 +2200,7 @@ class DeclarationGenerator {
       }
     }
 
-    private void visitRecordType(RecordType type) {
+    private void visitRecordType(ObjectType type) {
       emit("{");
       Iterator<String> it = getSortedPropertyNamesToEmit(type).iterator();
       while (it.hasNext()) {
@@ -3032,8 +3031,6 @@ class DeclarationGenerator {
       String maybeGlobalName = maybeRenameGlobalType(type.getDisplayName());
       if (maybeGlobalName != null) {
         emit(maybeGlobalName);
-      } else if (type.isRecordType()) {
-        visitRecordType((RecordType) type);
       } else if (type.isDict()) {
         emit("{[key: string]: any}");
       } else if (type.getReferenceName() != null) {
@@ -3055,7 +3052,7 @@ class DeclarationGenerator {
           typesUsed.add(type.getDisplayName());
         }
       } else {
-        emit("GlobalObject");
+        visitRecordType(type);
       }
       return null;
     }

--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -769,13 +769,15 @@ class DeclarationGenerator {
     Iterator<TypedVar> it = externSymbols.iterator();
 
     while (it.hasNext()) {
-      // Some extern symbols appear twice, once unprefixed, and once prefixed with window.
+      // Some extern symbols appear twice, once unprefixed, and once prefixed with window or this.
       // Skip the second one, if both exist.
       TypedVar symbol = it.next();
-      if (symbol.getName().startsWith("window.")
-          && externSymbolNames.contains(symbol.getName().substring(7))) {
-        it.remove();
-        externSymbolNames.remove(symbol.getName());
+      if (symbol.getName().startsWith("window.") || symbol.getName().startsWith("this.")) {
+        String normalizedName = symbol.getName().replaceAll("^(window|this)\\.", "");
+        if (externSymbolNames.contains(normalizedName)) {
+          it.remove();
+          externSymbolNames.remove(symbol.getName());
+        }
       }
     }
 

--- a/src/test/java/com/google/javascript/clutz/nested_namespace_unprovided.d.ts
+++ b/src/test/java/com/google/javascript/clutz/nested_namespace_unprovided.d.ts
@@ -1,0 +1,7 @@
+declare namespace ಠ_ಠ.clutz.some.ns {
+  var inner : { A : number , B : number } ;
+}
+declare module 'goog:some.ns' {
+  import alias = ಠ_ಠ.clutz.some.ns;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/nested_namespace_unprovided.js
+++ b/src/test/java/com/google/javascript/clutz/nested_namespace_unprovided.js
@@ -1,0 +1,10 @@
+goog.provide('some.ns');
+
+/** @const */
+some.ns.inner = {};
+
+/** @type {number} */
+some.ns.inner.A = 0;
+
+/** @type {number} */
+some.ns.inner.B = 0;

--- a/src/test/java/com/google/javascript/clutz/types.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types.d.ts
@@ -14,7 +14,7 @@ declare namespace ಠ_ಠ.clutz.types {
   /**
    * marked const to appear in `compiler.getTopScope().getAllSymbols()`
    */
-  var inferredobj : GlobalObject ;
+  var inferredobj : { } ;
   var j : { [ key: number ]: string } | null ;
   var recordType : { a : string , b : any } ;
   var recordTypeOptional : { a : string , optional ? : string } ;

--- a/src/test/java/com/google/javascript/clutz/undefined_provide.d.ts
+++ b/src/test/java/com/google/javascript/clutz/undefined_provide.d.ts
@@ -1,12 +1,12 @@
 declare namespace ಠ_ಠ.clutz.undefined.nested {
-  var provide : GlobalObject ;
+  var provide : { } ;
 }
 declare module 'goog:undefined.nested.provide' {
   import alias = ಠ_ಠ.clutz.undefined.nested.provide;
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz {
-  var undefined_provide : GlobalObject ;
+  var undefined_provide : { } ;
 }
 declare module 'goog:undefined_provide' {
   import alias = ಠ_ಠ.clutz.undefined_provide;


### PR DESCRIPTION
Previously, we just emitted GlobalObject (alias for Object). However, we
do have enough information to emit an objectl literal type, even though
 closure does not report those types as proper record types.

Especially for inferred namespaces this option is preferable to the
opaque object type.

For a real opaque 'Object' types instead of 'GlobalObject', clutz now
emits '{}' which is equivalent in TypeScript.