### PR TITLE
Inherit visibility of parent properties

### DIFF
--- a/src/test/java/com/google/javascript/clutz/inherit_visibility.d.ts
+++ b/src/test/java/com/google/javascript/clutz/inherit_visibility.d.ts
@@ -1,0 +1,27 @@
+declare namespace ಠ_ಠ.clutz.module$exports$inherit_visibility {
+  class Child extends ಠ_ಠ.clutz.module$exports$inherit_visibility.Parent {
+    private noStructuralTyping_module$exports$inherit_visibility_Child : any;
+    protected protected ( ) : void ;
+    protected protectedNoJSDoc ( ) : void ;
+    publicExplicit ( ) : void ;
+    publicImplicit ( ) : void ;
+  }
+  class GrandChild extends ಠ_ಠ.clutz.module$exports$inherit_visibility.Child {
+    private noStructuralTyping_module$exports$inherit_visibility_GrandChild : any;
+    protected protected ( ) : void ;
+    protected protectedNoJSDoc ( ) : void ;
+    publicExplicit ( ) : void ;
+    publicImplicit ( ) : void ;
+  }
+  class Parent {
+    private noStructuralTyping_module$exports$inherit_visibility_Parent : any;
+    protected protected ( ) : void ;
+    protected protectedNoJSDoc ( ) : void ;
+    publicExplicit ( ) : void ;
+    publicImplicit ( ) : void ;
+  }
+}
+declare module 'goog:inherit_visibility' {
+  import inherit_visibility = ಠ_ಠ.clutz.module$exports$inherit_visibility;
+  export = inherit_visibility;
+}

--- a/src/test/java/com/google/javascript/clutz/inherit_visibility.js
+++ b/src/test/java/com/google/javascript/clutz/inherit_visibility.js
@@ -1,0 +1,39 @@
+goog.module('inherit_visibility');
+
+/** @constructor */
+function Parent() {}
+
+Parent.prototype.publicImplicit = function() {};
+/** @public */
+Parent.prototype.publicExplicit = function() {};
+/** @protected */
+Parent.prototype.protected = function() {};
+/** @protected */
+Parent.prototype.protectedNoJSDoc = function() {};
+
+/** @constructor @extends {Parent} */
+function Child() {}
+
+/** @override */
+Child.prototype.publicImplicit = function() {};
+/** @override */
+Child.prototype.publicExplicit = function() {};
+/** @override */
+Child.prototype.protected = function() {};
+Child.prototype.protectedNoJSDoc = function() {};
+
+/** @constructor @extends {Child} */
+function GrandChild() {}
+
+// In Closure, a child class can override an implicit public property with protected.
+/** @override @protected */
+GrandChild.prototype.publicImplicit = function() {};
+/** @override */
+GrandChild.prototype.publicExplicit = function() {};
+/** @override */
+GrandChild.prototype.protected = function() {};
+GrandChild.prototype.protectedNoJSDoc = function() {};
+
+exports.Parent = Parent;
+exports.Child = Child;
+exports.GrandChild = GrandChild;


### PR DESCRIPTION
Currently, if a child class property doesn't have visibility tag in the JSDoc explicitly, it is emitted as a public property.
But if the parent property is protected, the child property should inherit it and be emitted as a protected.

This PR resolves [15 errors of TS2415](https://github.com/teppeis/closure-library.d.ts/blob/0fe57c2b9664a308cf83c423e613852f4a7401fb/errors.txt) in Closure Library.