### PR TITLE
Fix imports from files with multiple namespaces.

### DIFF
--- a/src/main/java/com/google/javascript/gents/CollectModuleMetadata.java
+++ b/src/main/java/com/google/javascript/gents/CollectModuleMetadata.java
@@ -196,7 +196,10 @@ public final class CollectModuleMetadata extends AbstractTopLevelCallback implem
 
     /** namespace of the module in the original closure javascript. */
     private Set<String> jsNamespaces = new HashSet<>();
-    /** true if the goog.provide namespace/goog.module module's clutz generated .d.ts will have a default export. */
+    /**
+     * true if the goog.provide namespace/goog.module module's clutz generated .d.ts will have a
+     * default export.
+     */
     Map<String, Boolean> namespaceHasDefaultExport = new HashMap<>();
 
     /**

--- a/src/main/java/com/google/javascript/gents/CollectModuleMetadata.java
+++ b/src/main/java/com/google/javascript/gents/CollectModuleMetadata.java
@@ -196,7 +196,7 @@ public final class CollectModuleMetadata extends AbstractTopLevelCallback implem
 
     /** namespace of the module in the original closure javascript. */
     private Set<String> jsNamespaces = new HashSet<>();
-    /** true if the namespace's clutz generated .d.ts will have a default export. */
+    /** true if the goog.provide namespace/goog.module module's clutz generated .d.ts will have a default export. */
     Map<String, Boolean> namespaceHasDefaultExport = new HashMap<>();
 
     /**

--- a/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
+++ b/src/main/java/com/google/javascript/gents/ModuleConversionPass.java
@@ -580,7 +580,8 @@ public final class ModuleConversionPass implements CompilerPass {
         nodeToImport.addChildToBack(Node.newString(Token.STRING_KEY, localName));
       }
       // For non destructuring imports, it is safe to assume there's only one localName
-    } else if (moduleImport.module.hasDefaultExport) {
+    } else if (moduleImport.module.namespaceHasDefaultExport.getOrDefault(
+        moduleImport.requiredNamespace, false)) {
       // If it has a default export then use `import foo from 'goog:bar';`
       nodeToImport = Node.newString(Token.NAME, moduleImport.localNames.get(0));
     } else {

--- a/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/export_mixed_default_namespaces_keep.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/export_mixed_default_namespaces_keep.js
@@ -1,0 +1,14 @@
+// export_mixed_default_namespaces_keep.js exports 2 different namespaces
+// non_default.Nums isn't a default export, but default_export.Enum is
+goog.provide('non_default.Nums');
+non_default.Nums.One = 1;
+
+non_default.Nums.Two = 2;
+
+goog.provide('default_export.Enum');
+/** @enum{number} */
+default_export.Enum = {
+    A: 0,
+    B: 1,
+    C: 2,
+};

--- a/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/import_mixed_default_namespaces.js
+++ b/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/import_mixed_default_namespaces.js
@@ -1,0 +1,5 @@
+const Enum = goog.require('default_export.Enum');
+const Nums = goog.require('non_default.Nums');
+
+console.log(Enum.A);
+console.log(Nums.One);

--- a/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/import_mixed_default_namespaces.ts
+++ b/src/test/java/com/google/javascript/gents/multiTests/jslib_imports/import_mixed_default_namespaces.ts
@@ -1,0 +1,4 @@
+import Enum from 'goog:default_export.Enum';
+import * as Nums from 'goog:non_default.Nums';
+console.log(Enum.A);
+console.log(Nums.One);


### PR DESCRIPTION
Previously, gents assumed that each file only had one namespace that it
exported, so when checking if an import was of a default export or not,
it resolved to whether whatever the first exported namespace in the file
was.  This change makes it so each namespace that's exported is tracked
separately.