### PR TITLE
Emit value aliases for interfaces with static props.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -154,6 +154,8 @@ class DeclarationGenerator {
 
   private static final String MODULE_PREFIX = "module$exports$";
 
+  private static final Splitter DOT_SPLITTER = Splitter.on('.');
+
   public static void main(String[] args) {
     Options options = null;
     try {
@@ -743,9 +745,9 @@ class DeclarationGenerator {
         String namespace;
         String googModuleStyleName;
         if (e.getKey().contains(".")) {
-          String[] nameParts = e.getKey().split("\\.");
-          namespace = nameParts[0];
-          googModuleStyleName = nameParts[1];
+          List<String> nameParts = DOT_SPLITTER.splitToList(e.getKey());
+          namespace = nameParts.get(0);
+          googModuleStyleName = nameParts.get(1);
         } else {
           namespace = "";
           googModuleStyleName = e.getKey();
@@ -1062,8 +1064,8 @@ class DeclarationGenerator {
         // For inferred symbols there is no matching symbol, so the best we can do is pull the
         // type from the module object type map.
         for (String desiredSymbol : desiredSymbols) {
-          String[] parts = desiredSymbol.split("\\.");
-          String propName = parts[parts.length - 1];
+          List<String> parts = DOT_SPLITTER.splitToList(desiredSymbol);
+          String propName = parts.get(parts.size() - 1);
           if (!isValidJSProperty(propName)) {
             emitComment("skipping property " + propName + " because it is not a valid symbol.");
             continue;
@@ -1902,7 +1904,7 @@ class DeclarationGenerator {
      * literal initializers to complete the type alias.
      */
     private Set<String> collectAllLiterals(Map<String, Node> elements) {
-      Set<String> literalInitializers = new HashSet();
+      Set<String> literalInitializers = new HashSet<>();
       for (Node n : elements.values()) {
         if (n.isString()) {
           literalInitializers.add(n.getString());
@@ -2036,7 +2038,7 @@ class DeclarationGenerator {
      * so just replace the part of the display name before the first period
      */
     private String maybeRewriteImportedName(String displayName) {
-      String baseDisplayName = displayName.split("\\.")[0];
+      String baseDisplayName = DOT_SPLITTER.split(displayName).iterator().next();
       if (importRenameMap.containsKey(baseDisplayName)) {
         displayName = displayName.replace(baseDisplayName, importRenameMap.get(baseDisplayName));
       }

--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -1543,9 +1543,11 @@ class DeclarationGenerator {
       visitTemplateTypes(otype, Collections.emptyList(), false);
       emit(";");
       emitBreak();
-      if (!otype.isInterface()) {
+      if (!otype.isInterface() || !getTypePropertyNamesToEmit(otype, true).isEmpty()) {
         // TS type aliases are only useful in type positions.
-        // To emulate closure alias semantics, introduce also an aliased constructor
+        // To emulate closure alias semantics, introduce also an aliased constructor if there is a
+        // value associated with the type (i.e. non-interfaces or interfaces that also have static
+        // properties emitted on them).
         emit("var " + unqualifiedName);
         emit(":");
         emit("typeof");

--- a/src/test/java/com/google/javascript/clutz/DeclarationGeneratorTests.java
+++ b/src/test/java/com/google/javascript/clutz/DeclarationGeneratorTests.java
@@ -105,7 +105,7 @@ public class DeclarationGeneratorTests {
     // Test files that live in the 'multifilePartial' dir, and run with the --partialInput option
     // The resulting .d.ts files are checked with a DeclarationSyntaxTest, and they're also
     // compiled in a single run in MultiFileTest
-    File[] testMultifilePartailFiles =
+    File[] testMultifilePartialFiles =
         getPackagePath().resolve("multifilePartial").toFile().listFiles(filter);
     // Test files that live in the 'testPartialCrossModuleTypeImportsFiles' dir, and run with the
     // --partialInput and --googProvides options.  The resulting .d.ts files are checked with a
@@ -116,7 +116,7 @@ public class DeclarationGeneratorTests {
     File[] testOutputBaseFiles = getPackagePath().resolve("outputBase").toFile().listFiles(filter);
     List<File> filesList = Lists.newArrayList(testFiles);
     filesList.addAll(Arrays.asList(testPartialFiles));
-    filesList.addAll(Arrays.asList(testMultifilePartailFiles));
+    filesList.addAll(Arrays.asList(testMultifilePartialFiles));
     filesList.addAll(Arrays.asList(testPartialCrossModuleTypeImportsFiles));
     filesList.addAll(Arrays.asList(testOutputBaseFiles));
 

--- a/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
+++ b/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
@@ -27,21 +27,16 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DeclarationSyntaxTest {
   private static final FilenameFilter JS_MULTIFILE_PARTIAL =
-      new FilenameFilter() {
-        @Override
-        public boolean accept(File dir, String name) {
-          return JS_NO_EXTERNS.accept(dir, name) && dir.getName().equals("multifilePartial");
-        }
-      };
+      (File dir, String name) ->
+          JS_NO_EXTERNS.accept(dir, name) && dir.getName().equals("multifilePartial");
 
   private static final FilenameFilter JS_PARTIAL_CROSS_MODULE_TYPE_IMPORTS =
-      new FilenameFilter() {
-        @Override
-        public boolean accept(File dir, String name) {
-          return JS_NO_EXTERNS.accept(dir, name)
-              && dir.getName().equals("partialCrossModuleTypeImports");
-        }
-      };
+      (File dir, String name) ->
+          JS_NO_EXTERNS.accept(dir, name) && dir.getName().equals("partialCrossModuleTypeImports");
+
+  private static final FilenameFilter JS_ALIASED_INTERFACE =
+      (File dir, String name) ->
+          JS_NO_EXTERNS.accept(dir, name) && dir.getName().equals("aliasedInterface");
 
   public static final Path TSC =
       FileSystems.getDefault().getPath("node_modules", "typescript", "bin", "tsc");
@@ -76,6 +71,24 @@ public class DeclarationSyntaxTest {
     List<File> inputs =
         DeclarationGeneratorTests.getTestInputFiles(JS_PARTIAL_CROSS_MODULE_TYPE_IMPORTS);
     doTestDeclarationSyntax(inputs);
+  }
+
+  @Test
+  public void testAliasedInterfaceDeclarationSyntax() throws Exception {
+    List<File> inputs =
+        DeclarationGeneratorTests.getTestInputFiles(
+            (File dir, String name) ->
+                TS_SOURCES.accept(dir, name) && dir.getName().equals("aliasedInterface"));
+    List<String> tsPaths = new ArrayList<>();
+    for (File input : inputs) {
+      tsPaths.add(input.getPath());
+    }
+
+    List<String> tscCommand = Lists.newArrayList(TSC.toString());
+    tscCommand.addAll(TSC_FLAGS);
+    tscCommand.add("src/resources/closure.lib.d.ts");
+    tscCommand.addAll(tsPaths);
+    runChecked(tscCommand);
   }
 
   private void doTestDeclarationSyntax(List<File> inputs) throws Exception {

--- a/src/test/java/com/google/javascript/clutz/MultiFileTest.java
+++ b/src/test/java/com/google/javascript/clutz/MultiFileTest.java
@@ -108,6 +108,16 @@ public class MultiFileTest {
         .generatesDeclarations(golden);
   }
 
+  @Test
+  public void aliasedInterface() throws Exception {
+    File golden = input("aliasedInterface.d.ts");
+    assertThatProgram(
+            ImmutableList.of(
+                input("alias_for_interface.js"), input("aliased_interface_with_static.js")),
+            Collections.<File>emptyList())
+        .generatesDeclarations(golden);
+  }
+
   private File input(String filename) {
     Path testDir = FileSystems.getDefault().getPath("src", "test", "java");
     String packageName = ProgramSubject.class.getPackage().getName();

--- a/src/test/java/com/google/javascript/clutz/aliasedInterface/alias_for_interface.js
+++ b/src/test/java/com/google/javascript/clutz/aliasedInterface/alias_for_interface.js
@@ -1,0 +1,4 @@
+goog.module('alias_for_interface');
+
+var AliasedInterface = goog.require('aliased_interface');
+exports = AliasedInterface;

--- a/src/test/java/com/google/javascript/clutz/aliasedInterface/aliasedInterface.d.ts
+++ b/src/test/java/com/google/javascript/clutz/aliasedInterface/aliasedInterface.d.ts
@@ -1,0 +1,20 @@
+declare namespace ಠ_ಠ.clutz {
+  type module$exports$alias_for_interface = ಠ_ಠ.clutz.module$exports$aliased_interface ;
+  var module$exports$alias_for_interface : typeof ಠ_ಠ.clutz.module$exports$aliased_interface ;
+}
+declare module 'goog:alias_for_interface' {
+  import alias = ಠ_ಠ.clutz.module$exports$alias_for_interface;
+  export default alias;
+}
+declare namespace ಠ_ಠ.clutz {
+  namespace module$exports$aliased_interface {
+    function staticMethod ( ) : string ;
+  }
+  interface module$exports$aliased_interface {
+    x : string ;
+  }
+}
+declare module 'goog:aliased_interface' {
+  import alias = ಠ_ಠ.clutz.module$exports$aliased_interface;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/aliasedInterface/aliased_interface_with_static.js
+++ b/src/test/java/com/google/javascript/clutz/aliasedInterface/aliased_interface_with_static.js
@@ -1,0 +1,10 @@
+goog.module('aliased_interface');
+
+/** @interface */
+class AliasedInterface {
+  constructor() { /** @type {string} */ this.x; }
+  /** @return {string} */
+  static staticMethod() {}
+}
+
+exports = AliasedInterface;

--- a/src/test/java/com/google/javascript/clutz/aliasedInterface/user.ts
+++ b/src/test/java/com/google/javascript/clutz/aliasedInterface/user.ts
@@ -1,0 +1,3 @@
+import AliasForInterface from 'goog:alias_for_interface';
+
+AliasForInterface.staticMethod();

--- a/src/test/java/com/google/javascript/clutz/partial/partial_alias_for_interface.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/partial_alias_for_interface.d.ts
@@ -1,0 +1,8 @@
+declare namespace ಠ_ಠ.clutz {
+  type module$exports$alias_for_interface = ಠ_ಠ.clutz.module$exports$partial$aliased_interface ;
+  var module$exports$alias_for_interface : typeof ಠ_ಠ.clutz.module$exports$partial$aliased_interface ;
+}
+declare module 'goog:alias_for_interface' {
+  import alias = ಠ_ಠ.clutz.module$exports$alias_for_interface;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/partial_alias_for_interface.js
+++ b/src/test/java/com/google/javascript/clutz/partial/partial_alias_for_interface.js
@@ -1,0 +1,5 @@
+goog.module('alias_for_interface');
+
+var AliasedInterface = goog.require('partial.aliased_interface');
+// Make sure that alias_for_interface creates both a type and a var alias.
+exports = AliasedInterface;

--- a/src/test/java/com/google/javascript/clutz/partial/partial_aliased_interface.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/partial_aliased_interface.d.ts
@@ -1,0 +1,12 @@
+declare namespace ಠ_ಠ.clutz {
+  namespace module$exports$partial$aliased_interface {
+    function staticMethod ( ) : string ;
+  }
+  interface module$exports$partial$aliased_interface {
+    x : string ;
+  }
+}
+declare module 'goog:partial.aliased_interface' {
+  import alias = ಠ_ಠ.clutz.module$exports$partial$aliased_interface;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/partial_aliased_interface.js
+++ b/src/test/java/com/google/javascript/clutz/partial/partial_aliased_interface.js
@@ -1,0 +1,10 @@
+goog.module('partial.aliased_interface');
+
+/** @interface */
+class AliasedInterface {
+  constructor() { /** @type {string} */ this.x; }
+  /** @return {string} */
+  static staticMethod() {}
+}
+
+exports = AliasedInterface;


### PR DESCRIPTION
While #763 more systematically emitted static properties of interfaces,
users in some situations could still not access them. More specifically,
if an interface with static properites was re-exported (aliased), Clutz
would only emit a `type Alias = Actual` re-export, but not a
corresponding variable `var Alias: typeof Actual`.

This change fixes the problem by emitting `var` aliases for interfaces
with static properties.