### PR TITLE
Emit each inner class once

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -3296,6 +3296,7 @@ class DeclarationGenerator {
       for (NamedTypePair namedType : innerProps.keySet()) {
         JSType pType = namedType.type;
         String qualifiedName = innerNamespace + '.' + namedType.name;
+        if (provides.contains(qualifiedName)) continue;
 
         // This probably could be extended to enums and interfaces, but I rather wait for for some
         // real world use-cases before supporting what seems like a bad way to organize closure

--- a/src/test/java/com/google/javascript/clutz/goog_module_moduleloader.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_module_moduleloader.d.ts
@@ -1,0 +1,21 @@
+declare namespace ಠ_ಠ.clutz.goog {
+  function module (a : string ) : void ;
+}
+declare module 'goog:goog.module' {
+  import module = ಠ_ಠ.clutz.goog.module;
+  export default module;
+}
+declare namespace ಠ_ಠ.clutz.goog.module {
+  class ModuleLoader {
+    private noStructuralTyping_goog_module_ModuleLoader : any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.goog.module.ModuleLoader {
+  class EvaluateCodeEvent {
+    private noStructuralTyping_goog_module_ModuleLoader_EvaluateCodeEvent : any;
+  }
+}
+declare module 'goog:goog.module.ModuleLoader' {
+  import ModuleLoader = ಠ_ಠ.clutz.goog.module.ModuleLoader;
+  export default ModuleLoader;
+}

--- a/src/test/java/com/google/javascript/clutz/goog_module_moduleloader.js
+++ b/src/test/java/com/google/javascript/clutz/goog_module_moduleloader.js
@@ -1,0 +1,18 @@
+goog.provide('goog.module');
+goog.provide('goog.module.ModuleLoader');
+
+/**
+ * @suppress {duplicate}
+ * @type {function(string):void}
+ */
+goog.module = goog.module || {};
+
+/**
+ * @constructor
+ */
+goog.module.ModuleLoader = function() {};
+
+/**
+ * @constructor
+ */
+goog.module.ModuleLoader.EvaluateCodeEvent = function() {};


### PR DESCRIPTION
After https://github.com/angular/clutz/pull/822, `goog.module.ModuleLoader.EvaluateCodeEvent` and some classes are emitted twice throwing `TS2300: Duplicate identifier`.
Because `goog.module.ModuleLoader.EvaluateCodeEvent` is emitted as an inner class of not only `goog.module.ModuleLoader` but also `goog.module`.