### PR TITLE
(Fix #892) Write comments from enum types on generated .d.ts symbols

### DIFF
--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -1916,7 +1916,7 @@ class DeclarationGenerator {
           elementStream.collect(Collectors.toMap(Node::getString, Node::getFirstChild));
 
       JSType primitiveType = type.getEnumeratedTypeOfEnumObject();
-      if (maybeStringOrNumericEnum(primitiveType, unqualifiedName, objectOfAllMembers, elements)) {
+      if (maybeStringOrNumericEnum(type, unqualifiedName, objectOfAllMembers, elements)) {
         return;
       }
 
@@ -1979,10 +1979,12 @@ class DeclarationGenerator {
      * whether it successfully emitted the enum.
      */
     private boolean maybeStringOrNumericEnum(
-        JSType primitiveType,
+        EnumType enumType,
         String unqualifiedName,
         Node objectOfAllMembers,
         Map<String, Node> elements) {
+
+      JSType primitiveType = enumType.getEnumeratedTypeOfEnumObject();
       if (!primitiveType.equals(numberType) && !primitiveType.equals(stringType)) {
         return false;
       }
@@ -2002,6 +2004,7 @@ class DeclarationGenerator {
         }
       }
 
+      maybeEmitJsDoc(enumType.getJSDocInfo(), /* ignoreParams= */ true);
       emit("enum");
       emit(unqualifiedName);
       emit("{");

--- a/src/test/java/com/google/javascript/clutz/nested_enums.d.ts
+++ b/src/test/java/com/google/javascript/clutz/nested_enums.d.ts
@@ -1,0 +1,30 @@
+declare namespace ಠ_ಠ.clutz {
+  class module$exports$iterated$nestedenums {
+    private noStructuralTyping_module$exports$iterated$nestedenums : any;
+  }
+}
+declare namespace ಠ_ಠ.clutz.module$exports$iterated$nestedenums {
+  class B {
+    private noStructuralTyping_module$exports$iterated$nestedenums_B : any;
+  }
+  /**
+   * Some enum
+   */
+  enum SomeEnum {
+    FIRST = 1.0 ,
+    SECOND = 2.0 ,
+  }
+}
+declare namespace ಠ_ಠ.clutz.module$exports$iterated$nestedenums.B {
+  /**
+   * Another enum
+   */
+  enum AnotherEnum {
+    FIRST = 'first' ,
+    SECOND = 'second' ,
+  }
+}
+declare module 'goog:iterated.nestedenums' {
+  import nestedenums = ಠ_ಠ.clutz.module$exports$iterated$nestedenums;
+  export default nestedenums;
+}

--- a/src/test/java/com/google/javascript/clutz/nested_enums.js
+++ b/src/test/java/com/google/javascript/clutz/nested_enums.js
@@ -1,0 +1,32 @@
+goog.module('iterated.nestedenums');
+
+/**
+ * @struct
+ */
+class A {}
+
+/**
+ * Some enum
+ * @enum{number}
+ */
+A.SomeEnum = {
+  FIRST: 1,
+  SECOND: 2,
+}
+
+/**
+ * @struct
+ */
+A.B = class {};
+
+/**
+ * Another enum
+ * @enum{string}
+ */
+A.B.AnotherEnum = {
+  FIRST: 'first',
+  SECOND: 'second',
+}
+
+
+exports = A;

--- a/src/test/java/com/google/javascript/clutz/static_enum.d.ts
+++ b/src/test/java/com/google/javascript/clutz/static_enum.d.ts
@@ -5,6 +5,9 @@ declare namespace ಠ_ಠ.clutz {
   }
 }
 declare namespace ಠ_ಠ.clutz.module$exports$foo$C {
+  /**
+   * Test
+   */
   enum Enum {
     A = '' ,
   }


### PR DESCRIPTION
This is my attempt at making Clutz preserve comments from JS on enums and enum values.

This should fix #892 