### PR TITLE
 Removes @enum {string} and @enum {number} JsDoc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ use it with:
 
 ## Example usage
 
-We don't offer a binary distribution, so first you need to build from source:
+We don't offer a binary distribution, so first you need to build from source.
+From the root directory run:
 
 ```shell
 $ npm install

--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -193,8 +193,7 @@ public final class CommentLinkingPass implements CompilerPass {
 
         for (Pattern p : JSDOC_REPLACEMENTS_NO_KEEP) {
           Matcher m = p.matcher(comment);
-          boolean hasAMatch = m.find();
-          if (hasAMatch) {
+          if (m.find()) {
             if (m.group("eol") != null && m.group("eol").trim().length() == 0) {
               // if the end of the line was matched, then there's nothing to keep, remove the line
               comment = m.replaceAll("");

--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -28,8 +28,8 @@ public final class CommentLinkingPass implements CompilerPass {
   private static final String EOL = "(?<eol>[ \t]*\n)?";
 
   /**
-   * These RegExes delete everything except for the `block` (see BEGIN_JSDOC_LINE)
-   * and `keep` capture groups. These RegExes must contain a `keep` group.
+   * These RegExes delete everything except for the `block` (see BEGIN_JSDOC_LINE) and `keep`
+   * capture groups. These RegExes must contain a `keep` group.
    */
   private static final Pattern[] JSDOC_REPLACEMENTS_WITH_KEEP = {
     // Removes @param and @return if there is no description
@@ -46,15 +46,14 @@ public final class CommentLinkingPass implements CompilerPass {
    * and finish with EOL.
    */
   private static final Pattern[] JSDOC_REPLACEMENTS_NO_KEEP = {
-      Pattern.compile(
-          BEGIN_JSDOC_LINE + "@(extends|implements|type)[ \t]*(\\{[^@]*\\})[ \t]*" + EOL),
-      Pattern.compile(BEGIN_JSDOC_LINE + "@(constructor|interface|record)[ \t]*" + EOL),
-      Pattern.compile(
-          BEGIN_JSDOC_LINE
-              + "@(private|protected|public|package|const|enum)[ \t]*(\\{.*\\})?[ \t]*"
-              + EOL),
-      // Remove @typedef if there is no description.
-      Pattern.compile(BEGIN_JSDOC_LINE + "@typedef[ \t]*(\\{.*\\})" + EOL, Pattern.DOTALL)
+    Pattern.compile(BEGIN_JSDOC_LINE + "@(extends|implements|type)[ \t]*(\\{[^@]*\\})[ \t]*" + EOL),
+    Pattern.compile(BEGIN_JSDOC_LINE + "@(constructor|interface|record)[ \t]*" + EOL),
+    Pattern.compile(
+        BEGIN_JSDOC_LINE
+            + "@(private|protected|public|package|const|enum)[ \t]*(\\{.*\\})?[ \t]*"
+            + EOL),
+    // Remove @typedef if there is no description.
+    Pattern.compile(BEGIN_JSDOC_LINE + "@typedef[ \t]*(\\{.*\\})" + EOL, Pattern.DOTALL)
   };
 
   private static final Pattern[] COMMENT_REPLACEMENTS = {Pattern.compile("//\\s*goog.scope\\s*")};

--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -48,7 +48,7 @@ public final class CommentLinkingPass implements CompilerPass {
     Pattern.compile(BEGIN_JSDOC_LINE + "(?<keep>@enum)[ \t]*\\{(string|number)\\}"),
     // Removes @param and @return if there is no description
     Pattern.compile(
-        BEGIN_JSDOC_LINE + "@param[ \t]*(\\{.*\\})[ \t]*[\\w$]+[ \t]*(?<keep>\\*\\/|\n)"),
+        BEGIN_JSDOC_LINE + "@param[ \t]*(\\{.*\\})[ \t]*[\\w\\$]+[ \t]*(?<keep>\\*\\/|\n)"),
     Pattern.compile(BEGIN_JSDOC_LINE + "@returns?[ \t]*(\\{.*\\})[ \t]*(?<keep>\\*\\/|\n)"),
     Pattern.compile(BEGIN_JSDOC_LINE + "(?<keep>@(param|returns?))[ \t]*(\\{.*\\})"),
     // Remove type annotation from @export

--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -28,26 +28,32 @@ public final class CommentLinkingPass implements CompilerPass {
   private static final String EOL = "([ \t]*\n)?";
 
   /**
-   * These jsdocs delete everything except for the `keep` capture group Some regexes contain an
+   * These jsdocs delete everything except for the `keep` capture group. Some regexes contain an
    * empty capture group for uniform handling.
    */
   private static final Pattern[] JSDOC_REPLACEMENTS = {
+    // The <?keep> capture group is intentionally empty because it's not needed.
     Pattern.compile(
-        BEGIN_JSDOC_LINE + "@(extends|implements|type)[ \t]*(\\{[^@]*\\})[ \t]*(?<keep>)" + EOL,
-        Pattern.DOTALL),
+        BEGIN_JSDOC_LINE + "@(extends|implements|type)[ \t]*(\\{[^@]*\\})[ \t]*(?<keep>)" + EOL),
+    // The <?keep> capture group is intentionally empty because it's not needed.
     Pattern.compile(BEGIN_JSDOC_LINE + "@(constructor|interface|record)[ \t]*(?<keep>)" + EOL),
+    // The <?keep> capture group is intentionally empty because it's not needed.
     Pattern.compile(
         BEGIN_JSDOC_LINE
             + "@(private|protected|public|package|const)[ \t]*(\\{.*\\})?[ \t]*(?<keep>)"
             + EOL),
+    // Removes @enum {number} and @enum {string} without a description.
+    Pattern.compile(BEGIN_JSDOC_LINE + "@enum[ \t]*\\{(string|number)\\}[ \t]*(?<keep>\\*\\/|\n)"),
+    // Removes {number} or {string} type from @enum
+    Pattern.compile(BEGIN_JSDOC_LINE + "(?<keep>@enum)[ \t]*\\{(string|number)\\}"),
     // Removes @param and @return if there is no description
     Pattern.compile(
-        BEGIN_JSDOC_LINE + "@param[ \t]*(\\{.*\\})[ \t]*[\\w\\$]+[ \t]*(?<keep>\\*\\/|\n)"),
+        BEGIN_JSDOC_LINE + "@param[ \t]*(\\{.*\\})[ \t]*[\\w$]+[ \t]*(?<keep>\\*\\/|\n)"),
     Pattern.compile(BEGIN_JSDOC_LINE + "@returns?[ \t]*(\\{.*\\})[ \t]*(?<keep>\\*\\/|\n)"),
     Pattern.compile(BEGIN_JSDOC_LINE + "(?<keep>@(param|returns?))[ \t]*(\\{.*\\})"),
     // Remove type annotation from @export
     Pattern.compile(BEGIN_JSDOC_LINE + "(?<keep>@export)[ \t]*(\\{.*\\})"),
-    // Remove @typedef if there is no description
+    // Remove @typedef if there is no description. <keep> intentionally matches nothing.
     Pattern.compile(BEGIN_JSDOC_LINE + "@typedef[ \t]*(\\{.*\\})(?<keep>)" + EOL, Pattern.DOTALL)
   };
 

--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -28,20 +28,10 @@ public final class CommentLinkingPass implements CompilerPass {
   private static final String EOL = "([ \t]*\n)?";
 
   /**
-   * These jsdocs delete everything except for the `keep` capture group. Some regexes contain an
-   * empty capture group for uniform handling.
+   * These RegExes delete everything except for the `block` and `keep` capture groups.
    */
-  private static final Pattern[] JSDOC_REPLACEMENTS = {
-    // The <?keep> capture group is intentionally empty because it's not needed.
-    Pattern.compile(
-        BEGIN_JSDOC_LINE + "@(extends|implements|type)[ \t]*(\\{[^@]*\\})[ \t]*(?<keep>)" + EOL),
-    // The <?keep> capture group is intentionally empty because it's not needed.
-    Pattern.compile(BEGIN_JSDOC_LINE + "@(constructor|interface|record)[ \t]*(?<keep>)" + EOL),
-    // The <?keep> capture group is intentionally empty because it's not needed.
-    Pattern.compile(
-        BEGIN_JSDOC_LINE
-            + "@(private|protected|public|package|const)[ \t]*(\\{.*\\})?[ \t]*(?<keep>)"
-            + EOL),
+  private static final Pattern[] JSDOC_REPLACEMENTS_WITH_KEEP = {
+
     // Removes @enum {number} and @enum {string} without a description.
     Pattern.compile(BEGIN_JSDOC_LINE + "@enum[ \t]*\\{(string|number)\\}[ \t]*(?<keep>\\*\\/|\n)"),
     // Removes {number} or {string} type from @enum
@@ -53,12 +43,27 @@ public final class CommentLinkingPass implements CompilerPass {
     Pattern.compile(BEGIN_JSDOC_LINE + "(?<keep>@(param|returns?))[ \t]*(\\{.*\\})"),
     // Remove type annotation from @export
     Pattern.compile(BEGIN_JSDOC_LINE + "(?<keep>@export)[ \t]*(\\{.*\\})"),
-    // Remove @typedef if there is no description. <keep> intentionally matches nothing.
-    Pattern.compile(BEGIN_JSDOC_LINE + "@typedef[ \t]*(\\{.*\\})(?<keep>)" + EOL, Pattern.DOTALL)
+
   };
 
+  /**
+   * These RegExes delete everything that's matched by them.
+   */
+  private static final Pattern[] JSDOC_REPLACEMENTS_NO_KEEP = {
+      Pattern.compile(
+          BEGIN_JSDOC_LINE + "@(extends|implements|type)[ \t]*(\\{[^@]*\\})[ \t]*" + EOL),
+      Pattern.compile(BEGIN_JSDOC_LINE + "@(constructor|interface|record)[ \t]*" + EOL),
+      Pattern.compile(
+          BEGIN_JSDOC_LINE
+              + "@(private|protected|public|package|const)[ \t]*(\\{.*\\})?[ \t]*"
+              + EOL),
+      // Remove @typedef if there is no description.
+      Pattern.compile(BEGIN_JSDOC_LINE + "@typedef[ \t]*(\\{.*\\})" + EOL, Pattern.DOTALL)
+  };
+
+
   private static final Pattern[] COMMENT_REPLACEMENTS = {
-    Pattern.compile("//\\s*goog.scope\\s*(?<keep>)")
+    Pattern.compile("//\\s*goog.scope\\s*")
   };
 
   /**
@@ -182,17 +187,27 @@ public final class CommentLinkingPass implements CompilerPass {
 
     /** Removes unneeded tags and markers from the comment. */
     private String filterCommentContent(Type type, String comment) {
-      Pattern[] replacements = (type == Type.JSDOC) ? JSDOC_REPLACEMENTS : COMMENT_REPLACEMENTS;
-      for (Pattern p : replacements) {
-        Matcher m = p.matcher(comment);
-        if (m.find() && m.group("keep") != null && m.group("keep").trim().length() > 0) {
-          // keep documentation, if any
-          comment = m.replaceAll("${block}${keep}");
-        } else {
-          // nothing to keep, remove the line
-          comment = m.replaceAll("");
+      if (type == Type.JSDOC) {
+        for (Pattern p : JSDOC_REPLACEMENTS_WITH_KEEP) {
+          Matcher m = p.matcher(comment);
+          if (m.find() && m.group("keep") != null && m.group("keep").trim().length() > 0) {
+            // keep documentation, if any
+            comment = m.replaceAll("${block}${keep}");
+          } else {
+            // nothing to keep, remove the line
+            comment = m.replaceAll("");
+          }
+        }
+
+        for (Pattern p: JSDOC_REPLACEMENTS_NO_KEEP) {
+          comment = p.matcher(comment).replaceAll("");
+        }
+      } else {
+        for (Pattern p: COMMENT_REPLACEMENTS) {
+          comment = p.matcher(comment).replaceAll("");
         }
       }
+
       return isWhitespaceOnly(comment) ? "" : comment;
     }
 

--- a/src/test/java/com/google/javascript/gents/multiTests/goog_provide_rewrite/goog_scope.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/goog_provide_rewrite/goog_scope.ts
@@ -60,8 +60,6 @@ export interface InnerTypedefWithAssignment {
 type PrivateTypedef_ = {
   myFunction: (p1: any) => PrivateTypedef_
 };
-
-/** @enum {number} */
 Foo.FruitType = {
   UNKNOWN: 0,
   APPLE: 1,

--- a/src/test/java/com/google/javascript/gents/singleTests/class_interface.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/class_interface.ts
@@ -18,7 +18,7 @@ export interface RExtendsUsingEs6 extends IBase {
 }
 
 interface RecordClass {
-  /*The number of attempts before giving up. */
+  /** The number of attempts before giving up. */
   attempts: number;
   foo: boolean;
 

--- a/src/test/java/com/google/javascript/gents/singleTests/comments.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/comments.js
@@ -73,6 +73,11 @@ class B {
      * }}
      */
     this.twoParams = {param3: "param3", param4: "param4"};
+
+    /**
+     * @private @const {number} My special number.
+     */
+    this.privateConstParam = 3;
   }
 }
 

--- a/src/test/java/com/google/javascript/gents/singleTests/comments.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/comments.ts
@@ -41,6 +41,11 @@ class B {
   multipleLines: {param2: string|undefined} = {param2: 'param2'};
   twoParams: {param3: string|undefined,
               param4: string|undefined} = {param3: 'param3', param4: 'param4'};
+
+  /**
+   * My special number.
+   */
+  private privateConstParam: number = 3;
 }
 
 /** @export */

--- a/src/test/java/com/google/javascript/gents/singleTests/enum.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/enum.js
@@ -34,7 +34,7 @@ const EnumWithArithmetics = {
     B: 2
 };
 
-/** @enum {string} */
+/** @enum {string} My useful comment */
 const StrEnum = {
   A: 'foo',
   B: 'bar'

--- a/src/test/java/com/google/javascript/gents/singleTests/enum.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/enum.ts
@@ -30,13 +30,12 @@ export enum EnumWithArithmetics {
   B = 2
 }
 
-/** @enum My useful comment */
+/** My useful comment */
 export enum StrEnum {
   A = 'foo',
   B = 'bar'
 }
 
-/** @enum {{a: number}} */
 export const OtherEnum = {
   A: {a: 0},
   B: {a: 1}

--- a/src/test/java/com/google/javascript/gents/singleTests/enum.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/enum.ts
@@ -1,13 +1,11 @@
 /**
  * A non-trivial comment.
- * @enum {number}
  */
 export enum NumEnum {
   A,
   B
 }
 
-/** @enum {number} */
 export enum NonConseqNumEnum {
 
   // Comment A
@@ -20,7 +18,6 @@ export enum NonConseqNumEnum {
   E
 }
 
-/** @enum {number} */
 export enum RepeatedNumEnum {
   A,
   B = 0,
@@ -28,13 +25,12 @@ export enum RepeatedNumEnum {
   D = 2
 }
 
-/** @enum {number} */
 export enum EnumWithArithmetics {
   A = 10 * 10 + 2,
   B = 2
 }
 
-/** @enum {string} */
+/** @enum My useful comment */
 export enum StrEnum {
   A = 'foo',
   B = 'bar'


### PR DESCRIPTION
Removes @enum {string} and @enum {number} JsDoc. ￼…
@enum {string|number} without any additional doc doesn't add much value
in TypeScript.
If additional documentation is present, then keep @enum <explanation>
without the type.

For enums that are not strings or numbers, keep the type in JsDoc.