### PR TITLE
Add env option to load default externs

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -346,6 +346,9 @@ class DeclarationGenerator {
     for (String extern : opts.externs) {
       externFiles.add(SourceFile.fromPath(Paths.get(extern), UTF_8));
     }
+    if (opts.env != null) {
+      externFiles.addAll(getDefaultExterns(opts));
+    }
     String result = generateDeclarations(sourceFiles, externFiles, opts.depgraph);
 
     if ("-".equals(opts.output)) {

--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -346,7 +346,7 @@ class DeclarationGenerator {
     for (String extern : opts.externs) {
       externFiles.add(SourceFile.fromPath(Paths.get(extern), UTF_8));
     }
-    if (opts.env != null) {
+    if (opts.closureEnv != null) {
       externFiles.addAll(getDefaultExterns(opts));
     }
     String result = generateDeclarations(sourceFiles, externFiles, opts.depgraph);

--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -81,12 +81,12 @@ public class Options {
   List<String> externs = new ArrayList<>();
 
   @Option(
-    name = "--env",
+    name = "--closure_env",
     usage =
         "Determines the set of builtin externs to load. Options: BROWSER, CUSTOM. "
             + "Default: no builtin externs"
   )
-  CompilerOptions.Environment env = null;
+  CompilerOptions.Environment closureEnv = null;
 
   @Option(
     name = "--depgraphs",
@@ -197,8 +197,8 @@ public class Options {
     // Always parse and analyze the latest language features closure supports.
     options.setLanguage(LanguageMode.ECMASCRIPT_NEXT);
     options.setLanguageOut(LanguageMode.ECMASCRIPT5);
-    if (env != null) {
-      options.setEnvironment(env);
+    if (closureEnv != null) {
+      options.setEnvironment(closureEnv);
     }
     options.setCheckTypes(true);
     options.setInferTypes(true);

--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -81,6 +81,14 @@ public class Options {
   List<String> externs = new ArrayList<>();
 
   @Option(
+    name = "--env",
+    usage =
+        "Determines the set of builtin externs to load. Options: BROWSER, CUSTOM. "
+            + "Default: no builtin externs"
+  )
+  CompilerOptions.Environment env = null;
+
+  @Option(
     name = "--depgraphs",
     usage = "only generate output for files listed as a root in the given depgraphs",
     metaVar = "file.depgraph...",
@@ -189,6 +197,9 @@ public class Options {
     // Always parse and analyze the latest language features closure supports.
     options.setLanguage(LanguageMode.ECMASCRIPT_NEXT);
     options.setLanguageOut(LanguageMode.ECMASCRIPT5);
+    if (env != null) {
+      options.setEnvironment(env);
+    }
     options.setCheckTypes(true);
     options.setInferTypes(true);
     // turns off optimizations.

--- a/src/test/java/com/google/javascript/clutz/OptionsTest.java
+++ b/src/test/java/com/google/javascript/clutz/OptionsTest.java
@@ -151,35 +151,13 @@ public class OptionsTest {
   }
 
   @Test
-  public void testEnvDefault() throws Exception {
+  public void testClosureEnvCustom() throws Exception {
     Options opts =
         new Options(
             new String[] {
-              "my/thing/static/js/0-bootstrap.js",
+              "my/thing/static/js/0-bootstrap.js", "--closure_env", "CUSTOM",
             });
-    assertThat(opts.env).isEqualTo(null);
-  }
-
-  @Test
-  public void testEnvBrowser() throws Exception {
-    Options opts =
-        new Options(
-            new String[] {
-              "my/thing/static/js/0-bootstrap.js", "--env", "BROWSER",
-            });
-    assertThat(opts.env).isEqualTo(CompilerOptions.Environment.BROWSER);
-    assertThat(opts.getCompilerOptions().getEnvironment())
-        .isEqualTo(CompilerOptions.Environment.BROWSER);
-  }
-
-  @Test
-  public void testEnvCustom() throws Exception {
-    Options opts =
-        new Options(
-            new String[] {
-              "my/thing/static/js/0-bootstrap.js", "--env", "CUSTOM",
-            });
-    assertThat(opts.env).isEqualTo(CompilerOptions.Environment.CUSTOM);
+    assertThat(opts.closureEnv).isEqualTo(CompilerOptions.Environment.CUSTOM);
     assertThat(opts.getCompilerOptions().getEnvironment())
         .isEqualTo(CompilerOptions.Environment.CUSTOM);
   }

--- a/src/test/java/com/google/javascript/clutz/OptionsTest.java
+++ b/src/test/java/com/google/javascript/clutz/OptionsTest.java
@@ -3,6 +3,7 @@ package com.google.javascript.clutz;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.*;
 
+import com.google.javascript.jscomp.CompilerOptions;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import org.junit.Test;
@@ -147,6 +148,40 @@ public class OptionsTest {
               DepgraphTest.DEPGRAPH_PATH.toFile().toString(),
             });
     assertThat(opts.externs).isEmpty();
+  }
+
+  @Test
+  public void testEnvDefault() throws Exception {
+    Options opts =
+        new Options(
+            new String[] {
+              "my/thing/static/js/0-bootstrap.js",
+            });
+    assertThat(opts.env).isEqualTo(null);
+  }
+
+  @Test
+  public void testEnvBrowser() throws Exception {
+    Options opts =
+        new Options(
+            new String[] {
+              "my/thing/static/js/0-bootstrap.js", "--env", "BROWSER",
+            });
+    assertThat(opts.env).isEqualTo(CompilerOptions.Environment.BROWSER);
+    assertThat(opts.getCompilerOptions().getEnvironment())
+        .isEqualTo(CompilerOptions.Environment.BROWSER);
+  }
+
+  @Test
+  public void testEnvCustom() throws Exception {
+    Options opts =
+        new Options(
+            new String[] {
+              "my/thing/static/js/0-bootstrap.js", "--env", "CUSTOM",
+            });
+    assertThat(opts.env).isEqualTo(CompilerOptions.Environment.CUSTOM);
+    assertThat(opts.getCompilerOptions().getEnvironment())
+        .isEqualTo(CompilerOptions.Environment.CUSTOM);
   }
 
   @Test


### PR DESCRIPTION
This is quite useful because the default externs are essential.
The default behavior (no externs) is not changed.