### PR TITLE
update tests to new closure upstream

### DIFF
--- a/src/test/java/com/google/javascript/clutz/base.js
+++ b/src/test/java/com/google/javascript/clutz/base.js
@@ -1,3 +1,11 @@
+/**
+ * @fileoverview This file contains a portion of the Closure library's
+ * base.js, for the purpose of testing some of the patterns found
+ * there.  The following annotation is necessary for the compiler to recognize
+ * this file as one that may provide symbols like goog.require().
+ * @provideGoog
+ */
+
 // Changing this definition to false or removing or renaming it will cause closure to remove
 // goog from the list of provided symbols, thus breaking the output.
 /**

--- a/src/test/java/com/google/javascript/clutz/fn_params_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/fn_params_with_platform.d.ts
@@ -1,5 +1,5 @@
 declare namespace ಠ_ಠ.clutz.module$exports$fn_params_with_platform {
-  function es6args ($jscomp$destructuring$var0 : any , $jscomp$destructuring$var1 : any ,  ...rest : any [] ) : void ;
+  function es6args (a : any , b : any ,  ...rest : any [] ) : void ;
 }
 declare module 'goog:fn_params_with_platform' {
   import fn_params_with_platform = ಠ_ಠ.clutz.module$exports$fn_params_with_platform;

--- a/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
@@ -164,6 +164,11 @@ declare namespace ಠ_ಠ.clutz {
   }
 }
 declare namespace ಠ_ಠ.clutz {
+  interface NavigatorStorage {
+    storage : StorageManager ;
+  }
+}
+declare namespace ಠ_ಠ.clutz {
   interface ShareData {
     text ? : string ;
     title ? : string ;

--- a/src/test/java/com/google/javascript/clutz/partial/es6_missing_imported_base.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/es6_missing_imported_base.d.ts
@@ -2,22 +2,22 @@ declare namespace ಠ_ಠ.clutz.module$exports$missing$imported$base {
   class ClassExtendingDefaultObjectExporterBaseClass extends ClassExtendingDefaultObjectExporterBaseClass_Instance {
   }
   class ClassExtendingDefaultObjectExporterBaseClass_Instance extends ಠ_ಠ.clutz.module$exports$default$object$exporter.BaseClass_Instance {
-    constructor ( ...var_args : any [] ) ;
+    constructor ( ...a : any [] ) ;
   }
   class ClassExtendingMissingDestructuredRequire extends ClassExtendingMissingDestructuredRequire_Instance {
   }
   class ClassExtendingMissingDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$named$base$exporter.MissingDestructuredRequire_Instance {
-    constructor ( ...var_args : any [] ) ;
+    constructor ( ...a : any [] ) ;
   }
   class ClassExtendingMissingRequire extends ClassExtendingMissingRequire_Instance {
   }
   class ClassExtendingMissingRequire_Instance extends ಠ_ಠ.clutz.module$exports$default$base$exporter_Instance {
-    constructor ( ...var_args : any [] ) ;
+    constructor ( ...a : any [] ) ;
   }
   class ClassExtendingRenamedDestructuredRequire extends ClassExtendingRenamedDestructuredRequire_Instance {
   }
   class ClassExtendingRenamedDestructuredRequire_Instance extends ಠ_ಠ.clutz.module$exports$named$base$exporter.OriginalName_Instance {
-    constructor ( ...var_args : any [] ) ;
+    constructor ( ...a : any [] ) ;
   }
   var DeclarationOfMissingRequire : ಠ_ಠ.clutz.module$exports$default$base$exporter | null ;
   function FuncWithMissingRequireParam (c : ಠ_ಠ.clutz.module$exports$default$base$exporter | null ) : void ;

--- a/src/test/java/com/google/javascript/clutz/partial/platform_goog_require.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/platform_goog_require.d.ts
@@ -2,7 +2,7 @@ declare namespace ಠ_ಠ.clutz.module$exports$platform$goog$require {
   class C extends C_Instance {
   }
   class C_Instance extends ಠ_ಠ.clutz.module$exports$goog$events$EventTarget_Instance {
-    constructor ( ...var_args : any [] ) ;
+    constructor ( ...a : any [] ) ;
   }
 }
 declare module 'goog:platform.goog.require' {


### PR DESCRIPTION
This change restores a green build by fixing one bug and checking in new
baselines for the failing tests.

I added a file comment to base.js to show what it's for, and added a
newly required annotation on it.