### PR TITLE
Add option terminator "--" to CLI

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -27,6 +27,7 @@ import org.kohsuke.args4j.OptionDef;
 import org.kohsuke.args4j.spi.OptionHandler;
 import org.kohsuke.args4j.spi.Parameters;
 import org.kohsuke.args4j.spi.Setter;
+import org.kohsuke.args4j.spi.StopOptionHandler;
 
 public class Options {
   /**
@@ -162,7 +163,9 @@ public class Options {
   )
   private CompilerOptions.TracerMode tracerMode = CompilerOptions.TracerMode.OFF;
 
-  @Argument List<String> arguments = new ArrayList<>();
+  @Argument
+  @Option(name = "--", handler = StopOptionHandler.class)
+  List<String> arguments = new ArrayList<>();
 
   Depgraph depgraph;
   // TODO(martinprobst): Remove when internal Google is upgraded to a more recent args4j

--- a/src/main/java/com/google/javascript/gents/Options.java
+++ b/src/main/java/com/google/javascript/gents/Options.java
@@ -25,6 +25,7 @@ import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.spi.StopOptionHandler;
 import org.kohsuke.args4j.spi.StringArrayOptionHandler;
 
 /**
@@ -106,7 +107,9 @@ public class Options {
   )
   String absolutePathPrefix = "google3";
 
-  @Argument List<String> arguments = new ArrayList<>();
+  @Argument
+  @Option(name = "--", handler = StopOptionHandler.class)
+  List<String> arguments = new ArrayList<>();
 
   Set<String> srcFiles = new LinkedHashSet<>();
   Map<String, String> externsMap = null;

--- a/src/test/java/com/google/javascript/clutz/OptionsTest.java
+++ b/src/test/java/com/google/javascript/clutz/OptionsTest.java
@@ -191,4 +191,13 @@ public class OptionsTest {
             });
     assertThat(opts.externs).isEmpty();
   }
+
+  @Test
+  public void testStopOption() throws Exception {
+    Options opts =
+        new Options(
+            new String[] {"--externs", "extern1.js", "extern2.js", "--", "foo.js", "bar.js"});
+    assertThat(opts.arguments).containsExactly("foo.js", "bar.js").inOrder();
+    assertThat(opts.externs).containsExactly("extern1.js", "extern2.js").inOrder();
+  }
 }

--- a/src/test/java/com/google/javascript/gents/OptionsTest.java
+++ b/src/test/java/com/google/javascript/gents/OptionsTest.java
@@ -47,4 +47,13 @@ public class OptionsTest {
       System.setErr(stdErr);
     }
   }
+
+  @Test
+  public void testStopOption() throws Exception {
+    Options opts =
+        new Options(
+            new String[] {"--externs", "extern1.js", "extern2.js", "--", "foo.js", "bar.js"});
+    assertThat(opts.arguments).containsExactly("foo.js", "bar.js").inOrder();
+    assertThat(opts.externs).containsExactly("extern1.js", "extern2.js").inOrder();
+  }
 }


### PR DESCRIPTION
It's useful using with `find` and `xargs`.

```console
$ find ./foo -type f -name '*.js' | xargs clutz --externs extern1.js extern2.js --
```

http://args4j.kohsuke.org/args4j/apidocs/org/kohsuke/args4j/spi/StopOptionHandler.html