### PR TITLE
Accept --dependenciesManifest and --sourcesManifest

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -22,7 +22,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -32,9 +32,9 @@
       "integrity": "sha512-x90Hac4ERacGDcZSvHKK58Ga0STuMD+Doi5g0iG2zf7wlJef5Huvhs/3BvMRFxwRYyYSdl6mpQNrtfMxE8MQzw==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "glob": "7.1.2",
-        "resolve": "1.7.1"
+        "async": "^1.5.2",
+        "glob": "^7.0.0",
+        "resolve": "^1.1.6"
       }
     },
     "concat-map": {
@@ -55,12 +55,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "inflight": {
@@ -69,8 +69,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -85,7 +85,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "once": {
@@ -94,7 +94,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -115,7 +115,7 @@
       "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "typescript": {

--- a/src/main/java/com/google/javascript/gents/Options.java
+++ b/src/main/java/com/google/javascript/gents/Options.java
@@ -48,6 +48,24 @@ public class Options {
   String moduleRewriteLog = null;
 
   @Option(
+    name = "--dependenciesManifest",
+    usage =
+        "the path to a manifest file containing all dependencies\n"
+            + "This option overrides the explicitly passed files",
+    metaVar = "DEPENDENCIES_MANIFEST"
+  )
+  String dependenciesManifest = null;
+
+  @Option(
+    name = "--sourcesManifest",
+    usage =
+        "the path to a manifest file containing all files that need to be converted to TypeScript\n"
+            + "This option overrides the files passed by \"--convert\"",
+    metaVar = "SOURCES_MANIFEST"
+  )
+  String sourcesManifest = null;
+
+  @Option(
     name = "--convert",
     usage =
         "list of all files to be converted to TypeScript\n"
@@ -136,7 +154,27 @@ public class Options {
   Options(String[] args) throws CmdLineException {
     CmdLineParser parser = new CmdLineParser(this);
     parser.parseArgument(args);
-    srcFiles.addAll(arguments);
+
+    if (sourcesManifest != null) {
+      try {
+        filesToConvert = Files.readAllLines(Paths.get(sourcesManifest), UTF_8);
+      } catch (IOException e) {
+        throw new CmdLineException(
+            parser, "sources manifest file " + sourcesManifest + " not found.", e);
+      }
+    }
+
+    if (dependenciesManifest == null) {
+      srcFiles.addAll(arguments);
+    } else {
+      try {
+        srcFiles.addAll(Files.readAllLines(Paths.get(dependenciesManifest), UTF_8));
+      } catch (IOException e) {
+        throw new CmdLineException(
+            parser, "dependencies manifest file " + dependenciesManifest + " not found.", e);
+      }
+    }
+
     srcFiles.addAll(filesToConvert);
 
     if (srcFiles.isEmpty()) {

--- a/src/main/java/com/google/javascript/gents/Options.java
+++ b/src/main/java/com/google/javascript/gents/Options.java
@@ -51,7 +51,7 @@ public class Options {
     name = "--dependenciesManifest",
     usage =
         "the path to a manifest file containing all dependencies\n"
-            + "This option overrides the explicitly passed files",
+            + "Passing dependency files is disallowed when \"--dependenciesManifest\" option is used",
     metaVar = "DEPENDENCIES_MANIFEST"
   )
   String dependenciesManifest = null;
@@ -60,7 +60,7 @@ public class Options {
     name = "--sourcesManifest",
     usage =
         "the path to a manifest file containing all files that need to be converted to TypeScript\n"
-            + "This option overrides the files passed by \"--convert\"",
+            + "\"--convert\" option is disallowed when \"--sourcesManifest\" option is used",
     metaVar = "SOURCES_MANIFEST"
   )
   String sourcesManifest = null;
@@ -154,6 +154,16 @@ public class Options {
   Options(String[] args) throws CmdLineException {
     CmdLineParser parser = new CmdLineParser(this);
     parser.parseArgument(args);
+
+    if (filesToConvert.size() != 0 && sourcesManifest != null) {
+      throw new CmdLineException(
+          parser, "Don't specify a sources manifest file and source files at the same time.");
+    }
+    if (arguments.size() != 0 && dependenciesManifest != null) {
+      throw new CmdLineException(
+          parser,
+          "Don't specify a dependencies manifest file and dependency files at the same time.");
+    }
 
     if (sourcesManifest != null) {
       try {

--- a/src/main/java/com/google/javascript/gents/Options.java
+++ b/src/main/java/com/google/javascript/gents/Options.java
@@ -157,12 +157,13 @@ public class Options {
 
     if (filesToConvert.size() != 0 && sourcesManifest != null) {
       throw new CmdLineException(
-          parser, "Don't specify a sources manifest file and source files at the same time.");
+          parser,
+          "Don't specify a sources manifest file and source files (\"--convert\") at the same time.");
     }
     if (arguments.size() != 0 && dependenciesManifest != null) {
       throw new CmdLineException(
           parser,
-          "Don't specify a dependencies manifest file and dependency files at the same time.");
+          "Don't specify a dependencies manifest file and dependency files as arguments at the same time.");
     }
 
     if (sourcesManifest != null) {


### PR DESCRIPTION
This allows the node wrapper to pass manifest files instead of all files to gents, which causes E2BIG failures.