### PR TITLE
Adjust [symbol.iterator] emit to ignore classes extending Array.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/class_extends_array.d.ts
+++ b/src/test/java/com/google/javascript/clutz/class_extends_array.d.ts
@@ -2,6 +2,8 @@ declare namespace ಠ_ಠ.clutz.extend.array {
   class C extends Array< any > {
     private noStructuralTyping_extend_array_C : any;
     constructor ( ) ;
+    //!! Emitting [Symbol.iterator] would be wrong here, because one it should
+    //!! be just picked up from the Array base.
   }
 }
 declare module 'goog:extend.array.C' {

--- a/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
@@ -334,6 +334,17 @@ declare namespace ಠ_ಠ.clutz {
   }
 }
 declare namespace ಠ_ಠ.clutz {
+  interface RTCRtpSendParameters {
+    /**
+     * Possible string values are "maintain-framerate", "maintain-resolution", and
+     * "balanced".
+     */
+    degradationPreference ? : string ;
+    encodings : RTCRtpEncodingParameters [] ;
+    transactionId ? : string ;
+  }
+}
+declare namespace ಠ_ಠ.clutz {
   interface RTCRtpTransceiverInit {
     /**
      * The direction of the `RTCRtpTransceiver`. Defaults to "sendrecv".


### PR DESCRIPTION
The [symbol.iterator] emit is quite hacky because it just tests whether
Iterable is implemented anywhere through the extends/implements chain.
However, in scenarios where the implements clause is reachable through
an extended base class, the actual emit is not needed.

A recent change in closure, made it so that the always-present (even
without externs) Array types implement Iterable. This requires that the
symbol iterator code skips reemiting [symbol.iterable] for superclasses
of Array. Actually emitting [symbol.iterable] exposes another issue
where the platform .d.ts for Array expects [symbol.iterable] to be
IteratorIterable, but we can only reasonably emit Iterable given the
partial compilation of incremental clutz.

This change simply detects this scenario and avoid emitting.

Also, pick up a trivial general_with_platform.d.ts change to make the
tests pass.