### PR TITLE
Turn off conformance checks for clutz and gents.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -16,6 +16,8 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
@@ -183,6 +185,12 @@ public class Options {
           DependencyOptions.pruneLegacyForEntryPoints(entryPointIdentifiers));
     }
 
+    // Turns off common warning messages, when PhaseOptimizer decides to skip some passes due to
+    // unsupported code constructs. They are not very actionable to users, and do not seem to
+    // affect the quality of produced .d.ts.
+    Logger phaseLogger = Logger.getLogger("com.google.javascript.jscomp.PhaseOptimizer");
+    phaseLogger.setLevel(Level.OFF);
+
     // All diagnostics are WARNINGs (or off) and thus ignored unless debug == true.
     // Only report issues (and fail for them) that are specifically causing problems for Clutz.
     // The idea is to not do a general sanity check of Closure code, just make sure Clutz works.
@@ -206,6 +214,7 @@ public class Options {
     options.setChecksOnly(true);
     options.setPreserveDetailedSourceInfo(true);
     options.setParseJsDocDocumentation(Config.JsDocParsing.INCLUDE_DESCRIPTIONS_NO_WHITESPACE);
+    options.clearConformanceConfigs();
     if (partialInput) {
       options.setAssumeForwardDeclaredForMissingTypes(true);
       options.setWarningLevel(DiagnosticGroups.MISSING_SOURCES_WARNINGS, CheckLevel.OFF);

--- a/src/main/java/com/google/javascript/gents/Options.java
+++ b/src/main/java/com/google/javascript/gents/Options.java
@@ -19,6 +19,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
@@ -113,6 +115,12 @@ public class Options {
     final CompilerOptions options = new CompilerOptions();
     options.setClosurePass(true);
 
+    // Turns off common warning messages, when PhaseOptimizer decides to skip some passes due to
+    // unsupported code constructs. They are not very actionable to users and do not matter to
+    // gents.
+    Logger phaseLogger = Logger.getLogger("com.google.javascript.jscomp.PhaseOptimizer");
+    phaseLogger.setLevel(Level.OFF);
+
     options.setCheckGlobalNamesLevel(CheckLevel.ERROR);
     // Report duplicate definitions, e.g. for accidentally duplicated externs.
     options.setWarningLevel(DiagnosticGroups.DUPLICATE_VARS, CheckLevel.ERROR);
@@ -132,6 +140,8 @@ public class Options {
     options.setChecksOnly(true);
     options.setPreserveDetailedSourceInfo(true);
     options.setParseJsDocDocumentation(Config.JsDocParsing.INCLUDE_DESCRIPTIONS_NO_WHITESPACE);
+
+    options.clearConformanceConfigs();
 
     return options;
   }


### PR DESCRIPTION
Also, hides warnings from PhaseOptimizer. Both of these changes, do not
seem to affect clutz/gents capabilities, but rather just annoy users.