### PR TITLE
Fix a bug that gents converts number values in exported numeric enums to scientific notation.

### DIFF
--- a/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
@@ -760,7 +760,7 @@ public final class ModuleConversionPass implements CompilerPass {
     declarationNode.detach();
 
     Node export = new Node(Token.EXPORT, declarationNode);
-    export.useSourceInfoFromForTree(assignmentNode);
+    export.useSourceInfoFrom(assignmentNode);
 
     nodeComments.moveComment(declarationNode, export);
     parent.addChildBefore(export, next);

--- a/src/test/java/com/google/javascript/gents/singleTests/enum.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/enum.js
@@ -1,12 +1,20 @@
 goog.module('an.enum');
 
 /**
+ * @enum {number}
+ */
+const NumEnumNoExport = {
+  A: 0,
+  B: 1000
+};
+
+/**
  * A non-trivial comment.
  * @enum {number}
  */
 const NumEnum = {
-  A: 0,
-  B: 1
+  C: 0,
+  D: 1000
 };
 
 /** @enum {number} */

--- a/src/test/java/com/google/javascript/gents/singleTests/enum.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/enum.ts
@@ -1,10 +1,14 @@
+enum NumEnumNoExport {
+  A,
+  B = 1000
+}
 /**
  * A non-trivial comment.
  * @enum {number}
  */
 export enum NumEnum {
-  A,
-  B
+  C,
+  D = 1000
 }
 
 /** @enum {number} */


### PR DESCRIPTION
input:
```javascript
goog.module('enum');
/** @enum {number} */
const E = {A : 1000};
exports.E = E;
```
actual:
```typescript
export enum E {A = 1E3};
```
expect:
```typescript
export enum E {A = 1000};
```

What happened?
* When converting JavaScript assignment statements (`exports.E = E`) to TypeScript `export` keyword we create a new export node and drops it inline as the parent of the actual declaration node (`exportNode declarationNode;`). We then set the source info from the assignment statement on the new export node. That is correct because that's where the export is coming from. But we shouldn't do that recursively. Overwriting the source info of the declaration node and its sub tree with the source info of the assignment doesn't make sense. The declaration node is completely unchanged in this conversion.
* So we have wrong source info for all of these exports. That is usually fine. It's mostly only used for debugging purposes, except when it's not.
When the code generator emits the TypeScript output for an exported numeric enum it will run into a number node (A in the example above) at some point. Closure Compiler CodeConsumer has two implementations (!) of `addNumber()`. The overriding one is https://github.com/google/closure-compiler/blob/0e110f9c4f02a06decd2dfc3bd1e064601ffd91f/src/com/google/javascript/jscomp/CodePrinter.java#L316-L321, which as the comment says `Attempt to read the number format out of the original source location, falling back to the default behavior if we cannot locate it.` It reads the number format out of the original source location using source info, which now is the assignment statements location because we overwrote it when adding `export`. So the number format returned is `exports.E = E` the assignment statement :laughing: . That's of course an invalid number format and the code generator decides to fall back to the default behavior (https://github.com/google/closure-compiler/blob/0e110f9c4f02a06decd2dfc3bd1e064601ffd91f/src/com/google/javascript/jscomp/CodeConsumer.java#L342-L343) which uses scientific notation. And we get scientific notation.

Whew, one line change.