### PR TITLE
Add support for emitting iterated inner classes.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -3272,6 +3272,19 @@ class DeclarationGenerator {
         }
       }
       if (foundNamespaceMembers) emitNamespaceEnd();
+
+      // Recursively repeat the process for inner types of inner types.
+      for (NamedTypePair namedType : innerProps.keySet()) {
+        JSType pType = namedType.type;
+        String qualifiedName = innerNamespace + '.' + namedType.name;
+
+        // This probably could be extended to enums and interfaces, but I rather wait for for some
+        // real world use-cases before supporting what seems like a bad way to organize closure code
+        // layout.
+        if (isClassLike(pType)) {
+          walkInnerSymbols((FunctionType) pType, qualifiedName);
+        }
+      }
     }
 
     private void visitFunctionExpression(String propName, FunctionType ftype) {

--- a/src/test/java/com/google/javascript/clutz/double_inner_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/double_inner_class.d.ts
@@ -1,0 +1,24 @@
+declare namespace ಠ_ಠ.clutz {
+  class module$exports$iterated$innerclass {
+    private noStructuralTyping_module$exports$iterated$innerclass : any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.module$exports$iterated$innerclass {
+  class B {
+    private noStructuralTyping_module$exports$iterated$innerclass_B : any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.module$exports$iterated$innerclass.B {
+  class C {
+    private noStructuralTyping_module$exports$iterated$innerclass_B_C : any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.module$exports$iterated$innerclass.B.C {
+  class D {
+    private noStructuralTyping_module$exports$iterated$innerclass_B_C_D : any;
+  }
+}
+declare module 'goog:iterated.innerclass' {
+  import innerclass = ಠ_ಠ.clutz.module$exports$iterated$innerclass;
+  export default innerclass;
+}

--- a/src/test/java/com/google/javascript/clutz/double_inner_class.js
+++ b/src/test/java/com/google/javascript/clutz/double_inner_class.js
@@ -1,0 +1,25 @@
+goog.module('iterated.innerclass');
+
+/**
+ * @struct
+ */
+class A {}
+
+/**
+ * @struct
+ */
+A.B = class {};
+
+/**
+ * @struct
+ */
+A.B.C = class {};
+
+/**
+ * @struct
+ */
+A.B.C.D = class {
+};
+
+
+exports = A;


### PR DESCRIPTION
Clutz does a separate pass to emit inner properties of a Closure class
(like other classes, interfaces, enums or typedefs) that in TS are not
expressable as statics. The newly found properties are emitted in a
namespace.

This works because TS allows to have a namespace
and a class that share a name (despite both being values).

Previously, this process only worked at a single depth, but with this
change we iterate at aribrary depths for classes and interface, i.e.
inner classes that have their own inner classes.

For now we only interate on classes and interfaces, but technically we
can extend this to enums and typedefs if need arises.