### PR TITLE
Add FullscreenOptions to CLOSURE_EXTERNS_NOT_USED_IN_TYPESCRIPT list

### DIFF
--- a/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
+++ b/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
@@ -153,6 +153,7 @@ public class PlatformSymbols {
           "EventSourceInit",
           "ExceptionCode",
           "FetchRequestType",
+          "FullscreenOptions",
           "FontFace",
           "FontFaceDescriptors",
           "FontFaceLoadStatus",


### PR DESCRIPTION
For https://github.com/google/closure-compiler/commit/aed8df734fac7fed10e5f7c9f6582a659b7b1a63

But this test is too flaky...