### PR TITLE
Fix test broken with latest closure head.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/fn_params.d.ts
+++ b/src/test/java/com/google/javascript/clutz/fn_params.d.ts
@@ -5,8 +5,8 @@ declare namespace ಠ_ಠ.clutz.fn_params {
   /**
    * Parameters intentionally documented in the wrong order
    */
-  function varargs (x : string ,  ...y : ( number | undefined ) [] ) : void ;
-  function varargs_fns ( ...var_args : ( Function | null | undefined ) [] ) : void ;
+  function varargs (x : string ,  ...y : number [] ) : void ;
+  function varargs_fns ( ...var_args : ( Function | null ) [] ) : void ;
 }
 declare module 'goog:fn_params' {
   import alias = ಠ_ಠ.clutz.fn_params;

--- a/src/test/java/com/google/javascript/clutz/inferred_obj.d.ts
+++ b/src/test/java/com/google/javascript/clutz/inferred_obj.d.ts
@@ -1,6 +1,4 @@
 declare namespace ಠ_ಠ.clutz.inferred.nested.obj {
-  // skipping property '0123' because it is not a valid symbol.
-  // skipping property 'must-be-quoted' because it is not a valid symbol.
   var nestedObj : { '0123' : number , 'must-be-quoted' : number , quoted : number , regular : number } ;
   var quotedProp : number ;
   var regular : number ;

--- a/src/test/java/com/google/javascript/clutz/inferred_obj.js
+++ b/src/test/java/com/google/javascript/clutz/inferred_obj.js
@@ -11,11 +11,11 @@ inferred.nested.obj = {
   'quotedProp': 1,
   '0123': 2,
   'must-be-quoted': 3,
-  //!! TODO(radokirov): Add 'has.comma.bad' prop and fix issues.
+  //!! TODO(radokirov): Add a property named 'has.period' and fix issues.
   nestedObj: {
     regular: 0,
     'quoted': 1,
     '0123': 2,
-    'must-be-quoted': 3
+    'must-be-quoted': 3,
   }
 };

--- a/src/test/java/com/google/javascript/clutz/invalid_names.d.ts
+++ b/src/test/java/com/google/javascript/clutz/invalid_names.d.ts
@@ -1,16 +1,10 @@
 declare namespace ಠ_ಠ.clutz.invalid.names {
-  // skipping property '0' because it is not a valid symbol.
-  // skipping property '1' because it is not a valid symbol.
   var valid : null ;
 }
 declare module 'goog:invalid.names' {
   import alias = ಠ_ಠ.clutz.invalid.names;
   export = alias;
 }
-// skipping property ext.0 because it is not a valid symbol.
-// skipping property ext.1 because it is not a valid symbol.
-// skipping property ext.invalidNames.0 because it is not a valid symbol.
-// skipping property ext.invalidNames.1 because it is not a valid symbol.
 declare namespace ಠ_ಠ.clutz.ext.invalidNames {
   var valid : null ;
 }


### PR DESCRIPTION
It appears a number of invalid property names are simply no longer
reported seen by clutz, because the undelying closure object has
pre-filtered them.

This means we no longer print '//!! clutz skipped property foo' type of
comments on them.