### PR TITLE
Revert back the enum alias test.

### DIFF
--- a/src/test/java/com/google/javascript/clutz/testdata/partial/enum_alias.d.ts
+++ b/src/test/java/com/google/javascript/clutz/testdata/partial/enum_alias.d.ts
@@ -1,12 +1,8 @@
 // Generated from src/test/java/com/google/javascript/clutz/testdata/partial/enum_alias.js
 declare namespace ಠ_ಠ.clutz {
-  //!! Closure will begin emitting this soon:
-  //!! enum module$exports$enum_alias { }
-  //!!
-  //!! That is incorrect, wait until closure starts emitting it
-  //!! at head and then reenable the test and fix properly.
-  //!! https://github.com/angular/clutz/issues/862
-  let module$exports$enum_alias : any ;
+  //!! This is broken. See https://github.com/angular/clutz/issues/862.
+  enum module$exports$enum_alias {
+  }
 }
 declare module 'goog:enum_alias' {
   import enum_alias = ಠ_ಠ.clutz.module$exports$enum_alias;

--- a/src/test/java/com/google/javascript/clutz/testdata/partial/enum_alias.js
+++ b/src/test/java/com/google/javascript/clutz/testdata/partial/enum_alias.js
@@ -2,9 +2,7 @@ goog.module('enum_alias');
 
 const OtherEnum = goog.require('not_visible');
 
-//!! This test is temporary turned off to enable
-//!! change in behavior on closure side.
-//!! /** @enum {string} */
+/** @enum {string} */
 const Enum = OtherEnum;
 
 exports = Enum;


### PR DESCRIPTION
The behavior changed with a closure change in March. The test is still
broken but in a different way.