### PR TITLE
Proper fix for #853.

### DIFF
--- a/src/main/java/com/google/javascript/gents/Options.java
+++ b/src/main/java/com/google/javascript/gents/Options.java
@@ -8,6 +8,7 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.javascript.jscomp.CheckLevel;
 import com.google.javascript.jscomp.CompilerOptions;
+import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import com.google.javascript.jscomp.DiagnosticGroups;
 import com.google.javascript.jscomp.parsing.Config;
 import java.io.IOException;
@@ -129,7 +130,8 @@ public class Options {
     options.setWarningLevel(DiagnosticGroups.DUPLICATE_VARS, CheckLevel.ERROR);
 
     options.setLanguage(CompilerOptions.LanguageMode.ECMASCRIPT_NEXT);
-    options.setLanguageOut(CompilerOptions.LanguageMode.NO_TRANSPILE);
+    // For unknown to me reason, NO_TRANSPILE changes how arrow functions are emitted.
+    options.setLanguageOut(LanguageMode.ECMASCRIPT6_TYPED);
 
     // Do not transpile module declarations
     options.setWrapGoogModulesForWhitespaceOnly(false);

--- a/src/test/java/com/google/javascript/gents/singleTests/functions.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/functions.js
@@ -61,19 +61,17 @@ var retVoid = function() {};
  */
 var retUndef = function() {};
 
-// These tests are disabled, because they are broken by recent Closure change.
-// See https://github.com/angular/clutz/issues/853
 /**
  * @param {number} a
  * @return {number}
  */
-// const arrowWithJsDoc = a => { return a; };
+const arrowWithJsDoc = a => { return a; };
 
 /**
  * @param {number} a
  * @return {number}
  */
-// const arrowWithJsDocAndParens = (a) => { return a; };
+const arrowWithJsDocAndParens = (a) => { return a; };
 
 /**
  * @param {number} a

--- a/src/test/java/com/google/javascript/gents/singleTests/functions.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/functions.ts
@@ -31,16 +31,16 @@ let paramUndef = function(u: undefined, v: undefined) {};
 // Void returns
 let retVoid = function(): void {};
 let retUndef = function(): void {};
-
-// These tests are disabled, because they are broken by recent Closure change.
-// See https://github.com/angular/clutz/issues/853
-// const arrowWithJsDoc = a => { return a; };
-
-// const arrowWithJsDocAndParens = (a) => { return a; };
+const arrowWithJsDoc = (a: number): number => {
+  return a;
+};
+const arrowWithJsDocAndParens = (a: number): number => {
+  return a;
+};
 const arrowWithJsDocMultiArg = (a: number, b: number): number => {
   return a;
 };
-const arrowNoJsDoc = a => {
+const arrowNoJsDoc = (a) => {
   return a;
 };
-const implicitReturnArrow = a => a;
+const implicitReturnArrow = (a) => a;


### PR DESCRIPTION
Changes the gents output language to ECMASCRIPT2015_TYPED.

Not sure why the output language matters for gents, but it has been the
recommeneded fix from Closure team.

Fix #853