### PR TITLE
Improve Promise and remove --noStrictGenericChecks

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -2968,9 +2968,7 @@ class DeclarationGenerator {
         } else {
           return "then < RESULT > (opt_onFulfilled ? : ( (a : "
               + templateVarName
-              + " ) => "
-              + classTemplatizedType
-              + " | RESULT ) | null , "
+              + " ) => PromiseLike < RESULT > | RESULT ) | null , "
               + "opt_onRejected ? : ( (a : any ) => any ) | null) : "
               + classTemplatizedType
               + " ;";

--- a/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
+++ b/src/test/java/com/google/javascript/clutz/DeclarationSyntaxTest.java
@@ -49,10 +49,7 @@ public class DeclarationSyntaxTest {
           "--lib",
           "es5,dom,es2015.iterable",
           "--noImplicitAny",
-          "--strictNullChecks",
-          // TODO(lucassloan): Necessary to allow promise like things that extend other promise like
-          // things.  Turn off when turned off in g3
-          "--noStrictGenericChecks");
+          "--strictNullChecks");
 
   @Test
   public void testDeclarationSyntax() throws Exception {

--- a/src/test/java/com/google/javascript/clutz/goog_promise_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_promise_with_platform.d.ts
@@ -2,7 +2,7 @@ declare namespace ಠ_ಠ.clutz.goog {
   class Promise < TYPE , RESOLVER_CONTEXT > implements ಠ_ಠ.clutz.goog.Thenable < TYPE > {
     private noStructuralTyping_goog_Promise : any;
     constructor (resolver : (this : RESOLVER_CONTEXT , a : (a ? : TYPE | PromiseLike < TYPE > | null | { then : any } ) => any , b : (a ? : any ) => any ) => void , opt_context ? : RESOLVER_CONTEXT ) ;
-    then < RESULT > (opt_onFulfilled ? : ( (a : TYPE ) =>  any | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) :  any ;
+    then < RESULT > (opt_onFulfilled ? : ( (a : TYPE ) => PromiseLike < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) :  any ;
     static all < TYPE > (promises : any [] ) : ಠ_ಠ.clutz.goog.Promise < TYPE [] , any > ;
     static race < TYPE > (promises : any [] ) : ಠ_ಠ.clutz.goog.Promise < TYPE , any > ;
     static resolve < T >(value: ಠ_ಠ.clutz.goog.Promise < T , any > | T): any;
@@ -19,7 +19,7 @@ declare namespace ಠ_ಠ.clutz.goog {
     function isImplementedBy (object : any ) : boolean ;
   }
   interface Thenable < TYPE > extends PromiseLike < TYPE > {
-    then < RESULT > (opt_onFulfilled ? : ( (a : TYPE ) => ಠ_ಠ.clutz.goog.Thenable < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : ಠ_ಠ.clutz.goog.Thenable < RESULT > ;
+    then < RESULT > (opt_onFulfilled ? : ( (a : TYPE ) => PromiseLike < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : ಠ_ಠ.clutz.goog.Thenable < RESULT > ;
   }
 }
 declare module 'goog:goog.Thenable' {

--- a/src/test/java/com/google/javascript/clutz/partial/tte_promise_partial.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/tte_promise_partial.d.ts
@@ -2,7 +2,7 @@ declare namespace ಠ_ಠ.clutz.module$exports$tte$Promise$Partial {
   class PartialDeferred < VALUE = any > extends ಠ_ಠ.clutz.Base < VALUE > {
     private noStructuralTyping_module$exports$tte$Promise$Partial_PartialDeferred : any;
     constructor ( ) ;
-    then < RESULT > (opt_onFulfilled ? : ( (a : VALUE ) => ಠ_ಠ.clutz.module$exports$tte$Promise$Partial.PartialDeferred < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : ಠ_ಠ.clutz.module$exports$tte$Promise$Partial.PartialDeferred < RESULT > ;
+    then < RESULT > (opt_onFulfilled ? : ( (a : VALUE ) => PromiseLike < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) : ಠ_ಠ.clutz.module$exports$tte$Promise$Partial.PartialDeferred < RESULT > ;
   }
 }
 declare module 'goog:tte.Promise.Partial' {


### PR DESCRIPTION
`--noStrictGenericChecks` in DeclarationSyntaxTest was introduced temporary in https://github.com/angular/clutz/pull/689.
This PR is minimum improvement of Promise to remove `--noStrictGenericChecks` from `DeclarationSyntaxTest` and the users environment.

Both `goog.Thenable.prototype.then` and `goog.Promise.prototype.then` can receive `IThenable` (that is mapped to `PromiseLike` in TypeScript) and this fix resolves the strict generic check error.
https://github.com/google/closure-library/blob/e656c0807353188f42b67722d56724a5afc13228/closure/goog/promise/thenable.js#L47-L75

I can improve more, but [I can not understand the meaning of that TODO comment](https://github.com/angular/clutz/issues/806#issuecomment-445816477), so I will leave other code as it is.
