### PR TITLE
Upstreaming 6 minor internal changes.

### DIFF
--- a/src/main/java/com/google/javascript/clutz/ClutzErrorManager.java
+++ b/src/main/java/com/google/javascript/clutz/ClutzErrorManager.java
@@ -25,7 +25,7 @@ final class ClutzErrorManager extends PrintStreamErrorManager {
     if (!debug && level == CheckLevel.WARNING) return;
 
     if (reportClutzMissingTypes
-        && error.description.contains("Bad type annotation. Unknown type")) {
+        && error.getDescription().contains("Bad type annotation. Unknown type")) {
       // Prepend an error that hints at missing externs/dependencies.
       reportClutzMissingTypes = false;
       // Leave out the location on purpose, the specific places of missing types are reported from

--- a/src/main/java/com/google/javascript/clutz/Options.java
+++ b/src/main/java/com/google/javascript/clutz/Options.java
@@ -211,7 +211,7 @@ public class Options {
     options.setLanguageOut(LanguageMode.ECMASCRIPT5);
 
     options.setModuleResolutionMode(ModuleLoader.ResolutionMode.BROWSER_WITH_TRANSFORMED_PREFIXES);
-    ImmutableMap.Builder builder = ImmutableMap.builder();
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
     for (String str : browserResolverStrippedPrefixes) {
       builder.put(str, "/");
     }

--- a/src/test/java/com/google/javascript/clutz/testdata/all_optional_type.d.ts
+++ b/src/test/java/com/google/javascript/clutz/testdata/all_optional_type.d.ts
@@ -1,8 +1,7 @@
 // Generated from src/test/java/com/google/javascript/clutz/testdata/all_optional_type.js
 declare namespace ಠ_ಠ.clutz.module$exports$collapsed$union {
   function fn (arg : { opt_some ? : string } | Function | null ) : void ;
-  //!! TODO(rado): It would be better if {other: string} was not omitted.
-  function fn2 (arg : { opt_some ? : string } ) : void ;
+  function fn2 (arg : { opt_some ? : string } | { other : string } ) : void ;
 }
 declare module 'goog:collapsed.union' {
   import union = ಠ_ಠ.clutz.module$exports$collapsed$union;

--- a/src/test/java/com/google/javascript/clutz/testdata/general_with_platform.d.ts
+++ b/src/test/java/com/google/javascript/clutz/testdata/general_with_platform.d.ts
@@ -346,12 +346,12 @@ declare namespace ಠ_ಠ.clutz {
     WRITING : number ;
     abort ( ) : void ;
     error : FileError | null ;
-    onabort : ( (a : ProgressEvent ) => any ) | null ;
-    onerror : ( (a : ProgressEvent ) => any ) | null ;
-    onprogress : ( (a : ProgressEvent ) => any ) | null ;
-    onwrite : ( (a : ProgressEvent ) => any ) | null ;
-    onwriteend : ( (a : ProgressEvent ) => any ) | null ;
-    onwritestart : ( (a : ProgressEvent ) => any ) | null ;
+    onabort : ( (a : ProgressEvent < FileSaver > ) => any ) | null ;
+    onerror : ( (a : ProgressEvent < FileSaver > ) => any ) | null ;
+    onprogress : ( (a : ProgressEvent < FileSaver > ) => any ) | null ;
+    onwrite : ( (a : ProgressEvent < FileSaver > ) => any ) | null ;
+    onwriteend : ( (a : ProgressEvent < FileSaver > ) => any ) | null ;
+    onwritestart : ( (a : ProgressEvent < FileSaver > ) => any ) | null ;
     readyState : number ;
   }
 }

--- a/src/test/java/com/google/javascript/clutz/testdata/partial/missing_base_union.d.ts
+++ b/src/test/java/com/google/javascript/clutz/testdata/partial/missing_base_union.d.ts
@@ -4,15 +4,7 @@ declare namespace ಠ_ಠ.clutz.module$exports$missing$base$union {
   interface Derived extends ಠ_ಠ.clutz.module$exports$some$base.Base extends ಠ_ಠ.clutz.module$exports$some$base.Base {
     someField ? : string ;
   }
-  /**
-   * This is currently broken and we are waiting on a fix in Closure, since it
-   * cannot be simply fixed in Clutz.
-   *
-   * Right now, only a is emitted correctly, because it is not an union with
-   * null or undefined, the rest are collapsed into null or undefined, without a
-   * mention of Derived.
-   */
-  function fn (a : ಠ_ಠ.clutz.module$exports$missing$base$union.Derived , b : null , c ? : undefined ) : void ;
+  function fn (a : ಠ_ಠ.clutz.module$exports$missing$base$union.Derived , b : ಠ_ಠ.clutz.module$exports$missing$base$union.Derived | null , c ? : ಠ_ಠ.clutz.module$exports$missing$base$union.Derived ) : void ;
 }
 declare module 'goog:missing.base.union' {
   import union = ಠ_ಠ.clutz.module$exports$missing$base$union;

--- a/src/test/java/com/google/javascript/clutz/testdata/partial/missing_base_union.js
+++ b/src/test/java/com/google/javascript/clutz/testdata/partial/missing_base_union.js
@@ -16,13 +16,6 @@ class Derived extends Base {
 }
 
 /**
- * This is currently broken and we are waiting on a fix in Closure, since it
- * cannot be simply fixed in Clutz.
- *
- * Right now, only a is emitted correctly, because it is not an union with
- * null or undefined, the rest are collapsed into null or undefined, without a
- * mention of Derived.
- *
  * @param {!Derived} a
  * @param {Derived} b
  * @param {!Derived=} c

--- a/src/test/java/com/google/javascript/gents/singleTests/comments.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/comments.ts
@@ -39,8 +39,9 @@ class X extends A {}
 class B {
   twoLines: {param1: string|undefined} = {param1: 'param1'};
   multipleLines: {param2: string|undefined} = {param2: 'param2'};
-  twoParams: {param3: string|undefined,
-              param4: string|undefined} = {param3: 'param3', param4: 'param4'};
+  twoParams:
+      {param3: string|undefined,
+       param4: string|undefined} = {param3: 'param3', param4: 'param4'};
 
   /**
    * My special number.

--- a/src/test/java/com/google/javascript/gents/singleTests/functions.js
+++ b/src/test/java/com/google/javascript/gents/singleTests/functions.js
@@ -91,3 +91,14 @@ const arrowWithJsDocMultiArg = (a, b) => { return a; };
 const arrowNoJsDoc = a => { return a; };
 
 const implicitReturnArrow = a => a;
+
+// Argument descructuring
+// TODO(b/142972217): Add more tests, e.g. with default parameters
+// TODO(b/142972217): Fix, this should output
+// `function namedParams({a}: {a: number}) {}`
+/**
+ * @param {{
+ *   a: number,
+ * }} params
+ */
+function namedParams({a}) {}

--- a/src/test/java/com/google/javascript/gents/singleTests/functions.ts
+++ b/src/test/java/com/google/javascript/gents/singleTests/functions.ts
@@ -48,3 +48,14 @@ const arrowNoJsDoc = (a) => {
   return a;
 };
 const implicitReturnArrow = (a) => a;
+
+// Argument descructuring
+// TODO(b/142972217): Add more tests, e.g. with default parameters
+// TODO(b/142972217): Fix, this should output
+// `function namedParams({a}: {a: number}) {}`
+/**
+ * @param {{
+ *   a: number,
+ * }} params
+ */
+function namedParams({a}) {}


### PR DESCRIPTION
- closure has fixed union collapse at head, which required undating some
failing goldens.
- new extern changes.
- replacing .description with getDescription.
- Better Java types for Options.java.
- new test for gents with destructuring arguments.
- clang-format reformating for a gents test.