### PR TITLE
Upstream two small closure changes.

### DIFF
--- a/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
+++ b/src/main/java/com/google/javascript/gents/TypeAnnotationPass.java
@@ -264,8 +264,8 @@ public final class TypeAnnotationPass implements CompilerPass {
       Node attachTypeExpr = node;
       // Modify the primary AST to represent a function parameter as a
       // REST node, if the type indicates it is a rest parameter.
-      if (parameterType.getRoot().getToken() == Token.ELLIPSIS) {
-        attachTypeExpr = IR.rest(IR.name(node.getString()));
+      if (parameterType.getRoot().getToken() == Token.ITER_REST) {
+        attachTypeExpr = IR.iterRest(IR.name(node.getString()));
         nodeComments.replaceWithComment(node, attachTypeExpr);
       }
       // Modify the AST to represent an optional parameter
@@ -479,7 +479,7 @@ public final class TypeAnnotationPass implements CompilerPass {
             int paramIdx = 1;
             for (Node param : child2.children()) {
               String paramName = "p" + paramIdx++;
-              if (param.getToken() == Token.ELLIPSIS) {
+              if (param.getToken() == Token.ITER_REST) {
                 if (param.getFirstChild() != null) {
                   restType = convertTypeNodeAST(param);
                 }
@@ -505,7 +505,7 @@ public final class TypeAnnotationPass implements CompilerPass {
         }
         return functionType(returnType, requiredParams, optionalParams, restName, restType);
         // Variable function parameters are encoded as an array.
-      case ELLIPSIS:
+      case ITER_REST:
         Node arrType = convertTypeNodeAST(n.getFirstChild());
         if (arrType == null) {
           arrType = anyType();

--- a/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/general_with_platform.d.ts
@@ -698,7 +698,7 @@ declare namespace ಠ_ಠ.clutz {
   }
 }
 declare namespace ಠ_ಠ.clutz {
-  interface KeyframeAnimationOptions extends AnimationEffectTimingProperties {
+  interface KeyframeAnimationOptions extends KeyframeEffectOptions {
     id ? : string ;
   }
 }
@@ -706,6 +706,18 @@ declare namespace ಠ_ಠ.clutz {
   class KeyframeEffect extends KeyframeEffectReadOnly {
     private noStructuralTyping_KeyframeEffect : any;
     constructor (target : GlobalElement | null , frames : { [ key: string ]: any } [] | { [ key: string ]: any [] } , options ? : number | AnimationEffectTimingProperties | null ) ;
+  }
+}
+declare namespace ಠ_ಠ.clutz {
+  interface KeyframeEffectOptions extends AnimationEffectTimingProperties {
+    /**
+     * Possible values: 'replace', 'add', 'accumulate'
+     */
+    composite ? : string ;
+    /**
+     * Possible values: 'replace', 'accumulate'
+     */
+    iterationComposite ? : string ;
   }
 }
 declare namespace ಠ_ಠ.clutz {


### PR DESCRIPTION
- Rename Node from ELLIPSIS to ITER_REST.
  The two are synonyms. This matches change made to the closure AST so
  that ELLIPSIS can be deleted.
- add new type KeyframeEffectReadOnly to platform externs.