### PR TITLE
Fix gents not to throw when visiting a typedef alias.

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeConversionPass.java
@@ -120,12 +120,23 @@ public final class TypeConversionPass implements CompilerPass {
           // Typedef of simple types
           createTypeAlias(n, parent);
           break;
-        case NAME:
         case VAR:
         case LET:
         case CONST:
           createTypeAlias(n, parent);
           break;
+        case NAME:
+          // NAME token can occur in many locations. Only create an alias for ones that are direct
+          // children of statements.
+          // Without this check, gents will try to create two aliases for code like:
+          // /** @typedef {...} */
+          // Foo.Bar = Buz;
+          // Because of the NAME tokens - Bar and Buz.
+          if (parent.isExprResult() && parent.getChildCount() == 1) {
+            createTypeAlias(n, parent);
+          }
+          break;
+
         case CLASS:
           JSDocInfo jsDoc = n.getJSDocInfo();
           // If a class has the @interface or @record annotation we will respect that and turn it into an interface.

--- a/src/test/java/com/google/javascript/gents/singleTests/inner_typedef_alias.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/inner_typedef_alias.js
@@ -1,0 +1,19 @@
+goog.module('inner.class');
+
+class Inner {
+}
+
+class Outer {
+}
+
+/** @typedef {!Inner} */
+Outer.RenameInner = Inner;
+
+//!! Technicaly we should also test Outer.Inner = Inner, but that produces
+//!! a Closure error at the end of the gents run that we check against.
+//!! It happens because when we flatten the alias collides with the original
+//!! definition. That said, it does not crash gents.
+//!! TODO(rado): detect that this is an alias for something that is about to
+//!! be flattened and just don't emit.
+
+exports = Outer;

--- a/src/test/java/com/google/javascript/gents/singleTests/inner_typedef_alias.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/inner_typedef_alias.ts
@@ -1,0 +1,5 @@
+
+class Inner {}
+
+export class Outer {}
+type RenameInner = Inner;


### PR DESCRIPTION
Paterns of the shape:

class C {}
/** @typedef {...} */
C.Alias = Other;

where throwing off gents, because we were trying emit twice: once for
Alias and once for Other. Fix by not considering Other in such cases.