### PR TITLE
Remove JSCompiler snapshot testing from CircleCI and builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,11 @@ var_5: &npm_install
   run: npm install
 
 jobs:
-  # Job that runs the gradle tests with snapshot builds of Google closure compiler.
-  test_snapshot:
+  # Job that runs the gradle tests using a released Google closure compiler version.
+  test_released:
     <<: *job_defaults
     environment:
-      CI_MODE: Nightly
+      CI_MODE: Released
     steps:
       - checkout
       - restore_cache:
@@ -35,25 +35,8 @@ jobs:
       - run: ./gradlew check
       - *save_cache
 
-  # Job that runs the gradle tests using a released Google closure compiler version.
-  test_released_optional:
-    <<: *job_defaults
-    environment:
-      CI_MODE: Released
-    steps:
-      - checkout
-      - restore_cache:
-          key: *cache_key
-      - *npm_install
-      # In case Gradle fails for the released version of Google closure compiler, we don't want
-      # to exit the CI job with an error. Manually ensure that this command runs with failures
-      # allowed. Related CircleCI issue: https://ideas.circleci.com/ideas/CCI-I-646
-      - run: ./gradlew assemble || true
-      - run: ./gradlew check || true
-
 workflows:
   version: 2
   default_workflow:
     jobs:
-      - test_snapshot
-      - test_released_optional
+      - test_released

--- a/build.gradle
+++ b/build.gradle
@@ -67,13 +67,10 @@ dependencies {
     // Forced, as Closure Compiler depends on the wrong version.
     force = true
   }
-  // clutz runs against closure head inside google, so default to that, but also test against
-  // the latest release for external users
-  if (System.getenv().get('CI_MODE') == 'Released') {
-    compile 'com.google.javascript:closure-compiler:v20181008'
-  } else {
-    compile 'com.google.javascript:closure-compiler:1.0-SNAPSHOT'
-  }
+  // In the past we tested against nightly closure releases at  'com.google.javascript:closure-compiler:1.0-SNAPSHOT',
+  // but sonatype started 404-ing CircleCI. Now, we test against the latest released Closure version on Circle, and
+  // internally test against Closure head.
+  compile 'com.google.javascript:closure-compiler:v20190929'
 
   compile 'com.google.code.gson:gson:2.7'
   compile 'com.google.code.findbugs:jsr305:3.0.1'


### PR DESCRIPTION
Sonatype returns too many 404s for this to be reliable. In the future
github clutz/gents will test only against released closure versions, and
changes will be made internally against head.