### PR TITLE
 Fix: a class extending Array emits an invalid iterable method

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -2677,7 +2677,9 @@ class DeclarationGenerator {
       // in the case of unknown base.
       // For unknown reasons instanceType.isInterface() return false, so we turn off the emit for
       // all partial input compilations.
-      if (iteratorIterableType != null && instanceType.isSubtype(iteratorIterableType)) {
+      if (instanceType.isSubtype(typeRegistry.getNativeType(ARRAY_TYPE))) {
+        return;
+      } else if (iteratorIterableType != null && instanceType.isSubtype(iteratorIterableType)) {
         implemented = iteratorIterableType;
         returnType = "IterableIterator";
       } else if (iterableType != null

--- a/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
+++ b/src/main/java/com/google/javascript/clutz/PlatformSymbols.java
@@ -260,6 +260,7 @@ public class PlatformSymbols {
           "RTCDataChannelInitRecord_",
           "RTCIceServerInterface_",
           "RTCIceServerRecord_",
+          "RTCRtpSendParameters",
           "RTCRtpTransceiver",
           "RTCStatsElement",
           "RTCStatsResponse",


### PR DESCRIPTION
Fixes #836
This PR based on #837 commit to pass CI.

`Array` implements `Iterable` in Closure (https://github.com/google/closure-compiler/commit/160b54ea1ce77b2b39a35877e93e47570db87285), but implements `IterableIterator` in TypeScript. So the current generated d.ts throws [a type error](http://www.typescriptlang.org/play/#src=declare%20namespace%20ಠ_ಠ.clutz.extend.array%20%7B%0D%0A%20%20class%20C%20extends%20Array<%20any%20>%20%7B%0D%0A%20%20%20%20private%20noStructuralTyping_extend_array_C%20%3A%20any%3B%0D%0A%20%20%20%20constructor%20(%20)%20%3B%0D%0A%20%20%20%20%5BSymbol.iterator%5D()%3A%20%20Iterator%20<%20any%20>%20%3B%0D%0A%20%20%7D%0D%0A%7D).

I believe it doesn't have to emit `[Symbol.iterator]()` for subtypes of `Array`.

Original PR: https://github.com/angular/clutz/pull/712