### PR TITLE
Add RTCRtpSendParameters to CLOSURE_EXTERNS_NOT_USED_IN_TYPESCRIPT

### DIFF
--- a/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
+++ b/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
@@ -260,6 +260,7 @@ public class PlatformSymbols {
           "RTCDataChannelInitRecord_",
           "RTCIceServerInterface_",
           "RTCIceServerRecord_",
+          "RTCRtpSendParameters",
           "RTCRtpTransceiver",
           "RTCStatsElement",
           "RTCStatsResponse",


### PR DESCRIPTION
for https://github.com/google/closure-compiler/commit/c67539401b481a8459a95878ccf6c85031cd9883