### PR TITLE
Fix for clutz not failing on circular inferred objects.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/circular_prototype.d.ts
+++ b/src/test/java/com/google/javascript/clutz/circular_prototype.d.ts
@@ -1,0 +1,10 @@
+declare namespace ಠ_ಠ.clutz.module$exports$circular$obj {
+  let deepObj : { a : number , child : { //!! Unsupported circular reference for prop name: cycle
+  } , z : number } ;
+  let obj : { a : number , //!! Unsupported circular reference for prop name: constructor
+  z : number } ;
+}
+declare module 'goog:circular.obj' {
+  import obj = ಠ_ಠ.clutz.module$exports$circular$obj;
+  export = obj;
+}

--- a/src/test/java/com/google/javascript/clutz/circular_prototype.js
+++ b/src/test/java/com/google/javascript/clutz/circular_prototype.js
@@ -1,0 +1,25 @@
+goog.module('circular.obj');
+
+/** @const */
+let obj = {
+  a: 0,
+  z: 0
+};
+
+//!! What's the purpose of that is beyond me, but it happens in real code
+//!! https://github.com/mixmaxhq/tasty-treewalker/blob/master/src/TreeWalker-polyfill.js#L35
+//!! Note: that closure knows that `prototype` is special, but constructor shows
+//!! in the type as regular prop.
+obj.constructor = obj.prototype = obj;
+
+/** @const */
+let deepObj = {
+  a: 0,
+  z: 0
+};
+
+/** @const */
+deepObj.child = {cycle: deepObj};
+
+exports.obj = obj;
+exports.deepObj = deepObj;


### PR DESCRIPTION
The cannonical example being:

```
/** @const */
let a = {};
a.b = a;
```

For now, just detect simple loops (property points to the parent), and
avoid emitting the property. Instead mark the failed to emit property
with a comment.