### PR TITLE
Add example of union of partially visible interface collapsing.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/partial/missing_base_union.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_base_union.d.ts
@@ -1,0 +1,19 @@
+declare namespace ಠ_ಠ.clutz.module$exports$missing$base$union {
+  //!! The double extends here is a bug too.
+  interface Derived extends ಠ_ಠ.clutz.module$exports$some$base.Base extends ಠ_ಠ.clutz.module$exports$some$base.Base {
+    someField ? : string ;
+  }
+  /**
+   * This is currently broken and we are waiting on a fix in Closure, since it
+   * cannot be simply fixed in Clutz.
+   *
+   * Right now, only a is emitted correctly, because it is not an union with
+   * null or undefined, the rest are collapsed into null or undefined, without a
+   * mention of Derived.
+   */
+  function fn (a : ಠ_ಠ.clutz.module$exports$missing$base$union.Derived , b : null , c ? : undefined ) : void ;
+}
+declare module 'goog:missing.base.union' {
+  import union = ಠ_ಠ.clutz.module$exports$missing$base$union;
+  export = union;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/missing_base_union.js
+++ b/src/test/java/com/google/javascript/clutz/partial/missing_base_union.js
@@ -1,0 +1,35 @@
+goog.module('missing.base.union');
+
+const {Base} = goog.require('some.base');
+
+/**
+ * @record
+ */
+class Derived extends Base {
+  constructor() {
+    super();
+    /**
+     * @type {string|undefined}
+     */
+    this.someField;
+  }
+}
+
+/**
+ * This is currently broken and we are waiting on a fix in Closure, since it
+ * cannot be simply fixed in Clutz.
+ *
+ * Right now, only a is emitted correctly, because it is not an union with
+ * null or undefined, the rest are collapsed into null or undefined, without a
+ * mention of Derived.
+ *
+ * @param {!Derived} a
+ * @param {Derived} b
+ * @param {!Derived=} c
+ */
+function fn(a, b, c = {}) {}
+
+exports = {
+  fn,
+  Derived
+};


### PR DESCRIPTION
In case of interfaces that extend another one beyond the scope of
visibility of partial clutz, it appears that unions with |null or
|undefined are collapsed by Closure.

This adds a test exemplifying the failure.