### PR TITLE
Emit each inner class once.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -3301,6 +3301,7 @@ class DeclarationGenerator {
       for (NamedTypePair namedType : innerProps.keySet()) {
         JSType pType = namedType.type;
         String qualifiedName = innerNamespace + '.' + namedType.name;
+        if (provides.contains(qualifiedName)) continue;
 
         // This probably could be extended to enums and interfaces, but I rather wait for for some
         // real world use-cases before supporting what seems like a bad way to organize closure

--- a/src/test/java/com/google/javascript/clutz/inner_provide_with_inner_symbol.d.ts
+++ b/src/test/java/com/google/javascript/clutz/inner_provide_with_inner_symbol.d.ts
@@ -1,0 +1,21 @@
+declare namespace ಠ_ಠ.clutz.ns {
+  function provide ( ) : void ;
+}
+declare module 'goog:ns.provide' {
+  import provide = ಠ_ಠ.clutz.ns.provide;
+  export default provide;
+}
+declare namespace ಠ_ಠ.clutz.ns.provide {
+  class C {
+    private noStructuralTyping_ns_provide_C : any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.ns.provide.C {
+  class Inner {
+    private noStructuralTyping_ns_provide_C_Inner : any;
+  }
+}
+declare module 'goog:ns.provide.C' {
+  import C = ಠ_ಠ.clutz.ns.provide.C;
+  export default C;
+}

--- a/src/test/java/com/google/javascript/clutz/inner_provide_with_inner_symbol.js
+++ b/src/test/java/com/google/javascript/clutz/inner_provide_with_inner_symbol.js
@@ -1,0 +1,17 @@
+goog.provide('ns.provide');
+goog.provide('ns.provide.C');
+
+/**
+ * @type {function():void}
+ */
+ns.provide = function() {};
+
+/**
+ * @constructor
+ */
+ns.provide.C = function() {};
+
+/**
+ * @constructor
+ */
+ns.provide.C.Inner = function() {};


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/angular/clutz/commit/65e524ba2c1c341966eb3415682aa1ba21bc8c27
where we would emit inner classes twice under some circumstances.