### PR TITLE
Make sure to associate comments with the correct function args.

### DIFF
--- a/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
+++ b/src/main/java/com/google/javascript/gents/CommentLinkingPass.java
@@ -8,6 +8,7 @@ import com.google.javascript.jscomp.NodeTraversal;
 import com.google.javascript.jscomp.NodeTraversal.Callback;
 import com.google.javascript.jscomp.parsing.parser.trees.Comment;
 import com.google.javascript.jscomp.parsing.parser.trees.Comment.Type;
+import com.google.javascript.rhino.InputId;
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.Token;
 import java.util.ArrayList;
@@ -302,8 +303,37 @@ public final class CommentLinkingPass implements CompilerPass {
 
       if (getLastLineOfCurrentComment() == line) {
         // Comment on same line as code -- we have to make sure this is the node we should attach
-        // it to. It will be the first node after the comment.
-        if (getCurrentComment().location.end.column < n.getCharno()) {
+        // it to.
+        if (parent.isCall()) {
+          // We're inside a function call, we have to be careful about which node to attach to, since comments
+          // can go before or after an argument.
+          if (n.getNext() == null) {
+            // the last argument in the call, attach the comment here
+            linkCommentBufferToNode(n);
+          } else {
+            int endOfComment = getCurrentComment().location.end.column;
+            int startOfNextNode = n.getNext().getCharno();
+            if (endOfComment < startOfNextNode) {
+              // the comment is between this node and the next node, so check which side of the comment the comma
+              // separating the arguments is on to decide which argument to attach it to.
+              String lineContents =
+                  compiler
+                      .getInput(new InputId(n.getSourceFileName()))
+                      .getSourceFile()
+                      .getLine(line);
+              String interval = lineContents.substring(endOfComment, startOfNextNode);
+              if (interval.contains(",")) {
+                linkCommentBufferToNode(n);
+              } else {
+                linkCommentBufferToNode(n.getNext());
+              }
+            } else {
+              // comment is after this node, keep traversing the node graph
+              return true;
+            }
+          }
+        } else if (getCurrentComment().location.end.column < n.getCharno()) {
+          // comment is before this node, so attach it
           linkCommentBufferToNode(n);
         } else {
           return true;

--- a/src/test/java/com/google/javascript/gents/singleTests/inline_comments.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/inline_comments.js
@@ -1,0 +1,8 @@
+/** @param {...number} varargs */
+function foo(varargs) {}
+
+foo(1, 2 /* inline comment after arg, should attach to 2 */, 3, 4 /* ditto, should attach to 4 */, 5);
+
+foo(1, /* inline comment before arg, should attach to 2 */ 2);
+
+foo(1 /* inline comment should attach to 1, not to the next line */);

--- a/src/test/java/com/google/javascript/gents/singleTests/inline_comments.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/inline_comments.ts
@@ -1,0 +1,12 @@
+function foo(...varargs: number[]) {}
+foo(1,
+    /* inline comment after arg, should attach to 2 */
+    2, 3,
+    /* ditto, should attach to 4 */
+    4, 5);
+foo(1,
+    /* inline comment before arg, should attach to 2 */
+    2);
+foo(
+    /* inline comment should attach to 1, not to the next line */
+    1);


### PR DESCRIPTION
Previously inline comments were attached to the next node after the
comment, but that doesn't work in cases where a comment is after an
argument, but before the comma separating arguments.

fixes #646 