### PR TITLE
Fix a problem when migrating multiple sources that destructuring import the same module.

### DIFF
--- a/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/destructuring_imports_same_module.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/destructuring_imports_same_module.js
@@ -1,0 +1,4 @@
+//!! When multiple sources migrate together and destructuring import from the
+//!! same module all imports should be migrated independently of one another.
+const already_converted_to_ts_keep_module = goog.require("google3.src.test.java.com.google.javascript.gents.multiTests.converts_ts_module_require.already_converted_to_ts_keep");
+const {foo, bar} = already_converted_to_ts_keep_module;

--- a/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/destructuring_imports_same_module.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/destructuring_imports_same_module.ts
@@ -1,0 +1,1 @@
+import {bar, foo} from '../converts_ts_module_require/already_converted_to_ts_keep';


### PR DESCRIPTION
Turns out that I never understood gents 😞 

`root` is different from the sourceFile object from TypeScript. `root` is not the root node of a single
source file. Instead all source files are direct children of this "root" node. That means when the `DestructuringCollector` stores imported modules it's mixing the modules across multiple source files. The fix is to store the imported modules, per file.