### PR TITLE
Accept PromiseLike<T> in resolve() methods

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -3055,9 +3055,9 @@ class DeclarationGenerator {
           // any>`
           // when the callers have been fixed.
           if (className.equals("ಠ_ಠ.clutz.goog.Promise")) {
-            return "resolve < T >(value: " + className + " < T , any > | T): any;";
+            return "resolve < T >(value: PromiseLike < T > | T): any;";
           } else {
-            return "resolve < T >(value: " + className + " < T > | T): " + className + " < T >;";
+            return "resolve < T >(value: PromiseLike < T > | T): " + className + " < T >;";
           }
         case "race":
           return "race < T > (values : T [] ) : " + className + " < T > ;";

--- a/src/test/java/com/google/javascript/clutz/goog_promise_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/goog_promise_with_platform.d.ts
@@ -5,7 +5,7 @@ declare namespace ಠ_ಠ.clutz.goog {
     then < RESULT > (opt_onFulfilled ? : ( (a : TYPE ) => PromiseLike < RESULT > | RESULT ) | null , opt_onRejected ? : ( (a : any ) => any ) | null) :  any ;
     static all < TYPE > (promises : any [] ) : ಠ_ಠ.clutz.goog.Promise < TYPE [] , any > ;
     static race < TYPE > (promises : any [] ) : ಠ_ಠ.clutz.goog.Promise < TYPE , any > ;
-    static resolve < T >(value: ಠ_ಠ.clutz.goog.Promise < T , any > | T): any;
+    static resolve < T >(value: PromiseLike < T > | T): any;
   }
 }
 declare module 'goog:goog.Promise' {

--- a/src/test/java/com/google/javascript/clutz/tte_promise.d.ts
+++ b/src/test/java/com/google/javascript/clutz/tte_promise.d.ts
@@ -5,7 +5,7 @@ declare namespace ಠ_ಠ.clutz.angular.$q {
     when < RESULT, T > (value: T, successCallback: (promiseValue: T) => ಠ_ಠ.clutz.angular.$q.Promise < RESULT >|RESULT, errorCallback: null | undefined |  ((reason: any) => any), notifyCallback?: (state: any) => any): ಠ_ಠ.clutz.angular.$q.Promise < RESULT >;
     static all(promises : ಠ_ಠ.clutz.angular.$q.Promise < any > [] ) : ಠ_ಠ.clutz.angular.$q.Promise < any [] > ;
     static race < T > (values : T [] ) : ಠ_ಠ.clutz.angular.$q.Promise < T > ;
-    static resolve < T >(value: ಠ_ಠ.clutz.angular.$q.Promise < T > | T): ಠ_ಠ.clutz.angular.$q.Promise < T >;
+    static resolve < T >(value: PromiseLike < T > | T): ಠ_ಠ.clutz.angular.$q.Promise < T >;
   }
 }
 declare module 'goog:angular.$q.Promise' {


### PR DESCRIPTION
This is more consistent with the original JS APIs, which do not require the same class to be passed in.