### PR TITLE
Rename FUNCTION_INSTANCE_TYPE to U2U_CONSTRUCTOR_TYPE.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -2318,7 +2318,7 @@ class DeclarationGenerator {
 
     /** Whether the type was written as the literal 'Function' type */
     private boolean isLiteralFunction(JSType type) {
-      return type.equals(typeRegistry.getNativeType(JSTypeNative.FUNCTION_INSTANCE_TYPE));
+      return type.equals(typeRegistry.getNativeType(JSTypeNative.U2U_CONSTRUCTOR_TYPE));
     }
 
     private Void emitTemplatizedType(TemplatizedType type, boolean inImplementsExtendsPosition) {


### PR DESCRIPTION
Previously, the two were synonims, but Closure removed
FUNCTION_INSTANCE_TYPE from upstream.

U2U stands for unknown-to-unknown.