### PR TITLE
Remove googProvides flag.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -142,13 +142,6 @@ public class Options {
   String skipEmitRegExp = null;
 
   @Option(
-    name = "--googProvides",
-    usage =
-        "file containing a list of namespaces names that we know come from goog.provides (not goog.modules)"
-  )
-  String googProvidesFile = null;
-
-  @Option(
     name = "--collidingProvides",
     usage = "file containing a list of names that we know conflict with namespaces"
   )
@@ -180,7 +173,6 @@ public class Options {
   // TODO(martinprobst): Remove when internal Google is upgraded to a more recent args4j
   // library that supports Pattern arguments.
   Pattern skipEmitPattern;
-  Set<String> knownGoogProvides = new HashSet<>();
   Set<String> collidingProvides = new HashSet<>();
 
   public CompilerOptions getCompilerOptions() {
@@ -282,13 +274,6 @@ public class Options {
       throw new CmdLineException(parser, "No files or externs were given");
     }
 
-    if (googProvidesFile != null) {
-      try {
-        knownGoogProvides.addAll(Files.readLines(new File(googProvidesFile), UTF_8));
-      } catch (IOException e) {
-        throw new RuntimeException("Error reading goog provides file " + googProvidesFile, e);
-      }
-    }
     if (collidingProvidesFile != null) {
       try {
         collidingProvides.addAll(Files.readLines(new File(collidingProvidesFile), UTF_8));

--- a/src/test/java/com/google/javascript/clutz/OptionsTest.java
+++ b/src/test/java/com/google/javascript/clutz/OptionsTest.java
@@ -163,18 +163,6 @@ public class OptionsTest {
   }
 
   @Test
-  public void testGoogProvides() throws Exception {
-    Options opts =
-        new Options(
-            new String[] {
-              "foo.js",
-              "--googProvides",
-              DeclarationGeneratorTest.getTestInputFile("test_goog_provides").toFile().toString()
-            });
-    assertThat(opts.knownGoogProvides).containsExactly("foo.bar", "baz.quux");
-  }
-
-  @Test
   public void testPartialInputIgnoresDepgraphRootExternsIfNotPassedToExterns() throws Exception {
     // Due to "exported" libraries, what the depgraph considers "root" can be incorrect for the
     // purposes of incremental clutz. Arguments and Externs lists should only be filtered down


### PR DESCRIPTION
This is no longer needed and it was never really used. We use depgraphs
to get the info of whether something was a goog.module or goog.provide.