### PR TITLE
Add broken example of package-visible class

### DIFF
--- a/src/test/java/com/google/javascript/clutz/package_visible_class.d.ts
+++ b/src/test/java/com/google/javascript/clutz/package_visible_class.d.ts
@@ -1,0 +1,12 @@
+declare namespace ಠ_ಠ.clutz.package_visible_class {
+  //!! This fails because the declaration below is only a value, not a type.
+  type Class < PARAM > = ಠ_ಠ.clutz.module$contents$package_visible_class$Class_Class < PARAM > ;
+  let Class : typeof ಠ_ಠ.clutz.module$contents$package_visible_class$Class_Class ;
+}
+declare module 'goog:package_visible_class.Class' {
+  import Class = ಠ_ಠ.clutz.package_visible_class.Class;
+  export default Class;
+}
+declare namespace ಠ_ಠ.clutz {
+  let module$contents$package_visible_class$Class_Class : PrivateType;
+}

--- a/src/test/java/com/google/javascript/clutz/package_visible_class.js
+++ b/src/test/java/com/google/javascript/clutz/package_visible_class.js
@@ -1,0 +1,10 @@
+goog.module('package_visible_class.Class');
+goog.module.declareLegacyNamespace();
+
+/**
+ * @package
+ * @template PARAM
+ */
+class Class {}
+
+exports = Class;


### PR DESCRIPTION
Note this test is failing because the test actually does verify that the generated .d.ts file is valid.  But this is what is currently generated in production for exported package-private classes.

The upshot is that when the .d.ts error is suppressed, the package-private class is fully usable.

If, however, we change the alias to an `export import`, the error gets promoted out of the .d.ts file and into the actual (erroneous) .ts source - which is great, but the errors need to be fixed upstream before we can land the `export import` change.