### PR TITLE
Fix for latest Closure Compiler externs

### DIFF
--- a/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
+++ b/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
@@ -309,6 +309,7 @@ public class PlatformSymbols {
           "WebKitBlobBuilder",
           "WebKitNamespace",
           "WebWorker",
+          "WorkerOptions",
           "WorkerPerformance",
           "XDomainRequest",
           "XMLDOMDocument",


### PR DESCRIPTION
Closure Compiler added `WorkerOptions` to the externs in https://github.com/google/closure-compiler/commit/31886b0d5e6bad55d1b2a561f5b7c5bae8bc485e.

fixes #781 