### PR TITLE
Handle optional parameters with a default value of undefined.

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
@@ -333,10 +333,7 @@ public final class TypeAnnotationPass implements CompilerPass {
   /** Sets the annotated type expression corresponding to Node {@code n}. */
   private void setTypeExpression(Node n, @Nullable JSTypeExpression type, boolean isReturnType) {
     TypeDeclarationNode node = convert(type, isReturnType);
-    if (node != null) {
-      n.setDeclaredTypeExpression(node);
-      compiler.reportChangeToEnclosingScope(n);
-    }
+    setTypeExpression(n, node);
   }
 
   /** Sets the annotated type expression corresponding to Node {@code n}. */

--- a/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
@@ -259,6 +259,7 @@ public final class TypeAnnotationPass implements CompilerPass {
       if (parameterType == null) {
         return false;
       }
+      TypeDeclarationNode parameterTypeNode = convertTypeNodeAST(parameterType.getRoot());
       // Parameter is declared using verbose @param syntax before the function definition.
       Node attachTypeExpr = node;
       // Modify the primary AST to represent a function parameter as a
@@ -272,10 +273,14 @@ public final class TypeAnnotationPass implements CompilerPass {
         attachTypeExpr = IR.name(node.getString());
         if (!node.getParent().isDefaultValue()) {
           attachTypeExpr.putBooleanProp(Node.OPT_ES6_TYPED, true);
+        } else if (node.getParent().getChildAtIndex(1).isName()
+            && node.getParent().getChildAtIndex(1).getString().equals("undefined")) {
+          // if default value is "undefined" add undefined to the type
+          parameterTypeNode = flatUnionType(ImmutableList.of(parameterTypeNode, undefinedType()));
         }
         nodeComments.replaceWithComment(node, attachTypeExpr);
       }
-      setTypeExpression(attachTypeExpr, parameterType, false);
+      setTypeExpression(attachTypeExpr, parameterTypeNode);
       return true;
     }
   }
@@ -330,6 +335,14 @@ public final class TypeAnnotationPass implements CompilerPass {
     TypeDeclarationNode node = convert(type, isReturnType);
     if (node != null) {
       n.setDeclaredTypeExpression(node);
+      compiler.reportChangeToEnclosingScope(n);
+    }
+  }
+
+  /** Sets the annotated type expression corresponding to Node {@code n}. */
+  private void setTypeExpression(Node n, @Nullable TypeDeclarationNode type) {
+    if (type != null) {
+      n.setDeclaredTypeExpression(type);
       compiler.reportChangeToEnclosingScope(n);
     }
   }

--- a/src/test/java/com/google/javascript/gents/singleTests/functions.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/functions.js
@@ -15,6 +15,11 @@ function twoParams(b, s) {}
 /** @param {!Array<?>=} list */
 function withDefaultValue(list = []) {}
 
+/**
+ * @param {boolean=} a
+ */
+function undefinedDefault(a = undefined) {}
+
 // Function returns
 /**
  * @return {*}

--- a/src/test/java/com/google/javascript/gents/singleTests/functions.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/functions.js
@@ -20,6 +20,9 @@ function withDefaultValue(list = []) {}
  */
 function undefinedDefault(a = undefined) {}
 
+/** @param {!Array<?>=} list */
+function undefinedDefaultArray(list = undefined) {}
+
 // Function returns
 /**
  * @return {*}

--- a/src/test/java/com/google/javascript/gents/singleTests/functions.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/functions.ts
@@ -7,6 +7,8 @@ function twoParams(b: boolean, s: string) {}
 
 function withDefaultValue(list: any[] = []) {}
 
+function undefinedDefault(a: boolean|undefined = undefined) {}
+
 // Function returns
 let anyReturn = function(): any {
   return 'hello';

--- a/src/test/java/com/google/javascript/gents/singleTests/functions.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/functions.ts
@@ -9,6 +9,8 @@ function withDefaultValue(list: any[] = []) {}
 
 function undefinedDefault(a: boolean|undefined = undefined) {}
 
+function undefinedDefaultArray(list: any[]|undefined = undefined) {}
+
 // Function returns
 let anyReturn = function(): any {
   return 'hello';


### PR DESCRIPTION
/**
 * @param {boolean=} a
 */
function f(a = undefined)

should translate to

function f(a: boolean|undefined = undefined)

fixes #631, fixes #629