### PR TITLE
handle the global 'Storage' type

### DIFF
--- a/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
+++ b/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
@@ -71,7 +71,8 @@ public class PlatformSymbols {
           "EventTarget",
           "Float32Array",
           "Float64Array",
-          "Object");
+          "Object",
+          "Storage");
 
   /**
    * Set of symbols that are defined in a platform externs.js that we don't need a matching

--- a/src/resources/closure.lib.d.ts
+++ b/src/resources/closure.lib.d.ts
@@ -12,12 +12,14 @@ declare namespace ಠ_ಠ.clutz {
   var GlobalEvent: typeof Event;
   type GlobalEventTarget = EventTarget;
   var GlobalEventTarget: typeof EventTarget;
-  type GlobalObject = Object;
-  var GlobalObject: typeof Object;
   type GlobalFloat32Array = Float32Array;
   var GlobalFloat32Array: typeof Float32Array;
   type GlobalFloat64Array = Float64Array;
   var GlobalFloat64Array: typeof Float64Array;
+  type GlobalObject = Object;
+  var GlobalObject: typeof Object;
+  type GlobalStorage = Storage;
+  var GlobalStorage: typeof Storage;
 
   /** Represents the type returned when goog.require-ing an unknown symbol */
   type ClosureSymbolNotGoogProvided = void;


### PR DESCRIPTION
It needs the same scoping workaround as we do for other globals like
Object.