### PR TITLE
Fix double emit for inner and unprovided types.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -728,6 +728,11 @@ class DeclarationGenerator {
             || (!transitiveProvides.contains(name) && provides.contains(namespace))) {
           continue;
         }
+        // skip emit for provided inner symbols too as they are covered by the walkInnerSymbols
+        // pass.
+        if (isInnerSymbol(provides, name)) {
+          continue;
+        }
 
         // Skip extern symbols (they have a separate pass) and skip built-ins.
         // Built-ins can be indentified by having null as input file.
@@ -762,6 +767,22 @@ class DeclarationGenerator {
       if (typesUsed.size() == typesUsedCount) break;
       maxTypeUsedDepth--;
     }
+  }
+
+  /**
+   * Returns whether this is an inner symbol of at least one of the given goog.provides.
+   *
+   * @param provides A collection of goog.provide symbols
+   * @param name Fully qualified name of a symbol
+   * @return Whether this is an inner symbol
+   */
+  private boolean isInnerSymbol(Collection<String> provides, String name) {
+    for (String p : provides) {
+      if (name.startsWith(p + '.')) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/test/java/com/google/javascript/clutz/inner_unprovided_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/inner_unprovided_type.d.ts
@@ -1,0 +1,14 @@
+declare namespace ಠ_ಠ.clutz.ns {
+  /**
+   * Using the inner typedef to make sure that two different passes don't
+   * emit it.
+   */
+  function f ( ) : ಠ_ಠ.clutz.ns.f.Inner ;
+}
+declare namespace ಠ_ಠ.clutz.ns.f {
+  type Inner = { a : number } ;
+}
+declare module 'goog:ns' {
+  import ns = ಠ_ಠ.clutz.ns;
+  export = ns;
+}

--- a/src/test/java/com/google/javascript/clutz/inner_unprovided_type.js
+++ b/src/test/java/com/google/javascript/clutz/inner_unprovided_type.js
@@ -1,0 +1,16 @@
+goog.provide('ns');
+
+/**
+ * Using the inner typedef to make sure that two different passes don't
+ * emit it.
+ * @returns {ns.f.Inner}
+ */
+ns.f = function() {};
+
+
+/**
+ * @typedef {{
+ *   a: number
+ * }}
+ */
+ns.f.Inner;


### PR DESCRIPTION
Clutz mainly emits goog.provide symbols (goog.module exports appear as
such to clutz). However, sometimes that is not enough, there are two
extra passes - 1) emitting inner symbols 2) emitting types that are used
but unprovided.

Inner symbols emit is needed because TS has no inner
classes/enums/interfaces, so they have to be emitted as separate
namespaces.

With
https://github.com/angular/clutz/commit/b1442f1af513524809dffac743edc2630a23c678
we improved the inner emit to emit more.

However, this means in some cases inner symbol emit and unprovided emit
were emitting the same type. This change makes sure that unprovided emit
doesn't visit inner symbols.