### PR TITLE
Remove no longer relevant comment.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -2488,14 +2488,7 @@ class DeclarationGenerator {
     }
 
     private void visitUnionType(UnionType ut, boolean inOptionalPosition) {
-      // We intentionally use getAlternates instead of getAlternates because
-      // the former unifies some types like Function into supertypes. The rules are murky as usual
-      // but it appears that getAlternates does less collapsing, see
-      // all_optional_type test.
-      // This is very far from perfect, because Closure still unifies some type
-      // unions.
-      // For example, if one writes <code>{a: string|undefined} | {b:string}</code>, at this point
-      // we only see <code>{a: string|undefined}</code>.
+
       Collection<JSType> alts = ut.getAlternates();
 
       // When visiting an optional function argument or optional field (`foo?` syntax),


### PR DESCRIPTION
In the past closure had getAlternates and
getAlternatesWithoutStructuralTyping. Since
https://github.com/angular/clutz/commit/733783dc299805a963272d4d77bf11b12668fad4
there is only a single method, so this comment is not relevant.