### PR TITLE
Rename goog.provide from 'global' to 'globalNs'

### DIFF
--- a/src/test/java/com/google/javascript/clutz/testdata/partial/global_generic_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/testdata/partial/global_generic_type.d.ts
@@ -1,17 +1,17 @@
 // Generated from src/test/java/com/google/javascript/clutz/testdata/partial/global_generic_type.js
-declare namespace ಠ_ಠ.clutz.global.generic {
+declare namespace ಠ_ಠ.clutz.globalNs.generic {
   let type : Map < string , string > ;
 }
-declare module 'goog:global.generic.type' {
-  import type = ಠ_ಠ.clutz.global.generic.type;
+declare module 'goog:globalNs.generic.type' {
+  import type = ಠ_ಠ.clutz.globalNs.generic.type;
   export default type;
 }
 // Generated from src/test/java/com/google/javascript/clutz/testdata/partial/global_generic_type.js
-declare namespace ಠ_ಠ.clutz.global.non.generic {
+declare namespace ಠ_ಠ.clutz.globalNs.non.generic {
   let type : Map ;
 }
-declare module 'goog:global.non.generic.type' {
-  import type = ಠ_ಠ.clutz.global.non.generic.type;
+declare module 'goog:globalNs.non.generic.type' {
+  import type = ಠ_ಠ.clutz.globalNs.non.generic.type;
   export default type;
 }
 // Generated from src/test/java/com/google/javascript/clutz/testdata/partial/global_generic_type.js

--- a/src/test/java/com/google/javascript/clutz/testdata/partial/global_generic_type.js
+++ b/src/test/java/com/google/javascript/clutz/testdata/partial/global_generic_type.js
@@ -1,12 +1,12 @@
-goog.provide('global.generic.type');
-goog.provide('global.non.generic.type');
+goog.provide('globalNs.generic.type');
+goog.provide('globalNs.non.generic.type');
 goog.provide('nested.generic.type');
 
 /** @type {!Map<string, string>} */
-global.generic.type = null;
+globalNs.generic.type = null;
 
 /** @type {!Map} */
-global.non.generic.type = null;
+globalNs.non.generic.type = null;
 
 /** @type {!SomeType<!Map<string, string>>} */
 nested.generic.type = null;


### PR DESCRIPTION
A Closure Compiler change will begin special casing 'global' as it is native to Node environments. This causes issues when trying to goog.provide it. See also discussion on Google internal
http://cl/270391864.