### PR TITLE
Support aliases through module objects.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/AliasMapBuilder.java
+++ b/src/main/java/com/google/javascript/clutz/AliasMapBuilder.java
@@ -79,7 +79,7 @@ public class AliasMapBuilder extends ImportBasedMapBuilder {
               localVariableToImportedSymbolNameMap.get(localVariableName));
         }
       } else if (isNamedExportAssignment(statement)) {
-        // `exports.foo = foo`
+        // `exports.foo = foo;`
         String localVariableName = getExportsAssignmentRHS(statement);
         String exportName = getNamedExportName(statement);
 
@@ -88,6 +88,14 @@ public class AliasMapBuilder extends ImportBasedMapBuilder {
               buildNamedExportSymbolName(localModuleId, exportName),
               localVariableToImportedSymbolNameMap.get(localVariableName));
         }
+      } else if (isNamedExportPropAssignment(statement)) {
+        // `exports.foo = foo.bar;`
+        String localVariableName = getExportsAssignmentPropRootName(statement);
+        String localPropName = getExportsAssignmentPropName(statement);
+        String exportName = getNamedExportName(statement);
+        aliasMap.put(
+            buildNamedExportSymbolName(localModuleId, exportName),
+            localVariableToImportedSymbolNameMap.get(localVariableName) + "." + localPropName);
       }
     }
 

--- a/src/main/java/com/google/javascript/clutz/ImportBasedMapBuilder.java
+++ b/src/main/java/com/google/javascript/clutz/ImportBasedMapBuilder.java
@@ -203,6 +203,35 @@ public abstract class ImportBasedMapBuilder {
     return statement.getFirstChild().getFirstChild().getFirstChild().getString().equals("exports");
   }
 
+  /** Matches `exports.foo = foo.bar;` */
+  protected boolean isNamedExportPropAssignment(Node statement) {
+    if (!statement.isExprResult()) {
+      return false;
+    }
+
+    if (!statement.getFirstChild().isAssign()) {
+      return false;
+    }
+
+    if (!statement.getFirstChild().getFirstChild().isGetProp()) {
+      return false;
+    }
+
+    if (!statement.getFirstChild().getFirstChild().getFirstChild().isName()) {
+      return false;
+    }
+
+    if (!statement.getFirstChild().getSecondChild().isGetProp()) {
+      return false;
+    }
+
+    if (!statement.getFirstChild().getSecondChild().getFirstChild().isName()) {
+      return false;
+    }
+
+    return statement.getFirstChild().getFirstChild().getFirstChild().getString().equals("exports");
+  }
+
   /** Returns `foo` from 'exports.foo = bar` */
   protected String getNamedExportName(Node statement) {
     return statement.getFirstChild().getFirstChild().getChildAtIndex(1).getString();
@@ -210,7 +239,17 @@ public abstract class ImportBasedMapBuilder {
 
   /** Returns `foo` from `exports = foo` or `exports.foo = foo` */
   protected String getExportsAssignmentRHS(Node statement) {
-    return statement.getFirstChild().getChildAtIndex(1).getString();
+    return statement.getFirstChild().getSecondChild().getString();
+  }
+
+  /** Returns `foo` from `exports = foo.bar` or `exports.foo = foo.bar` */
+  protected String getExportsAssignmentPropRootName(Node statement) {
+    return statement.getFirstChild().getSecondChild().getFirstChild().getString();
+  }
+
+  /** Returns `bar` from `exports = foo.bar` or `exports.foo = foo.bar` */
+  protected String getExportsAssignmentPropName(Node statement) {
+    return statement.getFirstChild().getSecondChild().getSecondChild().getString();
   }
 
   protected Map<String, String> objectLiteralASTToStringMap(Node objectLiteral) {

--- a/src/test/java/com/google/javascript/clutz/partial/module_reexport_with_module_obj.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/module_reexport_with_module_obj.d.ts
@@ -1,0 +1,10 @@
+declare namespace ಠ_ಠ.clutz.module$exports$bare$named$reexport {
+  type Class = ಠ_ಠ.clutz.module$exports$original$module.Class ;
+  var Class : typeof ಠ_ಠ.clutz.module$exports$original$module.Class ;
+  type fn = ಠ_ಠ.clutz.module$exports$original$module.fn ;
+  var fn : typeof ಠ_ಠ.clutz.module$exports$original$module.fn ;
+}
+declare module 'goog:bare.named.reexport' {
+  import reexport = ಠ_ಠ.clutz.module$exports$bare$named$reexport;
+  export = reexport;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/module_reexport_with_module_obj.js
+++ b/src/test/java/com/google/javascript/clutz/partial/module_reexport_with_module_obj.js
@@ -1,0 +1,10 @@
+goog.module('bare.named.reexport');
+
+const Mod = goog.require('original.module');
+
+exports.Class = Mod.Class;
+//!! Note, that we will incorrectly generate a type reexport for fn
+//!! even though it is only a value. Since we have partial info
+//!! in clutz, we pick the conservative view that everything can be
+//!! class and emit a type and a value alias.
+exports.fn = Mod.fn;


### PR DESCRIPTION
Now clutz understands the pattern:

```
goog.module('bare.named.reexport');

const Mod = goog.require('original.module');

exports.x = Mod.x;
```

and generates proper reexports. By necessity of incremental mode it
generates a type and var reexport of x, even if it is only a value or
only a type.