### PR TITLE
Special case AngularJS promise.then

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -2944,8 +2944,9 @@ class DeclarationGenerator {
       // fixed.
       String classTemplatizedType =
           className.equals("ಠ_ಠ.clutz.goog.Promise") ? " any" : className + " < RESULT >";
+      // The AngularJS promise type should match the TypeScript type declaration since they describe
+      // the same runtime.
       if (propName.equals("then")) {
-        // Prune promise<never> off AngularJS IPromise.then return type.
         if (className.equals("ಠ_ಠ.clutz.angular.$q.Promise")) {
           return "then < RESULT > (opt_onFulfilled ? : ( (a : "
               + templateVarName

--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -2945,14 +2945,28 @@ class DeclarationGenerator {
       String classTemplatizedType =
           className.equals("ಠ_ಠ.clutz.goog.Promise") ? " any" : className + " < RESULT >";
       if (propName.equals("then")) {
-        return "then < RESULT > (opt_onFulfilled ? : ( (a : "
-            + templateVarName
-            + " ) => "
-            + classTemplatizedType
-            + " | RESULT ) | null , "
-            + "opt_onRejected ? : ( (a : any ) => any ) | null) : "
-            + classTemplatizedType
-            + " ;";
+        // Prune promise<never> off AngularJS IPromise.then return type.
+        if (className.equals("ಠ_ಠ.clutz.angular.$q.Promise")) {
+          return "then < RESULT > (opt_onFulfilled ? : ( (a : "
+              + templateVarName
+              + " ) => "
+              + classTemplatizedType
+              + " | RESULT | "
+              + className
+              + "<never>) | null , "
+              + "opt_onRejected ? : ( (a : any ) => any ) | null) : "
+              + classTemplatizedType
+              + " ;";
+        } else {
+          return "then < RESULT > (opt_onFulfilled ? : ( (a : "
+              + templateVarName
+              + " ) => "
+              + classTemplatizedType
+              + " | RESULT ) | null , "
+              + "opt_onRejected ? : ( (a : any ) => any ) | null) : "
+              + classTemplatizedType
+              + " ;";
+        }
       }
       if (propName.equals("when")) {
         return "when < RESULT, T > (value: T, successCallback: (promiseValue: T) => "

--- a/src/test/java/com/google/javascript/clutz/tte_promise.d.ts
+++ b/src/test/java/com/google/javascript/clutz/tte_promise.d.ts
@@ -1,32 +1,32 @@
-declare namespace ಠ_ಠ.clutz.tte {
+declare namespace ಠ_ಠ.clutz.angular.$q {
   class Promise < T > extends Promise_Instance < T > {
-    static all(promises : ಠ_ಠ.clutz.tte.Promise < any > [] ) : ಠ_ಠ.clutz.tte.Promise < any [] > ;
-    static race < T > (values : T [] ) : ಠ_ಠ.clutz.tte.Promise < T > ;
-    static resolve < T >(value: ಠ_ಠ.clutz.tte.Promise < T > | T): ಠ_ಠ.clutz.tte.Promise < T >;
+    static all(promises : ಠ_ಠ.clutz.angular.$q.Promise < any > [] ) : ಠ_ಠ.clutz.angular.$q.Promise < any [] > ;
+    static race < T > (values : T [] ) : ಠ_ಠ.clutz.angular.$q.Promise < T > ;
+    static resolve < T >(value: ಠ_ಠ.clutz.angular.$q.Promise < T > | T): ಠ_ಠ.clutz.angular.$q.Promise < T >;
   }
   class Promise_Instance < T > {
     private noStructuralTyping_: any;
-    then < RESULT > (opt_onFulfilled ? : ( (a : T ) => ಠ_ಠ.clutz.tte.Promise < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : ಠ_ಠ.clutz.tte.Promise < RESULT > ;
-    when < RESULT, T > (value: T, successCallback: (promiseValue: T) => ಠ_ಠ.clutz.tte.Promise < RESULT >|RESULT, errorCallback: null | undefined |  ((reason: any) => any), notifyCallback?: (state: any) => any): ಠ_ಠ.clutz.tte.Promise < RESULT >;
+    then < RESULT > (opt_onFulfilled ? : ( (a : T ) => ಠ_ಠ.clutz.angular.$q.Promise < RESULT > | RESULT | ಠ_ಠ.clutz.angular.$q.Promise<never>) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : ಠ_ಠ.clutz.angular.$q.Promise < RESULT > ;
+    when < RESULT, T > (value: T, successCallback: (promiseValue: T) => ಠ_ಠ.clutz.angular.$q.Promise < RESULT >|RESULT, errorCallback: null | undefined |  ((reason: any) => any), notifyCallback?: (state: any) => any): ಠ_ಠ.clutz.angular.$q.Promise < RESULT >;
   }
 }
-declare module 'goog:tte.Promise' {
-  import Promise = ಠ_ಠ.clutz.tte.Promise;
+declare module 'goog:angular.$q.Promise' {
+  import Promise = ಠ_ಠ.clutz.angular.$q.Promise;
   export default Promise;
 }
-declare namespace ಠ_ಠ.clutz.tte {
+declare namespace ಠ_ಠ.clutz.angular.$q {
   class PromiseService < T > extends PromiseService_Instance < T > {
   }
   class PromiseService_Instance < T > {
     private noStructuralTyping_: any;
-    all(promises : ಠ_ಠ.clutz.tte.PromiseService.Promise < any > [] ) : ಠ_ಠ.clutz.tte.PromiseService.Promise < any [] > ;
+    all(promises : ಠ_ಠ.clutz.angular.$q.PromiseService.Promise < any > [] ) : ಠ_ಠ.clutz.angular.$q.PromiseService.Promise < any [] > ;
   }
 }
-declare namespace ಠ_ಠ.clutz.tte.PromiseService {
+declare namespace ಠ_ಠ.clutz.angular.$q.PromiseService {
   interface Promise < T > {
   }
 }
-declare module 'goog:tte.PromiseService' {
-  import PromiseService = ಠ_ಠ.clutz.tte.PromiseService;
+declare module 'goog:angular.$q.PromiseService' {
+  import PromiseService = ಠ_ಠ.clutz.angular.$q.PromiseService;
   export default PromiseService;
 }

--- a/src/test/java/com/google/javascript/clutz/tte_promise.js
+++ b/src/test/java/com/google/javascript/clutz/tte_promise.js
@@ -1,5 +1,5 @@
-goog.provide('tte.Promise');
-goog.provide('tte.PromiseService');
+goog.provide('angular.$q.Promise');
+goog.provide('angular.$q.PromiseService');
 
 /**
  * The examples below come from closure's typings of angular and es6 promise
@@ -12,7 +12,7 @@ goog.provide('tte.PromiseService');
  * @constructor
  * @template T
  */
-tte.Promise = function() {};
+angular.$q.Promise = function() {};
 
 /**
  *
@@ -27,12 +27,12 @@ tte.Promise = function() {};
  *       mapunion(VALUE, (V) =>
  *         cond(isTemplatized(V) && sub(rawTypeOf(V), 'IThenable'),
  *           templateTypeOf(V, 0),
- *           cond(sub(V, 'tte.Promise'),
+ *           cond(sub(V, 'angular.$q.Promise'),
  *              unknown(),
  *              V)))))
  *  =:
  */
-tte.Promise.prototype.then =
+angular.$q.Promise.prototype.then =
     function(opt_onFulfilled, opt_onRejected, opt_notifyCallback) {};
 
 /**
@@ -61,7 +61,7 @@ tte.Promise.prototype.then =
  *           'Object')))))
  * =:
  */
-tte.Promise.all = function(promises) {};
+angular.$q.Promise.all = function(promises) {};
 
 /**
  * @param {VALUE=} opt_value
@@ -77,11 +77,11 @@ tte.Promise.all = function(promises) {};
  *              V)))))
  * =:
  */
-tte.Promise.resolve = function(opt_value) {};
+angular.$q.Promise.resolve = function(opt_value) {};
 
 /**
  * @param {!Array<VALUE>} values
- * @return {!tte.Promise<RESULT>}
+ * @return {!angular.$q.Promise<RESULT>}
  * @template VALUE
  * @template RESULT := mapunion(VALUE, (V) =>
  *     cond(isUnknown(V),
@@ -91,7 +91,7 @@ tte.Promise.resolve = function(opt_value) {};
  *             cond(sub(V, 'Thenable'), unknown(), V))))
  * =:
  */
-tte.Promise.race = function(values) {};
+angular.$q.Promise.race = function(values) {};
 
 /**
  * @see "https://github.com/google/closure-compiler/commit/be3f15e58812b0843ad0ccc0bcddb5a1506d56e8"
@@ -112,7 +112,7 @@ tte.Promise.race = function(values) {};
  *              V)))))
  * =:
  */
-tte.Promise.prototype.when = function(
+angular.$q.Promise.prototype.when = function(
     opt_value, opt_successCallback, opt_errorCallback, opt_progressCallback) {};
 
 //!! In angular 'all' is a instance method on the $q service, and not a static
@@ -121,7 +121,7 @@ tte.Promise.prototype.when = function(
  * @constructor
  * @template T
  */
-tte.PromiseService = function() {};
+angular.$q.PromiseService = function() {};
 
 /**
  *
@@ -149,10 +149,10 @@ tte.PromiseService = function() {};
  *           'Object')))))
  * =:
  */
-tte.PromiseService.prototype.all = function(promises) {};
+angular.$q.PromiseService.prototype.all = function(promises) {};
 
 /**
  * @record
  * @template T
  */
-tte.PromiseService.Promise = function() {};
+angular.$q.PromiseService.Promise = function() {};

--- a/src/test/java/com/google/javascript/clutz/tte_promise_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/tte_promise_usage.ts
@@ -1,4 +1,4 @@
-import Promise from 'goog:tte.Promise';
+import Promise from 'goog:angular.$q.Promise';
 
 let x = new Promise<string>();
 let y: Promise<string> = x.then(x => x).then(x => x + 'foo');


### PR DESCRIPTION
Keeps Clutz emitted AngularJS promise type close to the TS AngularJS type declaration.

When the callback function of `.then()` returns a `promise<never> | T` the TS AngularJS type declaration is smart enough to prune `promise<never>` and return just `promise<T>` (see [AngularJS .d.ts on DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/374598de675780b1312912d43dff88f9fbfcf0d8/types/angular/index.d.ts#L1201)). This PR attempts to port that functionality to Clutz.

The TypeScript [built-in promise](https://github.com/Microsoft/TypeScript/blob/v2.9.2/lib/lib.es5.d.ts#L1336) doesn't have this so don't prune `never` for any `.then` functions.
