### PR TITLE
reformat the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # Clutz - Closure to TypeScript Declarations (`.d.ts`) generator.
+
 [![Build Status](https://travis-ci.org/angular/clutz.svg?branch=master)](https://travis-ci.org/angular/clutz)
 
 This project uses the
 [Closure Compiler](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler)
-to parse Closure-style JSDoc type annotations from ES5/ES2015 code, and generates a suitable
-TypeScript type definition file (`.d.ts`) for the exported API.
+to parse Closure-style JSDoc type annotations from ES5/ES2015 code, and
+generates a suitable TypeScript type definition file (`.d.ts`) for the exported
+API.
 
-The intent is to allow TypeScript code to import libraries written with Closure-style type
-declarations. Having the clutz generated declarations allows type-checking in the
-TypeScript compiler and IDE tooling (for highlighting errors and type-sensitive
-auto-complete) as if the imported code was written in TypeScript.
+The intent is to allow TypeScript code to import libraries written with
+Closure-style type declarations. Having the clutz generated declarations allows
+type-checking in the TypeScript compiler and IDE tooling (for highlighting
+errors and type-sensitive auto-complete) as if the imported code was written in
+TypeScript.
 
 ## Example usage
 
 We don't offer a binary distribution, so first you need to build from source:
+
 ```shell
 $ npm install
 $ gradle build installDist
@@ -21,9 +25,10 @@ $ gradle build installDist
 BUILD SUCCESSFUL
 ```
 
-You can use Clutz from the command line using the wrapper script produced by Grade or
-by executing the JAR file in `build/libs/` yourself.
-Here is a sample execution:
+You can use Clutz from the command line using the wrapper script produced by
+Grade or by executing the JAR file in `build/libs/` yourself. Here is a sample
+execution:
+
 ```shell
 $ PATH=$PATH:./build/install/clutz/bin
 $ clutz path/to/my/source1.js path/to/my/source2.js ...
@@ -31,10 +36,11 @@ $ clutz path/to/my/source1.js path/to/my/source2.js ...
         -o out.d.ts
 ```
 
-This creates TypeScript type definitions in `out.d.ts` for all the closure types discovered in the inputs.
-Symbols which were declared with `goog.provide('x')` may be imported in TypeScript as `import x from 'goog:x';`.
-For full explanation of what TypeScript types are produced for different Closure usages, see the `.js` and `.d.ts`
-files in `src/test/com/google/javascript/clutz`.
+This creates TypeScript type definitions in `out.d.ts` for all the closure types
+discovered in the inputs. Symbols which were declared with `goog.provide('x')`
+may be imported in TypeScript as `import x from 'goog:x';`. For full explanation
+of what TypeScript types are produced for different Closure usages, see the
+`.js` and `.d.ts` files in `src/test/com/google/javascript/clutz`.
 
 When compiling TypeScript code that depends on the closure code, include the
 `src/resources/closure.lib.d.ts` file along with `out.d.ts`.
@@ -45,21 +51,24 @@ with Closure alone. The arguments for invoking clutz are intentionally similar
 to the arguments for invoking the Closure compiler. You can find the additional
 compiler flags that clutz passes to Closure Compiler in
 `src/main/java/com/google/javascript/clutz/Options.java`. If the failure is
-reproducible this way, then you have a closure type error in your code (or a
-bug in Closure Compiler).
+reproducible this way, then you have a closure type error in your code (or a bug
+in Closure Compiler).
 
 ## Supported Version of TypeScript
-Clutz produces declaration files that are guaranteed to be accepted by a
-version of TypeScript
-[2.7.2](https://github.com/Microsoft/TypeScript/tree/v2.7.2). The current test
-suite runs against the version of `typescript` in `npm-shrinkwrap.json`, so that is
-always a good choice.
+
+Clutz produces declaration files that are guaranteed to be accepted by a version
+of TypeScript [2.7.2](https://github.com/Microsoft/TypeScript/tree/v2.7.2). The
+current test suite runs against the version of `typescript` in
+`npm-shrinkwrap.json`, so that is always a good choice.
 
 ## Tests
+
 You can run the test suite with:
+
 ```shell
 $ ./gradlew test
 ```
+
 Pass the environment variable `UPDATE_GOLDENS=y` to update the golden files.
 
 # Gents - Closure to TypeScript converter
@@ -167,5 +176,4 @@ infer the types of every variable and generate giant type declarations.
 
 ### Known Issues and TODOs
 
-[Github
-issues](https://github.com/angular/clutz/issues?q=is%3Aopen+is%3Aissue+label%3Agents)
+[Github issues](https://github.com/angular/clutz/issues?q=is%3Aopen+is%3Aissue+label%3Agents)


### PR DESCRIPTION
This uses the google-internal markdown formatter as a one-time
reformat of the README file.  Because it is google-internal I
cannot hook it into the build, but I figure at least a one-time
formatting pass here will make the file a little less gross for
subsequent edits.

(I also investigated using prettier.io's formatter but it wants to
rewrite the JS snippets within the README too.)