### PR TITLE
The :assemble task builds an executable jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,3 +107,14 @@ googleJavaFormat {
 testlogger {
   theme 'mocha'
 }
+
+jar {
+  manifest {
+    attributes 'Main-Class': 'com.google.javascript.Main'
+  }
+  from {
+    configurations.compile.collect {
+      it.isDirectory() ? it : zipTree(it)
+    }
+  }
+}

--- a/src/main/java/com/google/javascript/Main.java
+++ b/src/main/java/com/google/javascript/Main.java
@@ -4,20 +4,21 @@ import com.google.javascript.clutz.DeclarationGenerator;
 import com.google.javascript.gents.TypeScriptGenerator;
 
 public class Main {
-    public static void main(String[] args) {
-        if (args.length == 0) {
-            System.out.println(String.format("Usage: %s <clutz|gents> [...args]", Main.class.getSimpleName()));
-            System.exit(1);
-        }
-
-        String tool = args[0];
-        String[] subArgs = new String[args.length-1];
-        System.arraycopy(args, 1, subArgs, 0, subArgs.length);
-
-        if ("clutz".equals(tool)) {
-            DeclarationGenerator.main(subArgs);
-        } else if ("gents".equals(tool)) {
-            TypeScriptGenerator.main(subArgs);
-        }
+  public static void main(String[] args) {
+    if (args.length == 0) {
+      System.out.println(
+          String.format("Usage: %s <clutz|gents> [...args]", Main.class.getSimpleName()));
+      System.exit(1);
     }
+
+    String tool = args[0];
+    String[] subArgs = new String[args.length - 1];
+    System.arraycopy(args, 1, subArgs, 0, subArgs.length);
+
+    if ("clutz".equals(tool)) {
+      DeclarationGenerator.main(subArgs);
+    } else if ("gents".equals(tool)) {
+      TypeScriptGenerator.main(subArgs);
+    }
+  }
 }

--- a/src/main/java/com/google/javascript/Main.java
+++ b/src/main/java/com/google/javascript/Main.java
@@ -1,0 +1,23 @@
+package com.google.javascript;
+
+import com.google.javascript.clutz.DeclarationGenerator;
+import com.google.javascript.gents.TypeScriptGenerator;
+
+public class Main {
+    public static void main(String[] args) {
+        if (args.length == 0) {
+            System.out.println(String.format("Usage: %s <clutz|gents> [...args]", Main.class.getSimpleName()));
+            System.exit(1);
+        }
+
+        String tool = args[0];
+        String[] subArgs = new String[args.length-1];
+        System.arraycopy(args, 1, subArgs, 0, subArgs.length);
+
+        if ("clutz".equals(tool)) {
+            DeclarationGenerator.main(subArgs);
+        } else if ("gents".equals(tool)) {
+            TypeScriptGenerator.main(subArgs);
+        }
+    }
+}

--- a/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/clutz/DeclarationGenerator.java
@@ -79,7 +79,7 @@ import javax.annotation.Nullable;
 import org.kohsuke.args4j.CmdLineException;
 
 /** A tool that generates {@code .d.ts} declarations from a Google Closure JavaScript program. */
-class DeclarationGenerator {
+public class DeclarationGenerator {
 
   /**
    * Words for which we cannot generate 'namespace foo.Word {}'; Instead clutz tries to roll them up


### PR DESCRIPTION
Now when `./gradlew assemble` is run, the jar built contains
all of its dependencies and so it can be run directly.

Run `java -jar build/libs/clutz-1.0.jar clutz ...` to run clutz
and `java -jar build/libs/clutz-1.0.jar gents ...` to run gents.