### PR TITLE
Consume ES_NEXT from clutz

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -186,6 +186,7 @@ public class Options {
     // Late Provides are errors by default, but they do not prevent clutz from transpiling.
     options.setWarningLevel(DiagnosticGroups.LATE_PROVIDE, CheckLevel.OFF);
 
+    // Always parse and analyze the latest language features closure supports.
     options.setLanguage(LanguageMode.ECMASCRIPT_NEXT);
     options.setLanguageOut(LanguageMode.ECMASCRIPT5);
     options.setCheckTypes(true);

--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -186,7 +186,7 @@ public class Options {
     // Late Provides are errors by default, but they do not prevent clutz from transpiling.
     options.setWarningLevel(DiagnosticGroups.LATE_PROVIDE, CheckLevel.OFF);
 
-    options.setLanguage(LanguageMode.ECMASCRIPT_2017);
+    options.setLanguage(LanguageMode.ECMASCRIPT_NEXT);
     options.setLanguageOut(LanguageMode.ECMASCRIPT5);
     options.setCheckTypes(true);
     options.setInferTypes(true);


### PR DESCRIPTION
This enables parsing code like async generators and for await.

All internal tests pass. See downstreaming change at cl/223155956