### PR TITLE
Map AsyncIteratorIterable to AsyncIterableIterator for latest Closure Compiler

### DIFF
--- a/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
+++ b/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
@@ -25,6 +25,7 @@ public class PlatformSymbols {
       new ImmutableMap.Builder<String, String>()
           .put("CSSProperties", "CSSStyleDeclaration")
           .put("IteratorIterable", "IterableIterator")
+          .put("AsyncIteratorIterable", "AsyncIterableIterator")
           .put("Generator", "IterableIterator")
           .put("IArrayLike", "ArrayLike")
           .put("Arguments", "IArguments")


### PR DESCRIPTION
Currently [clutz CI is failed](https://travis-ci.org/angular/clutz/jobs/465108148) because latest compiler https://github.com/google/closure-compiler/commit/91c0ace5eeeae92912e12bd84617eaf60ea7f536 introduced `AsyncIteratorIterable`.
clutz should map it to [AsyncIterableIterator](https://github.com/Microsoft/TypeScript/blob/71286e3d49c10e0e99faac360a6bbd40f12db7b6/src/lib/esnext.asynciterable.d.ts) like `IteratorIterable`.