### PR TITLE
Fix clutz emit for inner classes inside named exports.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/inner_class_named_export.d.ts
+++ b/src/test/java/com/google/javascript/clutz/inner_class_named_export.d.ts
@@ -1,0 +1,19 @@
+declare namespace ಠ_ಠ.clutz.module$exports$innerclass$namedexport {
+  class A {
+    private noStructuralTyping_module$exports$innerclass$namedexport_A : any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.module$exports$innerclass$namedexport.A {
+  class B {
+    private noStructuralTyping_module$exports$innerclass$namedexport_A_B : any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.module$exports$innerclass$namedexport.A.B {
+  class C {
+    private noStructuralTyping_module$exports$innerclass$namedexport_A_B_C : any;
+  }
+}
+declare module 'goog:innerclass.namedexport' {
+  import namedexport = ಠ_ಠ.clutz.module$exports$innerclass$namedexport;
+  export = namedexport;
+}

--- a/src/test/java/com/google/javascript/clutz/inner_class_named_export.js
+++ b/src/test/java/com/google/javascript/clutz/inner_class_named_export.js
@@ -1,0 +1,9 @@
+goog.module('innerclass.namedexport');
+
+class A {}
+
+A.B = class {};
+
+A.B.C = class {};
+
+exports = {A};

--- a/src/test/java/com/google/javascript/clutz/inner_class_named_export_usage.ts
+++ b/src/test/java/com/google/javascript/clutz/inner_class_named_export_usage.ts
@@ -1,0 +1,6 @@
+import {A} from 'goog:innerclass.namedexport';
+
+// using A, A.B and A.B.C as a type and a value.
+let a: A = new A();
+let b: A.B = new A.B();
+let c: A.B.C = new A.B.C();


### PR DESCRIPTION
Somehow despite all existing machinery we missed this case. Fix simply
extends the existing walkInnerSymbols for non-default exports.

Fixes #865