### PR TITLE
Upgrade golden after a Closure compiler change.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/infer_in_goog_module.d.ts
+++ b/src/test/java/com/google/javascript/clutz/infer_in_goog_module.d.ts
@@ -1,6 +1,6 @@
 declare namespace ಠ_ಠ.clutz.module$exports$infer {
-  let a : string ;
   let b : string ;
+  let a : string ;
 }
 declare module 'goog:infer' {
   import infer = ಠ_ಠ.clutz.module$exports$infer;


### PR DESCRIPTION
Closure's inference algorithm has changed - the directly infereable
expressions  `const a = '0'` are treated differently from inferable
expressions that go through some indirection - `const b = f();`.