### PR TITLE
Fix test of async_await_with_platform for latest Closure Compiler

### DIFF
--- a/src/test/java/com/google/javascript/clutz/async_await_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/async_await_with_platform.d.ts
@@ -1,8 +1,8 @@
 declare namespace ಠ_ಠ.clutz {
   class module$exports$asyncawait {
     private noStructuralTyping_: any;
-    bar ( ) : any ;
-    foo ( ) : any ;
+    bar ( ) : Promise < undefined > ;
+    foo ( ) : Promise < undefined > ;
   }
 }
 declare module 'goog:asyncawait' {


### PR DESCRIPTION
from `com.google.javascript:closure-compiler:1.0-20181121.190252-418`