### PR TITLE
Emit static properties of interfaces.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/goog_promise_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_promise_with_platform.d.ts
@@ -15,14 +15,14 @@ declare module 'goog:goog.Promise' {
   export default alias;
 }
 declare namespace ಠ_ಠ.clutz.goog {
+  namespace Thenable {
+    var IMPLEMENTED_BY_PROP : string ;
+    function addImplementation (ctor : { new ( ...a : any [] ) : ಠ_ಠ.clutz.goog.Thenable < any > } ) : void ;
+    function isImplementedBy (object : any ) : boolean ;
+  }
   interface Thenable < TYPE > extends PromiseLike < TYPE > {
     then < RESULT > (opt_onFulfilled ? : ( (a : TYPE ) => ಠ_ಠ.clutz.goog.Thenable < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : ಠ_ಠ.clutz.goog.Thenable < RESULT > ;
   }
-}
-declare namespace ಠ_ಠ.clutz.goog.Thenable {
-  var IMPLEMENTED_BY_PROP : string ;
-  function addImplementation (ctor : { new ( ...a : any [] ) : ಠ_ಠ.clutz.goog.Thenable < any > } ) : void ;
-  function isImplementedBy (object : any ) : boolean ;
 }
 declare module 'goog:goog.Thenable' {
   import alias = ಠ_ಠ.clutz.goog.Thenable;

--- a/src/test/java/com/google/javascript/clutz/interface.d.ts
+++ b/src/test/java/com/google/javascript/clutz/interface.d.ts
@@ -9,8 +9,6 @@ declare namespace ಠ_ಠ.clutz.interface_exp {
   class SomeClazz_Instance {
     private noStructuralTyping_: any;
   }
-  function staticMethod ( ) : number ;
-  var staticProp : number ;
 }
 declare module 'goog:interface_exp' {
   import alias = ಠ_ಠ.clutz.interface_exp;

--- a/src/test/java/com/google/javascript/clutz/interface.js
+++ b/src/test/java/com/google/javascript/clutz/interface.js
@@ -7,12 +7,6 @@ interface_exp = function() {};
 /** @return {number} */
 interface_exp.prototype.method = function() {};
 
-/** @return {number} */
-interface_exp.staticMethod = function() {return interface_exp.staticProp;};
-
-/** @type {number} */
-interface_exp.staticProp = 0;
-
 /** @enum {number} */
 interface_exp.SomeEnum = {
   A: 1,

--- a/src/test/java/com/google/javascript/clutz/interface_provided_static_method.d.ts
+++ b/src/test/java/com/google/javascript/clutz/interface_provided_static_method.d.ts
@@ -1,0 +1,11 @@
+declare namespace ಠ_ಠ.clutz.interface_provided_static_method {
+  namespace FunctionIf {
+    function staticMethod ( ) : string ;
+  }
+  interface FunctionIf {
+  }
+}
+declare module 'goog:interface_provided_static_method.FunctionIf' {
+  import alias = ಠ_ಠ.clutz.interface_provided_static_method.FunctionIf;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/interface_provided_static_method.js
+++ b/src/test/java/com/google/javascript/clutz/interface_provided_static_method.js
@@ -1,0 +1,6 @@
+goog.provide('interface_provided_static_method.FunctionIf');
+
+/** @interface */
+interface_provided_static_method.FunctionIf = function() {};
+/** @return {string} */
+interface_provided_static_method.FunctionIf.staticMethod = function() { return 'a'; };

--- a/src/test/java/com/google/javascript/clutz/interface_static_method.d.ts
+++ b/src/test/java/com/google/javascript/clutz/interface_static_method.d.ts
@@ -1,0 +1,19 @@
+declare namespace ಠ_ಠ.clutz.module$exports$interface_static_method {
+  namespace ClassIf {
+    function staticMethod ( ) : any ;
+  }
+  interface ClassIf {
+    method ( ) : string ;
+  }
+  namespace FunctionIf {
+    function staticMethod ( ) : string ;
+    var staticProperty : string ;
+  }
+  interface FunctionIf {
+    method ( ) : string ;
+  }
+}
+declare module 'goog:interface_static_method' {
+  import alias = ಠ_ಠ.clutz.module$exports$interface_static_method;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/interface_static_method.js
+++ b/src/test/java/com/google/javascript/clutz/interface_static_method.js
@@ -1,0 +1,21 @@
+goog.module('interface_static_method');
+
+/** @interface */
+var FunctionIf = function() {};
+/** @return {string} */
+FunctionIf.prototype.method = function() {};
+/** @return {string} */
+FunctionIf.staticMethod = function() { return 'a'; };
+/** @type {string} */
+FunctionIf.staticProperty;
+
+/** @interface */
+class ClassIf {
+  /** @return {string} */
+  method() {};
+
+  static staticMethod() { return 'a'; }
+}
+
+exports.FunctionIf = FunctionIf;
+exports.ClassIf = ClassIf;

--- a/src/test/java/com/google/javascript/clutz/interface_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/interface_usage.ts
@@ -1,9 +1,12 @@
 import I from 'goog:interface_exp';
 import E from 'goog:interface_exp.SomeEnum';
+import * as ifStaticMethod from 'goog:interface_static_method';
+import FunctionIf from 'goog:interface_provided_static_method.FunctionIf';
 
 class C implements I {
     method(): number { return 0; }
 }
 
-var a: number = I.staticMethod();
+var str: string = ifStaticMethod.FunctionIf.staticMethod();
+var str2: string = FunctionIf.staticMethod();
 var e: E = E.A;


### PR DESCRIPTION
In Closure, JS code can legally define static properties on interfaces:

    /** @interface */
    class Foo {
      static bar() { return 'a'; }
    }

This is also allowed on interfaces not using the newer class syntax, but
just prototype declarations.

In TypeScript, this can be represented as a namespace object that
matches the interface's name:

    // A normal interface definition.
    interface A {
      foo(): void;
    }

    namespace A {
      // Declare a static function in A
      export function bar() {
        return 'bar';
      }
    }

    // Can invoke bar on A.
    A.bar();

    // B can still impement A with only the `foo` method defined.
    class B implements A {
      foo() {}
    }