### PR TITLE
Fix determinism in Clutz output.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/ImportBasedMapBuilder.java
+++ b/src/main/java/com/google/javascript/clutz/ImportBasedMapBuilder.java
@@ -16,7 +16,7 @@ public abstract class ImportBasedMapBuilder {
    * variables to build a map based on the concrete class's implementation of build.
    */
   public Map<String, String> build(Collection<Node> parsedInputs, Set<String> googProvides) {
-    Map<String, String> importRenameMap = new HashMap<>();
+    Map<String, String> importRenameMap = new LinkedHashMap<>();
     for (Node ast : parsedInputs) {
       // Symbols can be imported into a variable in a goog.module() file, so look for imports in the
       // body of the goog module.
@@ -255,7 +255,7 @@ public abstract class ImportBasedMapBuilder {
   }
 
   protected Map<String, String> objectLiteralASTToStringMap(Node objectLiteral) {
-    Map<String, String> stringMap = new HashMap<>();
+    Map<String, String> stringMap = new LinkedHashMap<>();
     for (Node objectMember : objectLiteral.children()) {
       String originalName = objectMember.getString();
       // Object literals can use the original name `{A}` or rename it `{RenameA: A}`.

--- a/src/main/java/com/google/javascript/clutz/ImportRenameMapBuilder.java
+++ b/src/main/java/com/google/javascript/clutz/ImportRenameMapBuilder.java
@@ -1,7 +1,7 @@
 package com.google.javascript.clutz;
 
 import com.google.javascript.rhino.Node;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -24,7 +24,7 @@ public class ImportRenameMapBuilder extends ImportBasedMapBuilder {
   @Override
   protected Map<String, String> build(
       String localModuleId, Node moduleBody, Set<String> googProvides) {
-    Map<String, String> importRenameMap = new HashMap<>();
+    Map<String, String> importRenameMap = new LinkedHashMap<>();
 
     for (Node statement : moduleBody.children()) {
       // Here and below goog.require and goog.requireType are treated identically.

--- a/src/main/java/com/google/javascript/clutz/LegacyNamespaceReexportMapBuilder.java
+++ b/src/main/java/com/google/javascript/clutz/LegacyNamespaceReexportMapBuilder.java
@@ -1,7 +1,7 @@
 package com.google.javascript.clutz;
 
 import com.google.javascript.rhino.Node;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -19,7 +19,7 @@ public class LegacyNamespaceReexportMapBuilder extends ImportBasedMapBuilder {
   @Override
   protected Map<String, String> build(
       String localModuleId, Node moduleBody, Set<String> googProvides) {
-    Map<String, String> reexportMap = new HashMap<>();
+    Map<String, String> reexportMap = new LinkedHashMap<>();
     if (localModuleId == null) {
       return reexportMap;
     }

--- a/src/test/java/com/google/javascript/clutz/testdata/partialCrossModuleTypeImports/goog_legacy_namespace_exporter.d.ts
+++ b/src/test/java/com/google/javascript/clutz/testdata/partialCrossModuleTypeImports/goog_legacy_namespace_exporter.d.ts
@@ -22,10 +22,10 @@ declare namespace ಠ_ಠ.clutz {
   }
 }
 declare namespace ಠ_ಠ.clutz.module$exports$goog$legacy$namespace$exporter {
-  type OriginalName = ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_OriginalName ;
-  let OriginalName : typeof ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_OriginalName ;
-}
-declare namespace ಠ_ಠ.clutz.module$exports$goog$legacy$namespace$exporter {
   type LegacyBaseClass = ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_LegacyBaseClass ;
   let LegacyBaseClass : typeof ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_LegacyBaseClass ;
+}
+declare namespace ಠ_ಠ.clutz.module$exports$goog$legacy$namespace$exporter {
+  type OriginalName = ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_OriginalName ;
+  let OriginalName : typeof ಠ_ಠ.clutz.module$contents$goog$legacy$namespace$exporter_OriginalName ;
 }


### PR DESCRIPTION
Replaces all HashMap/Set with LinkedHashMap/Set which guarantee
iteration order matches the input order.

Replace some Collections.toMap calls with for loops, because I couldn't
find a Collections.toLinkedMap calls.

Replace Collections.emptyMap calls with LinkedHashMap constructors.

Fixes one test, which has different emit order now.