### PR TITLE
build: switch to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,59 @@
+# Cache key for CircleCI. We want to invalidate the cache whenever the gradle build
+# configuration changed.
+var_1: &cache_key angular-clutz-{{ checksum "build.gradle" }}
+# Use the CircleCI browsers image that comes with JDK8 and NodeJS installed. We need NodeJS
+# besides Java and Gradle because tests depend on the NPM modules that need to be installed.
+var_2: &default_docker_image circleci/node:10.12-browsers
+
+# Settings common to each job
+var_3: &job_defaults
+  working_directory: ~/clutz
+  docker:
+  - image: *default_docker_image
+
+var_4: &save_cache
+  save_cache:
+    key: *cache_key
+    paths:
+    - "~/.gradle"
+
+var_5: &npm_install
+  run: npm install
+
+jobs:
+  # Job that runs the gradle tests with snapshot builds of Google closure compiler.
+  test_snapshot:
+    <<: *job_defaults
+    environment:
+      CI_MODE: Nightly
+    steps:
+      - checkout
+      - restore_cache:
+          key: *cache_key
+      - *npm_install
+      - run: ./gradlew assemble
+      - run: ./gradlew check
+      - *save_cache
+
+  # Job that runs the gradle tests using a released Google closure compiler version.
+  test_released_optional:
+    <<: *job_defaults
+    environment:
+      CI_MODE: Released
+    steps:
+      - checkout
+      - restore_cache:
+          key: *cache_key
+      - *npm_install
+      # In case Gradle fails for the released version of Google closure compiler, we don't want
+      # to exit the CI job with an error. Manually ensure that this command runs with failures
+      # allowed. Related CircleCI issue: https://ideas.circleci.com/ideas/CCI-I-646
+      - run: ./gradlew assemble || true
+      - run: ./gradlew check || true
+
+workflows:
+  version: 2
+  default_workflow:
+    jobs:
+      - test_snapshot
+      - test_released_optional

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: java
 sudo: false
 cache:
   directories:
-  - $HOME/.gradle
+    - $HOME/.gradle
 jdk:
   - oraclejdk8
 env:
@@ -17,4 +17,3 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: "CI_MODE=Released"
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clutz - Closure to TypeScript Declarations (`.d.ts`) generator.
 
-[![Build Status](https://travis-ci.org/angular/clutz.svg?branch=master)](https://travis-ci.org/angular/clutz)
+[![Build Status](https://circleci.com/gh/angular/clutz.svg?style=svg)](https://circleci.com/gh/angular/clutz)
 
 This project uses the
 [Closure Compiler](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler)


### PR DESCRIPTION
Blocked on https://github.com/angular/clutz/pull/838 which fixes the CI failures on `master`