### PR TITLE
Upstreaming fix to skip this.props coming the window object.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -769,13 +769,15 @@ class DeclarationGenerator {
     Iterator<TypedVar> it = externSymbols.iterator();
 
     while (it.hasNext()) {
-      // Some extern symbols appear twice, once unprefixed, and once prefixed with window.
+      // Some extern symbols appear twice, once unprefixed, and once prefixed with window or this.
       // Skip the second one, if both exist.
       TypedVar symbol = it.next();
-      if (symbol.getName().startsWith("window.")
-          && externSymbolNames.contains(symbol.getName().substring(7))) {
-        it.remove();
-        externSymbolNames.remove(symbol.getName());
+      if (symbol.getName().startsWith("window.") || symbol.getName().startsWith("this.")) {
+        String normalizedName = symbol.getName().replaceAll("^(window|this)\\.", "");
+        if (externSymbolNames.contains(normalizedName)) {
+          it.remove();
+          externSymbolNames.remove(symbol.getName());
+        }
       }
     }
 


### PR DESCRIPTION
A recent change in closure made window externs appear duplicated as
this.foo too.

https://github.com/google/closure-compiler/commit/f3bc96d9ebc296ee79fa1f4c8051f8db5d51f709

Original author @kevinoconnor7