### PR TITLE
Add OffscreenCanvas to CLOSURE_EXTERNS_NOT_USED_IN_TYPESCRIPT

### DIFF
--- a/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
+++ b/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
@@ -229,6 +229,7 @@ public class PlatformSymbols {
           "OES_depth_texture",
           "OES_vertex_array_object",
           "ObjectPropertyDescriptor",
+          "OffscreenCanvas",
           "PerformanceLongTaskTiming",
           "PerformanceObserver",
           "PerformanceObserverCallback",


### PR DESCRIPTION
Currently [clutz CI is failed](https://travis-ci.org/angular/clutz/jobs/466982084) because latest compiler introduced `OffscreenCanvas` in https://github.com/google/closure-compiler/commit/2738c0907a0a5791ebf28ec32a5f40988a5ace8d.