### PR TITLE
Fix reexports in the case where RHS comes from an externs.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/AliasMapBuilder.java
+++ b/src/main/java/com/google/javascript/clutz/AliasMapBuilder.java
@@ -93,9 +93,13 @@ public class AliasMapBuilder extends ImportBasedMapBuilder {
         String localVariableName = getExportsAssignmentPropRootName(statement);
         String localPropName = getExportsAssignmentPropName(statement);
         String exportName = getNamedExportName(statement);
+        String localNamespaceName =
+            localVariableToImportedSymbolNameMap.containsKey(localVariableName)
+                ? localVariableToImportedSymbolNameMap.get(localVariableName)
+                : localVariableName;
         aliasMap.put(
             buildNamedExportSymbolName(localModuleId, exportName),
-            localVariableToImportedSymbolNameMap.get(localVariableName) + "." + localPropName);
+            localNamespaceName + "." + localPropName);
       }
     }
 

--- a/src/test/java/com/google/javascript/clutz/partial/extern_reexport.d.ts
+++ b/src/test/java/com/google/javascript/clutz/partial/extern_reexport.d.ts
@@ -1,0 +1,9 @@
+declare namespace ಠ_ಠ.clutz.module$exports$extern$reexport {
+  type x = ಠ_ಠ.clutz.someExtern.x ;
+  let x : typeof ಠ_ಠ.clutz.someExtern.x ;
+  let y : any ;
+}
+declare module 'goog:extern.reexport' {
+  import reexport = ಠ_ಠ.clutz.module$exports$extern$reexport;
+  export = reexport;
+}

--- a/src/test/java/com/google/javascript/clutz/partial/extern_reexport.js
+++ b/src/test/java/com/google/javascript/clutz/partial/extern_reexport.js
@@ -1,0 +1,6 @@
+goog.module('extern.reexport');
+
+exports.x = someExtern.x;
+//!! Deeper extern reexports currently fail with 'any'.
+//!! TODO(rado): fix deeper reexports.
+exports.y = someExtern.deeper.y;


### PR DESCRIPTION
For example `exports.x = someExtern.x`, prior to this clutz emitted
absolute junk using 'null.x' as a symbol.

Note, that this further exposes an issue with deeper reexports
'someExtern.deeper.y', which will be fixed in subsequent PR.