### PR TITLE
allow empty depgraphs

### DIFF
--- a/src/main/java/com/google/javascript/clutz/Depgraph.java
+++ b/src/main/java/com/google/javascript/clutz/Depgraph.java
@@ -112,9 +112,7 @@ class Depgraph {
         throw new RuntimeException("malformed depgraph: " + depgraphName, e);
       }
     }
-    if (result.roots.isEmpty() && result.rootExterns.isEmpty()) {
-      throw new IllegalStateException("No roots were found in the provided depgraphs files");
-    }
+
     return result;
   }
 


### PR DESCRIPTION
If an upstream build rule produces no source, then it's possible to have
an empty depgraph that is not malformed.