### PR TITLE
More fixes to enable running Clutz tests in other environments.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -438,12 +438,15 @@ class DeclarationGenerator {
       }
       Collection<String> inputProvides = compilerInput.getProvides();
       Collection<String> filteredProvides = new ArrayList<>();
-      // It appears closure reports 'module$src$...filepath...' provides
+      // It appears closure reports 'module$...filepath...' provides
       // for files that have no goog.provide or goog.module.
       // Such files cannot be really imported by typescript, so we do not
       // produce a .d.ts for them.
+      // Note: It appears that in the github test environment these provides start with
+      // `module$src$<filepath>`, while internally they miss the "src" and it is just
+      // `module$<filepath>.
       for (String p : inputProvides) {
-        if (!p.startsWith("module$src$")) {
+        if (!p.startsWith("module$")) {
           filteredProvides.add(p);
         }
       }
@@ -944,6 +947,8 @@ class DeclarationGenerator {
 
     // Don't emit externs for Closure types that nobody uses.
     if (PlatformSymbols.CLOSURE_EXTERNS_NOT_USED_IN_TYPESCRIPT.contains(symbolName)) return true;
+    if (PlatformSymbols.ADDITIONAL_CLOSURE_EXTERNS_NOT_USED_IN_TYPESCRIPT.contains(symbolName))
+      return true;
     // Don't emit externs for Closure types that have TypeScript equivalents.
     if (PlatformSymbols.CLOSURE_TO_TYPESCRIPT.containsKey(symbolName)) return true;
     // Don't emit externs for Closure types that exist in TypeScript already.

--- a/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
+++ b/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
@@ -1772,4 +1772,11 @@ public class PlatformSymbols {
           "webkitRTCPeerConnection",
           "webkitRequestAnimationFrame",
           "window");
+
+  /**
+   * Intentionally empty, this list exists, so that one can add symbols to it in forks for other
+   * environments - like the google internal environment.
+   */
+  public static final ImmutableSet<String> ADDITIONAL_CLOSURE_EXTERNS_NOT_USED_IN_TYPESCRIPT =
+      ImmutableSet.of();
 }

--- a/src/test/java/com/google/javascript/clutz/MultiFileTest.java
+++ b/src/test/java/com/google/javascript/clutz/MultiFileTest.java
@@ -119,7 +119,8 @@ public class MultiFileTest {
   }
 
   private File input(String filename) {
-    Path testDir = FileSystems.getDefault().getPath("src", "test", "java");
+    Path root = FileSystems.getDefault().getPath(ProgramSubject.SOURCE_ROOT);
+    Path testDir = root.resolve("src").resolve("test").resolve("java");
     String packageName = ProgramSubject.class.getPackage().getName();
     Path myPackage = testDir.resolve(packageName.replace('.', File.separatorChar));
     return myPackage.resolve(name.getMethodName()).resolve(filename).toAbsolutePath().toFile();


### PR DESCRIPTION
- new variable ADDITIONAL_CLOSURE_EXTERNS_NOT_USED_IN_TYPESCRIPT for
extensions of externs.
- using SOURCE_ROOT for MultiFileTest
- empty files filtering adjustment.