### PR TITLE
update closure compiler version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
   // clutz runs against closure head inside google, so default to that, but also test against
   // the latest release for external users
   if (System.getenv().get('CI_MODE') == 'Released') {
-    compile 'com.google.javascript:closure-compiler:v20180204'
+    compile 'com.google.javascript:closure-compiler:v20181008'
   } else {
     compile 'com.google.javascript:closure-compiler:1.0-SNAPSHOT'
   }


### PR DESCRIPTION
Last update was in Feb 2018.  This puts us on Oct 2018.

Realistically clutz is developed against tip of tree closure, but this
puts the 'release' build tests closer to reality.
