### PR TITLE
Remove destructuring to fix JSC_GOOG_SCOPE_NON_ALIAS_LOCAL

### DIFF
--- a/src/test/java/com/google/javascript/clutz/testdata/partial/goog_module_get.d.ts
+++ b/src/test/java/com/google/javascript/clutz/testdata/partial/goog_module_get.d.ts
@@ -31,3 +31,11 @@ declare module 'goog:goog.scope.ClassExtendingRenamedDestructuredRequire' {
   import ClassExtendingRenamedDestructuredRequire = ಠ_ಠ.clutz.goog.scope.ClassExtendingRenamedDestructuredRequire;
   export default ClassExtendingRenamedDestructuredRequire;
 }
+// Generated from src/test/java/com/google/javascript/clutz/testdata/partial/goog_module_get.js
+declare namespace ಠ_ಠ.clutz.goog.scope {
+  let NameAssignedToMissingGoogModuleGet : number ;
+}
+declare module 'goog:goog.scope.NameAssignedToMissingGoogModuleGet' {
+  import NameAssignedToMissingGoogModuleGet = ಠ_ಠ.clutz.goog.scope.NameAssignedToMissingGoogModuleGet;
+  export default NameAssignedToMissingGoogModuleGet;
+}

--- a/src/test/java/com/google/javascript/clutz/testdata/partial/goog_module_get.js
+++ b/src/test/java/com/google/javascript/clutz/testdata/partial/goog_module_get.js
@@ -1,6 +1,7 @@
 goog.provide('goog.scope.ClassExtendingMissingGoogModuleGet');
 goog.provide('goog.scope.ClassExtendingMissingDestructuredRequire');
 goog.provide('goog.scope.ClassExtendingRenamedDestructuredRequire');
+goog.provide('goog.scope.NameAssignedToMissingGoogModuleGet');
 
 goog.scope(() => {
   const MissingGoogModuleGet = goog.module.get('goog.module.default.exports');
@@ -12,7 +13,9 @@ goog.scope(() => {
 
   }
 
-  const {MissingDestructuredRequire, OriginalName: RenamedDestructuredRequire} = goog.module.get('goog.module.named.exports');
+  const namedExports = goog.module.get('goog.module.named.exports');
+  const MissingDestructuredRequire = namedExports.MissingDestructuredRequire;
+  const RenamedDestructuredRequire = namedExports.OriginalName;
 
   /**
    * @constructor
@@ -29,4 +32,7 @@ goog.scope(() => {
   goog.scope.ClassExtendingRenamedDestructuredRequire = function() {
 
   }
+
+  /** @const {number} */
+  goog.scope.NameAssignedToMissingGoogModuleGet = namedExports.SIZE * 2;
 });


### PR DESCRIPTION
The destructuring pattern this test is using is banned in regular compiler invocations, but until an upcoming Closure Compiler change, is allowed in Clutz invocations. [example](https://closure-compiler-debugger.appspot.com/#input0%3Dgoog.provide('a')%253B%26input1%3Dgoog.scope(function()%2520%257B%250A%2520%2520const%2520%257Bb%257D%2520%253D%2520goog.module.get('a')%253B%250A%257D)%253B%26conformanceConfig%26externs%26refasterjs-template%26CHECK_TYPES%3Dtrue%26CLOSURE_PASS%3Dtrue%26PRESERVE_TYPE_ANNOTATIONS%3Dtrue%26PRETTY_PRINT%3Dtrue)

Also adds a regression test for when the right-hand side of a goog.provide assignment uses a goog.module.get. I ran into this case while testing a Closure Compiler change.