### PR TITLE
Improve this type

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -3140,16 +3140,18 @@ class DeclarationGenerator {
       final JSType typeOfThis = ftype.getTypeOfThis();
       // Don't emit for a constructor like `function(new: T)`.
       // A `this` parameter in a constructor is not allowed in TypeScript.
-      if (typeOfThis != null && !ftype.isConstructor()) {
-        final JSDocInfo jsDocInfo = ftype.getJSDocInfo();
-        // Emit for templatized this like `function(this: T)` or JSDoc `@this` type.
-        if (typeOfThis.isTemplateType() || (jsDocInfo != null && jsDocInfo.getThisType() != null)) {
-          emitNoSpace("this :");
-          visitType(typeOfThis);
-          if (parameters.hasNext()) {
-            emit(", ");
-          }
-        }
+      if (typeOfThis == null || ftype.isConstructor()) {
+        return;
+      }
+      final JSDocInfo jsDocInfo = ftype.getJSDocInfo();
+      // Emit for templatized this param like `function(this: T)` or JSDoc `@this` type.
+      if (!typeOfThis.isTemplateType() && (jsDocInfo == null || jsDocInfo.getThisType() == null)) {
+        return;
+      }
+      emitNoSpace("this :");
+      visitType(typeOfThis);
+      if (parameters.hasNext()) {
+        emit(", ");
       }
     }
 

--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -3134,7 +3134,7 @@ class DeclarationGenerator {
     /**
      * Emit a this parameter like `func(this: Foo)` in a function parameters.
      *
-     * TODO: emit for non-templatized this like `function(this: HTMLElement)`
+     * <p>TODO: emit for non-templatized this like `function(this: HTMLElement)`
      */
     private void emitThisParameter(FunctionType ftype, Iterator<Node> parameters) {
       final JSType typeOfThis = ftype.getTypeOfThis();

--- a/src/test/java/com/google/javascript/clutz/ctor_func.d.ts
+++ b/src/test/java/com/google/javascript/clutz/ctor_func.d.ts
@@ -6,6 +6,7 @@ declare namespace ಠ_ಠ.clutz.ctor_func {
   let ctorFuncField : { new (a : string , b : number ) : ಠ_ಠ.clutz.ctor_func.Ctor < any > } ;
   let ctorFuncFieldAlias : { new (a : string , b : number ) : ಠ_ಠ.clutz.ctor_func.Ctor < any > } ;
   function ctorFuncParam (ctor : { new (a : number ) : ಠ_ಠ.clutz.ctor_func.Ctor < any > } ) : void ;
+  function ctorFuncParamTemplatized < T > (ctor : { new (a : number ) : T } ) : T ;
 }
 declare module 'goog:ctor_func' {
   import ctor_func = ಠ_ಠ.clutz.ctor_func;

--- a/src/test/java/com/google/javascript/clutz/ctor_func.js
+++ b/src/test/java/com/google/javascript/clutz/ctor_func.js
@@ -16,3 +16,12 @@ ctor_func.ctorFuncFieldAlias = ctor_func.ctorFuncField;
 
 /** @param {function(new:ctor_func.Ctor, number)} ctor */
 ctor_func.ctorFuncParam = function(ctor) {};
+
+/**
+  * @param {function(new:T, number)} ctor
+  * @return {T}
+  * @template T
+  */
+ctor_func.ctorFuncParamTemplatized = function(ctor) {
+  return new ctor(0);
+};

--- a/src/test/java/com/google/javascript/clutz/goog_promise_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_promise_with_platform.d.ts
@@ -1,7 +1,7 @@
 declare namespace ಠ_ಠ.clutz.goog {
   class Promise < TYPE , RESOLVER_CONTEXT > implements ಠ_ಠ.clutz.goog.Thenable < TYPE > {
     private noStructuralTyping_: any;
-    constructor (resolver : (a : (a ? : TYPE | PromiseLike < TYPE > | null | { then : any } ) => any , b : (a ? : any ) => any ) => void , opt_context ? : RESOLVER_CONTEXT ) ;
+    constructor (resolver : (this : RESOLVER_CONTEXT , a : (a ? : TYPE | PromiseLike < TYPE > | null | { then : any } ) => any , b : (a ? : any ) => any ) => void , opt_context ? : RESOLVER_CONTEXT ) ;
     then < RESULT > (opt_onFulfilled ? : ( (a : TYPE ) =>  any | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) :  any ;
     static all < TYPE > (promises : any [] ) : ಠ_ಠ.clutz.goog.Promise < TYPE [] , any > ;
     static race < TYPE > (promises : any [] ) : ಠ_ಠ.clutz.goog.Promise < TYPE , any > ;

--- a/src/test/java/com/google/javascript/clutz/static_this_templated_prop.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_this_templated_prop.d.ts
@@ -4,7 +4,7 @@ declare namespace ಠ_ಠ.clutz.static_this_templated_prop {
    */
   class SomeContainer {
     private noStructuralTyping_: any;
-    static nestedClass ( ) : void ;
+    static nestedClass < SCOPE > (this : SCOPE ) : void ;
   }
 }
 declare module 'goog:static_this_templated_prop' {

--- a/src/test/java/com/google/javascript/clutz/this_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/this_type.d.ts
@@ -1,0 +1,7 @@
+declare namespace ಠ_ಠ.clutz.nsThisType {
+  function func (this : Function , str : string ) : void ;
+}
+declare module 'goog:nsThisType' {
+  import nsThisType = ಠ_ಠ.clutz.nsThisType;
+  export = nsThisType;
+}

--- a/src/test/java/com/google/javascript/clutz/this_type.js
+++ b/src/test/java/com/google/javascript/clutz/this_type.js
@@ -1,0 +1,9 @@
+goog.provide('nsThisType');
+
+/**
+ * @param {string} str
+ * @this {Function}
+ */
+nsThisType.func = function(str) {
+};
+

--- a/src/test/java/com/google/javascript/clutz/this_type_param.d.ts
+++ b/src/test/java/com/google/javascript/clutz/this_type_param.d.ts
@@ -2,7 +2,8 @@ declare namespace ಠ_ಠ.clutz.nsThis {
   class C {
     private noStructuralTyping_: any;
     bar ( ) : ಠ_ಠ.clutz.nsThis.C ;
-    foo ( ) : this ;
+    foo < THIS > (this : THIS ) : THIS ;
+    foo2 < THIS > (this : THIS , str : string ) : THIS ;
   }
 }
 declare module 'goog:nsThis.C' {

--- a/src/test/java/com/google/javascript/clutz/this_type_param.d.ts
+++ b/src/test/java/com/google/javascript/clutz/this_type_param.d.ts
@@ -2,8 +2,9 @@ declare namespace ಠ_ಠ.clutz.nsThis {
   class C {
     private noStructuralTyping_: any;
     bar ( ) : ಠ_ಠ.clutz.nsThis.C ;
-    foo < THIS > (this : THIS ) : THIS ;
-    foo2 < THIS > (this : THIS , str : string ) : THIS ;
+    foo ( ) : this ;
+    foo2 (str : string ) : this ;
+    foo3 < THIS > (this : THIS , arr : THIS [] ) : this ;
   }
 }
 declare module 'goog:nsThis.C' {

--- a/src/test/java/com/google/javascript/clutz/this_type_param.js
+++ b/src/test/java/com/google/javascript/clutz/this_type_param.js
@@ -25,6 +25,15 @@ nsThis.C.prototype.foo2 = function(str) {
   return this;
 };
 
+/**
+ * @param {!Array<THIS>} arr
+ * @return {THIS}
+ * @this {THIS}
+ * @template THIS
+ */
+nsThis.C.prototype.foo3 = function(arr) {
+  return this;
+};
 
 /**
  * @return {!nsThis.C}

--- a/src/test/java/com/google/javascript/clutz/this_type_param.js
+++ b/src/test/java/com/google/javascript/clutz/this_type_param.js
@@ -16,6 +16,17 @@ nsThis.C.prototype.foo = function() {
 };
 
 /**
+ * @param {string} str
+ * @return {THIS}
+ * @this {THIS}
+ * @template THIS
+ */
+nsThis.C.prototype.foo2 = function(str) {
+  return this;
+};
+
+
+/**
  * @return {!nsThis.C}
  */
 nsThis.C.prototype.bar = function() {

--- a/src/test/java/com/google/javascript/clutz/this_type_param_generics.d.ts
+++ b/src/test/java/com/google/javascript/clutz/this_type_param_generics.d.ts
@@ -1,0 +1,18 @@
+declare namespace ಠ_ಠ.clutz.nsThisGenerics {
+  class A {
+    private noStructuralTyping_: any;
+    array < T > (this : T ) : T [] ;
+    foo < T > (this : T ) : ಠ_ಠ.clutz.nsThisGenerics.GenericClass < T > ;
+    object < T > (this : T ) : { [ key: string ]: T } ;
+    record < T > (this : T ) : { foo : T } ;
+    union < T > (this : T ) : ಠ_ಠ.clutz.nsThisGenerics.GenericClass < T > | null | string ;
+  }
+  class GenericClass < TYPE > {
+    private noStructuralTyping_: any;
+    constructor (t : TYPE ) ;
+  }
+}
+declare module 'goog:nsThisGenerics' {
+  import nsThisGenerics = ಠ_ಠ.clutz.nsThisGenerics;
+  export = nsThisGenerics;
+}

--- a/src/test/java/com/google/javascript/clutz/this_type_param_generics.js
+++ b/src/test/java/com/google/javascript/clutz/this_type_param_generics.js
@@ -1,0 +1,58 @@
+goog.provide('nsThisGenerics');
+
+/**
+ * @constructor
+ * @param {TYPE} t
+ * @template TYPE
+ */
+nsThisGenerics.GenericClass = function(t) {};
+
+/**
+ * @constructor
+ */
+nsThisGenerics.A = function() {};
+
+/**
+ * @return {!nsThisGenerics.GenericClass<T>}
+ * @this {T}
+ * @template T
+ */
+nsThisGenerics.A.prototype.foo = function() {
+  return new nsThisGenerics.GenericClass(this);
+};
+
+/**
+ * @return {nsThisGenerics.GenericClass<T> | string}
+ * @this {T}
+ * @template T
+ */
+nsThisGenerics.A.prototype.union = function() {
+  return new nsThisGenerics.GenericClass(this);
+};
+
+/**
+ * @return {!Array<T>}
+ * @this {T}
+ * @template T
+ */
+nsThisGenerics.A.prototype.array = function() {
+  return [this];
+};
+
+/**
+ * @return {!Object<string, T>}
+ * @this {T}
+ * @template T
+ */
+nsThisGenerics.A.prototype.object = function() {
+  return {foo: this};
+};
+
+/**
+ * @return {{foo: T}}
+ * @this {T}
+ * @template T
+ */
+nsThisGenerics.A.prototype.record = function() {
+  return {foo: this};
+};

--- a/src/test/java/com/google/javascript/clutz/this_type_param_generics_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/this_type_param_generics_usage.ts
@@ -1,0 +1,10 @@
+import * as ns from 'goog:nsThisGenerics';
+
+class B extends ns.A {}
+const b = new B();
+const ba: B[] = b.array();
+const bf: ns.GenericClass<B> = b.foo();
+const bo: {[key: string]: B} = b.object();
+const br: {foo: B} = b.record();
+const bu: ns.GenericClass <B> | null | string = b.union();
+


### PR DESCRIPTION
fixes #709 

## New features

Additionally, these forms are supported:

```js
/**
 * @return {!GenericClass<T>}
 * @this {T}
 * @template T
 */
A.prototype.foo = function() {
  return new GenericClass(this);
};

/**
 * @return {!Array<T>}
 * @this {T}
 * @template T
 */
A.prototype.array = function() {
  return [this];
};

/**
 * @return {!Object<string, T>}
 * @this {T}
 * @template T
 */
A.prototype.object = function() {
  return {foo: this};
};

/**
 * @return {{foo: T}}
 * @this {T}
 * @template T
 */
A.prototype.record = function() {
  return {foo: this};
};


/**
 * @param {string} str
 * @this {Function}
 */
A.func = function(str) {
};
```

are converted to

```ts
  class A {
    array < T > (this : T ) : T [] ;
    foo < T > (this : T ) : GenericClass < T > ;
    object < T > (this : T ) : { [ key: string ]: T } ;
    record < T > (this : T ) : { foo : T } ;
    func (this : Function , str : string ) : void ;
  }
```

But non-templatized `this` in a function type is not supported yet.
```js
/**
 * @type {function(this: Date)}
 */
var foo = function() {};
```

## Changes

```js
/**
 * @return {THIS}
 * @this {THIS}
 * @template THIS
 */
C.prototype.foo = function() {
  return this;
};
```
is currently converted to 
```ts
  class C {
    foo ( ) : this ;
  }
```
but in this PR, it is converted to
```ts
  class C {
    foo < THIS > (this : THIS ) : THIS ;
  }
```

Because polymorphic `this` types are invalid in some places, but templatized `this` is all valid. They are equivalent. For simplicity, I convert all to templatized `this`.

```ts
declare namespace ಠ_ಠ.clutz.nsThis {
  class A {
    // all valid
    returnThis<T>(this: T): T;
    array<T>(this: T): T[];
    generics<T>(this: T): Set<T>;
    object<T>(this: T) : { [ key: string ]: T } ;
    record<T>(this: T): { foo: T };
  }
  class B {
    returnThis(): this; // valid
    generics(): Set<this>;  // valid
    array(): this[]; // valid
    object(): { [ key: string ]: this } ; // invalid!!!
    record(): { foo: this }; // invalid!!!
  }
}
```
[playground](http://www.typescriptlang.org/play/#src=declare%20namespace%20%E0%B2%A0_%E0%B2%A0.clutz.nsThis%20%7B%0D%0A%20%20class%20A%20%7B%0D%0A%20%20%20%20returnThis%3CT%3E(this%3A%20T)%3A%20T%3B%0D%0A%20%20%20%20array%3CT%3E(this%3A%20T)%3A%20T%5B%5D%3B%0D%0A%20%20%20%20generics%3CT%3E(this%3A%20T)%3A%20Set%3CT%3E%3B%0D%0A%20%20%20%20object%3CT%3E(this%3A%20T)%20%3A%20%7B%20%5B%20key%3A%20string%20%5D%3A%20T%20%7D%20%3B%0D%0A%20%20%20%20record%3CT%3E(this%3A%20T)%3A%20%7B%20foo%3A%20T%20%7D%3B%0D%0A%20%20%7D%0D%0A%20%20class%20B%20%7B%0D%0A%20%20%20%20returnThis()%3A%20this%3B%0D%0A%20%20%20%20generics()%3A%20Set%3Cthis%3E%3B%0D%0A%20%20%20%20array()%3A%20this%5B%5D%3B%0D%0A%20%20%20%20object()%3A%20%7B%20%5B%20key%3A%20string%20%5D%3A%20this%20%7D%20%3B%0D%0A%20%20%20%20record()%3A%20%7B%20foo%3A%20this%20%7D%3B%0D%0A%20%20%7D%0D%0A%7D)
