### PR TITLE
Handle static props using an @template this.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -2786,7 +2786,7 @@ class DeclarationGenerator {
         }
         // Avoid re-emitting template variables defined on the class level if method is not static.
         List<String> skipTemplateParams =
-            isStatic ? Collections.<String>emptyList() : classTemplateTypeNames;
+            isStatic ? Collections.emptyList() : classTemplateTypeNames;
         JSType typeOfThis = ftype.getTypeOfThis();
         // If a method returns the 'this' object, it needs to be typed to match the type of the
         // instance it is invoked on. That way when called on the subclass it should return the
@@ -2796,6 +2796,8 @@ class DeclarationGenerator {
         // In TypeScript one can use the reserved 'this' type, without templatization.
         // Detect the pattern here and remove the templatized type from the emit.
         if (typeOfThis != null && typeOfThis.isTemplateType()) {
+          // skipTemplateParams might be an immutable list.
+          skipTemplateParams = new ArrayList<>(skipTemplateParams);
           skipTemplateParams.add(typeOfThis.getDisplayName());
         }
         visitFunctionDeclaration(ftype, skipTemplateParams);

--- a/src/test/java/com/google/javascript/clutz/static_this_templated_prop.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_this_templated_prop.d.ts
@@ -1,0 +1,15 @@
+declare namespace ಠ_ಠ.clutz.static_this_templated_prop {
+  /**
+   * Some container to hold the static property.
+   */
+  class SomeContainer extends SomeContainer_Instance {
+    static nestedClass ( ) : void ;
+  }
+  class SomeContainer_Instance {
+    private noStructuralTyping_: any;
+  }
+}
+declare module 'goog:static_this_templated_prop' {
+  import alias = ಠ_ಠ.clutz.static_this_templated_prop;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/clutz/static_this_templated_prop.js
+++ b/src/test/java/com/google/javascript/clutz/static_this_templated_prop.js
@@ -1,0 +1,14 @@
+goog.provide('static_this_templated_prop');
+
+/**
+ * Some container to hold the static property.
+ * @constructor
+ */
+static_this_templated_prop.SomeContainer = function() {}
+
+/**
+ * @template SCOPE
+ * @this SCOPE
+ */
+static_this_templated_prop.SomeContainer.nestedClass = function() {};
+


### PR DESCRIPTION
Previously, this would crash because of the popular "let me use an empty
list here" issue.