### PR TITLE
Fix NamedNodeMap

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -2259,30 +2259,20 @@ class DeclarationGenerator {
         return null;
       }
 
-      switch (type.getDisplayName()) {
-          // Arguments<?> and NodeList<?> in es3 externs are correspondingly
-          // IArguments and NodeList interfaces (not-parametrized) in lib.d.ts.
-        case "Arguments":
-          emit("IArguments");
-          return null;
-        case "NodeList":
-          emit("NodeList");
-          return null;
-        case "MessageEvent":
-          emit("MessageEvent");
-          return null;
-        default:
-          break;
+      final String displayName = type.getDisplayName();
+      if (PlatformSymbols.NOT_TEMPLATIZED_IN_TYPESCRIPT.contains(displayName)) {
+        emit(PlatformSymbols.CLOSURE_TO_TYPESCRIPT.getOrDefault(displayName, displayName));
+        return null;
       }
 
-      String maybeGlobalName = maybeRenameGlobalType(type.getDisplayName());
+      String maybeGlobalName = maybeRenameGlobalType(displayName);
       templateTypeName = maybeGlobalName == null ? templateTypeName : maybeGlobalName;
 
       if (type.getTemplateTypes().isEmpty()) {
         // In Closure, subtypes of `TemplatizedType`s that do not take type arguments are still
         // represented by templatized types.
         emit(templateTypeName);
-        typesUsed.add(type.getDisplayName());
+        typesUsed.add(displayName);
         return null;
       }
       Iterator<JSType> it = type.getTemplateTypes().iterator();
@@ -2293,7 +2283,7 @@ class DeclarationGenerator {
         return null;
       }
       emit(templateTypeName);
-      typesUsed.add(type.getDisplayName());
+      typesUsed.add(displayName);
       emitGenericTypeArguments(it);
       return null;
     }

--- a/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
+++ b/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
@@ -32,6 +32,15 @@ public class PlatformSymbols {
           .put("IIterableResult", "IteratorResult")
           .build();
 
+  /** Closure symbols that are templatized in Closure but not in TypeScript. */
+  public static final ImmutableSet<String> NOT_TEMPLATIZED_IN_TYPESCRIPT =
+      new ImmutableSet.Builder<String>()
+          .add("Arguments")
+          .add("NodeList")
+          .add("MessageEvent")
+          .add("NamedNodeMap")
+          .build();
+
   /**
    * List of global platform symbols that are redirected through an alias in closure.lib.d.ts. This
    * allows the following pattern to work:

--- a/src/test/java/com/google/javascript/clutz/types_externs_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/types_externs_with_platform.d.ts
@@ -11,6 +11,8 @@ declare namespace ಠ_ಠ.clutz.typesWithExterns {
   let a : { a : number } ;
   let b : IArguments ;
   let c : NodeList ;
+  let d : MessageEvent ;
+  let e : NamedNodeMap ;
   function elementMaybe ( ) : GlobalElement | null ;
   let myScope : ಠ_ಠ.clutz.namespace.Foo ;
   function topLevelFunction ( ...a : any [] ) : any ;

--- a/src/test/java/com/google/javascript/clutz/types_externs_with_platform.js
+++ b/src/test/java/com/google/javascript/clutz/types_externs_with_platform.js
@@ -45,11 +45,17 @@ typesWithExterns.C = function() {
 };
 goog.inherits(typesWithExterns.C, typesWithExterns.A);
 
-/** @type {!Arguments} */
+/** @type {!Arguments<*>} */
 typesWithExterns.b;
 
-/** @type {!NodeList} */
+/** @type {!NodeList<*>} */
 typesWithExterns.c;
+
+/** @type {!MessageEvent<*>} */
+typesWithExterns.d;
+
+/** @type {!NamedNodeMap<*>} */
+typesWithExterns.e;
 
 /** @typedef {IArrayLike} */
 typesWithExterns.ArrayLike;


### PR DESCRIPTION
`NamedNodeMap` is templatized in Closure (historical issue of DOM) but not in TypeScript like `NodeList` or `MessageEvent`. 

- https://github.com/google/closure-compiler/blob/50713dceb16b369f8f317e5b49e8a9dec2b47496/externs/browser/w3c_dom1.js#L463-L471
- https://github.com/Microsoft/TypeScript/blob/ee25cdecbca49b2b5a290ecd65224f425b1d6a9c/lib/lib.dom.iterable.d.ts#L127