### PR TITLE
Do not consider simpler default obj lit exports as default exports.

### DIFF
--- a/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
@@ -636,30 +636,29 @@ public final class ModuleConversionPass implements CompilerPass {
     Node rhs = assign.getLastChild();
     JSDocInfo jsDoc = NodeUtil.getBestJSDocInfo(assign);
 
-    ExportedSymbol symbolToExport =
-        ExportedSymbol.fromExportAssignment(rhs, exportedNamespace, exportedSymbol, fileName);
-
     if (lhs.matchesQualifiedName(exportedNamespace)) {
       rhs.detach();
-      Node exportSpecNode;
-      if (rhs.isName() && exportsToNodes.containsKey(symbolToExport)) {
-        // Rewrite the AST to export the symbol directly using information from the export
-        // assignment.
-        Node namedNode = exportsToNodes.get(symbolToExport);
-        Node next = namedNode.getNext();
-        Node parent = namedNode.getParent();
-        namedNode.detach();
-
-        Node export = new Node(Token.EXPORT, namedNode);
-        export.useSourceInfoFromForTree(assign);
-
-        nodeComments.moveComment(namedNode, export);
-        parent.addChildBefore(export, next);
+      if (isObjLitWithSimpleRefs(rhs)) {
+        for (Node child : rhs.children()) {
+          ExportedSymbol symbolToExport =
+              ExportedSymbol.fromExportAssignment(
+                  child.getFirstChild(), exportedNamespace, child.getString(), fileName);
+          moveExportStmtToADeclKeyword(assign, exportsToNodes.get(symbolToExport));
+        }
         exprNode.detach();
-
-        compiler.reportChangeToEnclosingScope(parent);
         return;
-      } else if (rhs.isName() && exportedSymbol.equals(rhs.getString())) {
+      }
+      ExportedSymbol symbolToExport =
+          ExportedSymbol.fromExportAssignment(rhs, exportedNamespace, exportedSymbol, fileName);
+      if (rhs.isName() && exportsToNodes.containsKey(symbolToExport)) {
+        moveExportStmtToADeclKeyword(assign, exportsToNodes.get(symbolToExport));
+        exprNode.detach();
+        return;
+      }
+
+      // Below the export node stays but is modified.
+      Node exportSpecNode;
+      if (rhs.isName() && exportedSymbol.equals(rhs.getString())) {
         // Rewrite the export line to: <code>export {rhs}</code>.
         exportSpecNode = createExportSpecs(rhs);
         exportSpecNode.useSourceInfoFrom(rhs);
@@ -676,6 +675,50 @@ public final class ModuleConversionPass implements CompilerPass {
       // Assume prefix has already been exported and just trim the prefix
       nameUtil.replacePrefixInName(lhs, exportedNamespace, exportedSymbol);
     }
+  }
+
+  /**
+   * Returns true is the object is an object literal where all values are symbols that match the
+   * name:
+   *
+   * <p>Ex: {A, B: B} -> true {A: C} -> false {A: A + 1} -> false
+   *
+   * <p>TODO(rado): see if we can also support simple renaming objects like {NewName: OldName}.
+   */
+  private boolean isObjLitWithSimpleRefs(Node node) {
+    if (!node.isObjectLit()) return false;
+    for (Node child : node.children()) {
+      if (!child.isStringKey() || !child.getFirstChild().isName()) {
+        return false;
+      }
+      if (!child.getString().equals(child.getFirstChild().getString())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Takes an assignment statement (export or goog.provide one), removes it and instead finds the
+   * matching declaration and adds an 'export' keyword.
+   *
+   * <p>Before: class C {} exports.C = C;
+   *
+   * <p>After: export class C {};
+   */
+  private void moveExportStmtToADeclKeyword(Node assignmentNode, Node declarationNode) {
+    // Rewrite the AST to export the symbol directly using information from the export
+    // assignment.
+    Node next = declarationNode.getNext();
+    Node parent = declarationNode.getParent();
+    declarationNode.detach();
+
+    Node export = new Node(Token.EXPORT, declarationNode);
+    export.useSourceInfoFromForTree(assignmentNode);
+
+    nodeComments.moveComment(declarationNode, export);
+    parent.addChildBefore(export, next);
+    compiler.reportChangeToEnclosingScope(parent);
   }
 
   /** Creates an ExportSpecs node, which is the {...} part of an "export {name}" node. */

--- a/src/test/java/com/google/javascript/gents/multiTests/exported_default_obj/exporter.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/exported_default_obj/exporter.js
@@ -1,0 +1,5 @@
+goog.module('default_obj.exporter');
+
+class C {}
+
+exports = {C};

--- a/src/test/java/com/google/javascript/gents/multiTests/exported_default_obj/exporter.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/exported_default_obj/exporter.ts
@@ -1,0 +1,2 @@
+
+export class C {}

--- a/src/test/java/com/google/javascript/gents/multiTests/exported_default_obj/importer.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/exported_default_obj/importer.js
@@ -1,0 +1,6 @@
+goog.module('default_obj.importer');
+
+const {C} = goog.require('default_obj.exporter');
+
+let c = new C();
+

--- a/src/test/java/com/google/javascript/gents/multiTests/exported_default_obj/importer.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/exported_default_obj/importer.ts
@@ -1,0 +1,2 @@
+import {C} from './exporter';
+let c = new C();

--- a/src/test/java/com/google/javascript/gents/singleTests/module_default_export_obj.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_default_export_obj.js
@@ -1,0 +1,12 @@
+goog.module('mod.default.export.obj');
+
+/** some comment */
+class C {}
+
+function f() {}
+
+const a = 0;
+
+exports = {
+  C, f, a
+};

--- a/src/test/java/com/google/javascript/gents/singleTests/module_default_export_obj.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_default_export_obj.ts
@@ -1,0 +1,7 @@
+
+/** some comment */
+export class C {}
+
+export function f() {}
+
+export const a = 0;


### PR DESCRIPTION
Gents tries to not use default exports to account for an internal style
rule to not use default exports. However, some default exports are
trivial obj literals that just safe typing for the author.

class C {}
class D {}

exports = {C, D};

After this change gents will translate this file as if it was writen in
the equivalent style of:

exports.C = C;
exports.D = D;

Closes #527