### PR TITLE
Fixes exporting typedefs through obj lit.

### DIFF
--- a/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
@@ -128,7 +128,7 @@ public final class ModuleConversionPass implements CompilerPass {
       }
 
       if (!n.isExprResult()) {
-        if (n.isConst() || n.isClass() || n.isFunction()) {
+        if (n.isConst() || n.isClass() || n.isFunction() || n.isLet() || n.isConst() || n.isVar()) {
           collectMetdataForExports(n, fileName);
         }
         return;
@@ -686,7 +686,10 @@ public final class ModuleConversionPass implements CompilerPass {
           ExportedSymbol symbolToExport =
               ExportedSymbol.fromExportAssignment(
                   child.getFirstChild(), exportedNamespace, child.getString(), fileName);
-          moveExportStmtToADeclKeyword(assign, exportsToNodes.get(symbolToExport));
+          Node exportNode = exportsToNodes.get(symbolToExport);
+          if (exportNode != null) {
+            moveExportStmtToADeclKeyword(assign, exportNode);
+          }
         }
         exprNode.detach();
         return;

--- a/src/test/java/com/google/javascript/gents/singleTests/module_both.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_both.js
@@ -1,9 +1,17 @@
 goog.module("both.A.B");
 
+/**
+ * Note: As written in .js if num is reassigned by a consumer of the goog.module
+ * L and C will still return the original value of '4'.
+ * During translation to .ts, according to ES6 module semantics, the
+ * reassignment will be reflected because the bindings are live.
+ *
+ * This is an intentional semantic mismatch, because most of the time the
+ * bindings are immutable and 'export let L' is syntactically preferable.
+ */
 var num = 4;
 /**
- * Note: `var` and `let` may be unsafe to export directly. 
- * @return {number} 
+ * @return {number}
  */
 var B = function() { return num; };
 
@@ -15,7 +23,6 @@ const C = function() { return num; };
 exports.C = C;
 
 /**
- * Note: `let` may be unsafe to export directly.
  * @return {number}
  */
 var L = function() { return num; };

--- a/src/test/java/com/google/javascript/gents/singleTests/module_both.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/module_both.ts
@@ -1,28 +1,26 @@
-let num = 4;
 
 /**
- * Note: `var` and `let` may be unsafe to export directly.
+ * Note: As written in .js if num is reassigned by a consumer of the goog.module
+ * L and C will still return the original value of '4'.
+ * During translation to .ts, according to ES6 module semantics, the
+ * reassignment will be reflected because the bindings are live.
+ *
+ * This is an intentional semantic mismatch, because most of the time the
+ * bindings are immutable and 'export let L' is syntactically preferable.
  */
-let B = function(): number {
+export let num = 4;
+
+export let B = function(): number {
   return num;
 };
-
-export {B};
 
 export function C(): number {
   return num;
 }
 
-/**
- * Note: `let` may be unsafe to export directly.
- */
-let L = function(): number {
+export let L = function(): number {
   return num;
 };
-
-export {L};
-
-export {num};
 
 export class foo {
   static z: number;

--- a/src/test/java/com/google/javascript/gents/singleTests/typedef_obj_export.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/typedef_obj_export.js
@@ -1,0 +1,10 @@
+goog.module('typedef.exported.obj');
+
+/**
+ * @typedef {number|string}
+ */
+let ATypeDef;
+
+exports = {
+  ATypeDef
+};

--- a/src/test/java/com/google/javascript/gents/singleTests/typedef_obj_export.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/typedef_obj_export.ts
@@ -1,0 +1,2 @@
+
+export type ATypeDef = number|string;


### PR DESCRIPTION
Previously this caused an NPE due to missing nodes. It appears we held
back unrolling

```
let x = 0;
export {x};
```

into

```
export let x = 0;
```

because of possibility of mutable bindings. I think the vast majority of
bindings are immutable (for example typedefs), so this cl reverts this
decision. It prefers the simpler syntactic output for the majority,
while accepting that in some cases the translation is not semantically
 accurate.