### PR TITLE
Turn off enum_alias test by removing enum annotation.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/partial/enum_alias.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/enum_alias.d.ts
@@ -1,6 +1,11 @@
 declare namespace ಠ_ಠ.clutz {
-  type module$exports$enum_alias = ಠ_ಠ.clutz.module$exports$enum_alias ;
-  let module$exports$enum_alias : typeof ಠ_ಠ.clutz.module$exports$enum_alias ;
+  //!! Closure will begin emitting this soon:
+  //!! enum module$exports$enum_alias { }
+  //!!
+  //!! That is incorrect, wait until closure starts emitting it
+  //!! at head and then reenable the test and fix properly.
+  //!! https://github.com/angular/clutz/issues/862
+  let module$exports$enum_alias : any ;
 }
 declare module 'goog:enum_alias' {
   import enum_alias = ಠ_ಠ.clutz.module$exports$enum_alias;

--- a/src/test/java/com/google/javascript/clutz/partial/enum_alias.js
+++ b/src/test/java/com/google/javascript/clutz/partial/enum_alias.js
@@ -2,7 +2,9 @@ goog.module('enum_alias');
 
 const OtherEnum = goog.require('not_visible');
 
-/** @enum {string} */
+//!! This test is temporary turned off to enable
+//!! change in behavior on closure side.
+//!! /** @enum {string} */
 const Enum = OtherEnum;
 
 exports = Enum;


### PR DESCRIPTION
The current emit is wrong - self circular. Closure team wants to land a
change that changes it into another (also wrong emit), turn off test to
unblock that.

https://github.com/angular/clutz/issues/862 to track proper fix.