### PR TITLE
fixes clutz crash when enum is declared directly inside the export ob…

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -1872,11 +1872,11 @@ class DeclarationGenerator {
         return;
       }
 
-      // The current node points to the enum type declaration, this means that the next node will
-      // be the OBJECTLIT containing all enum key and value pairs. However, globally declared
-      // enums that are indirectly provided will instead be pointing to the parent of the
-      // OBJECTLIT parent.
-      Node objectOfAllMembers = node.getNext() != null ? node.getNext() : node.getFirstChild();
+      // The current node points to either:
+      // 1) The GETPROP node for a goog.provide style export - a.b.MyEnum = {...};
+      // 2) The STRINGLIT node for a goog.module style export - exports = { MyEnum: {...}, ...}
+      // For case 1) we need to get the next node, while for 2) we need to get the first child.
+      Node objectOfAllMembers = node.getParent().isAssign() ? node.getNext() : node.getFirstChild();
       Stream<Node> elementStream = Streams.stream(objectOfAllMembers.children());
       Map<String, Node> elements =
           elementStream.collect(Collectors.toMap(Node::getString, Node::getFirstChild));

--- a/src/test/java/com/google/javascript/clutz/nested_exported_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/nested_exported_enum.d.ts
@@ -1,0 +1,10 @@
+declare namespace ಠ_ಠ.clutz.module$exports$nested$exported$enums {
+  enum A {
+    A1 = 'a1' ,
+  }
+  var B : number ;
+}
+declare module 'goog:nested.exported.enums' {
+  import enums = ಠ_ಠ.clutz.module$exports$nested$exported$enums;
+  export = enums;
+}

--- a/src/test/java/com/google/javascript/clutz/nested_exported_enum.js
+++ b/src/test/java/com/google/javascript/clutz/nested_exported_enum.js
@@ -1,0 +1,11 @@
+goog.module('nested.exported.enums');
+
+/** @const */
+exports = {
+  /** @const @enum {string} */
+  A: {
+    A1: 'a1',
+  },
+  // The structure of the AST changes if this extra property is present.
+  B: 0,
+};


### PR DESCRIPTION
…ject.

Previously, we did separated the two cases (enum assignment) and inline
declaration, but the check condition needed adjustment.